### PR TITLE
fix: [TOI] Credentials list ordering

### DIFF
--- a/pkg/toi/install/credentials_test.go
+++ b/pkg/toi/install/credentials_test.go
@@ -15,8 +15,6 @@
 package install_test
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -91,11 +89,13 @@ credentials:
 `
 		spec, err := install.ParseCredentialSpecification([]byte(input), "settings")
 		Expect(err).To(Succeed())
+
 		c, err := install.GetCredentials(ctx, spec, req.Credentials, nil)
 		Expect(err).To(Succeed())
+
 		output, err := runtime.DefaultYAMLEncoding.Marshal(c)
 		Expect(err).To(Succeed())
-		fmt.Printf("%s", output)
+
 		Expect("\n" + string(output)).To(Equal(cfgdata))
 	})
 


### PR DESCRIPTION
We generate the credentials list from a map, but iteration order over maps is
not deterministic.

> 3. The iteration order over maps is not specified and is not guaranteed to be
the same from one iteration to the next.
>
> Source: https://go.dev/ref/spec#For_range

I see two options to fix the flaky test:

* Option 1: Make the generated list of credentials deterministic.
* Option 2: Update the test so it does not rely on a deterministic order.

I considered Option 2, but the nature of the test seems to test the
final yaml output format and if we want to test the final output it has
to return the same content with the same input. We can check properties,
but that would require a lot of extra tests if we want to test all
fields one by one.

Potentially we can write a string matcher, but that would still require
us to check all properties individually.

I picked Option 1 not only because of the reason described above, but if
we generate a yaml file, and we want to manage those yaml files in a
version control system (like git) it would be beneficial if we generate
the same output from the same input, so if the input did not change, the
generated yaml file will be the same as well. Without fixing the order
of the credentials, it's not guaranteed and without any changes, the
generated output can be still different.

References:

* Issue: https://github.com/gardener/ocm/issues/47
* Go for-range specification: https://go.dev/ref/spec#For_range

Fixes #47

```bugfix developer

```
