### PR TITLE
Update the name regex validation in the schema to be more strict

### DIFF
--- a/resources/component-descriptor-ocm-v3-schema.yaml
+++ b/resources/component-descriptor-ocm-v3-schema.yaml
@@ -37,7 +37,7 @@ definitions:
   componentName:
     type: 'string'
     maxLength: 255
-    pattern: '^[a-z0-9.\-]+[.][a-z]{2,4}/[-a-z0-9/_.]*$'
+    pattern: '^[a-z0-9.\-]+[.][a-z]{2,4}([-a-z0-9_.]+/?)+[a-zA-Z0-9]+$'
 
   identityAttributeKey:
     minLength: 2

--- a/resources/component-descriptor-v2-schema.yaml
+++ b/resources/component-descriptor-v2-schema.yaml
@@ -20,7 +20,7 @@ definitions:
   componentName:
     type: 'string'
     maxLength: 255
-    pattern: '^[a-z0-9.\-]+[.][a-z]{2,4}/[-a-z0-9/_.]*$'
+    pattern: '^[a-z0-9.\-]+[.][a-z]{2,4}([-a-z0-9_]+/?)+[a-zA-Z0-9]+$'
 
   identityAttributeKey:
     minLength: 2


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the regex of the name schema validation to be more strict in the following way:

`a.c/name` - name is required
`a.c/` - invalid
`a.c///` - also invalid

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/ocm/issues/16

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
