### PR TITLE
refactor: wrap errors (part 1)

### DIFF
--- a/pkg/common/accessio/access.go
+++ b/pkg/common/accessio/access.go
@@ -16,6 +16,7 @@ package accessio
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"sync"
 
@@ -379,14 +380,22 @@ func (b *blobAccessView) IsClosed() bool {
 func (b *blobAccessView) Get() (result []byte, err error) {
 	return result, b.view.Execute(func() error {
 		result, err = b.access.Get()
-		return err
+		if err != nil {
+			return fmt.Errorf("unable to get access: %w", err)
+		}
+
+		return nil
 	})
 }
 
 func (b *blobAccessView) Reader() (result io.ReadCloser, err error) {
 	return result, b.view.Execute(func() error {
 		result, err = b.access.Reader()
-		return err
+		if err != nil {
+			return fmt.Errorf("unable to read access: %w", err)
+		}
+
+		return nil
 	})
 }
 

--- a/pkg/common/accessio/cache.go
+++ b/pkg/common/accessio/cache.go
@@ -73,15 +73,23 @@ func (c *refMgmt) Unref() error {
 	if c.closed {
 		return ErrClosed
 	}
-	c.refcount--
+
 	var err error
+
+	c.refcount--
 	if c.refcount <= 0 {
 		if c.cleanup != nil {
 			err = c.cleanup()
 		}
+
 		c.closed = true
 	}
-	return err
+
+	if err != nil {
+		return fmt.Errorf("unable to unref: %w", err)
+	}
+
+	return nil
 }
 
 func (c *refMgmt) UnrefLast() error {
@@ -90,18 +98,27 @@ func (c *refMgmt) UnrefLast() error {
 	if c.closed {
 		return ErrClosed
 	}
+
 	if c.refcount > 1 {
 		return errors.Newf("object still in use: %d reference(s) pending", c.refcount)
 	}
-	c.refcount--
+
 	var err error
+
+	c.refcount--
 	if c.refcount <= 0 {
 		if c.cleanup != nil {
 			err = c.cleanup()
 		}
+
 		c.closed = true
 	}
-	return err
+
+	if err != nil {
+		return fmt.Errorf("unable to unref last: %w", err)
+	}
+
+	return nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pkg/common/accessio/utils.go
+++ b/pkg/common/accessio/utils.go
@@ -15,6 +15,7 @@
 package accessio
 
 import (
+	"fmt"
 	"io"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
@@ -123,11 +124,18 @@ func (c *once) Close() error {
 	if c.closer == nil {
 		return nil
 	}
+
 	t := c.closer
 	c.closer = nil
 	err := t.Close()
+
 	for _, cb := range c.callbacks {
 		cb()
 	}
-	return err
+
+	if err != nil {
+		return fmt.Errorf("unable to close: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/common/accessobj/accessobject.go
+++ b/pkg/common/accessobj/accessobject.go
@@ -15,6 +15,8 @@
 package accessobj
 
 import (
+	"fmt"
+
 	"github.com/mandelsoft/filepath/pkg/filepath"
 	"github.com/mandelsoft/vfs/pkg/vfs"
 
@@ -117,17 +119,23 @@ func (a *AccessObject) Write(path string, mode vfs.FileMode, opts ...accessio.Op
 	if a.IsClosed() {
 		return accessio.ErrClosed
 	}
+
 	o := accessio.AccessOptions(opts...)
+
 	f := GetFormat(*o.FileFormat)
 	if f == nil {
 		return errors.ErrUnknown("file format", string(*o.FileFormat))
 	}
+
 	return f.Write(a, path, o, mode)
 }
 
 func (a *AccessObject) Update() error {
-	_, err := a.updateDescriptor()
-	return err
+	if _, err := a.updateDescriptor(); err != nil {
+		return fmt.Errorf("unable to update descriptor: %w", err)
+	}
+
+	return nil
 }
 
 func (a *AccessObject) Close() error {

--- a/pkg/common/accessobj/format-directory.go
+++ b/pkg/common/accessobj/format-directory.go
@@ -87,22 +87,24 @@ func (_ DirectoryHandler) Write(obj *AccessObject, path string, opts accessio.Op
 
 	_, err := obj.updateDescriptor()
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to update descriptor: %w", err)
 	}
 
 	// copy descriptor
 	err = vfs.CopyFile(obj.fs, obj.info.DescriptorFileName, opts.PathFileSystem, filepath.Join(path, obj.info.DescriptorFileName))
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to copy file '%s': %w", obj.info.DescriptorFileName, err)
 	}
+
 	// copy all content
 	fileInfos, err := vfs.ReadDir(obj.fs, obj.info.ElementDirectoryName)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return fmt.Errorf("unable to read %s: %w", obj.info.ElementDirectoryName, err)
+		return fmt.Errorf("unable to read '%s': %w", obj.info.ElementDirectoryName, err)
 	}
+
 	for _, fileInfo := range fileInfos {
 		if fileInfo.IsDir() {
 			continue

--- a/pkg/contexts/clictx/config/type.go
+++ b/pkg/contexts/clictx/config/type.go
@@ -15,6 +15,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/contexts/clictx/core"
 	"github.com/open-component-model/ocm/pkg/contexts/config"
@@ -55,25 +57,30 @@ func (a *Config) GetType() string {
 func (a *Config) AddOCIRepository(name string, spec ocicpi.RepositorySpec) error {
 	g, err := ocicpi.ToGenericRepositorySpec(spec)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to convert oci repository spec to generic spec: %w", err)
 	}
+
 	if a.OCIRepositories == nil {
 		a.OCIRepositories = map[string]*ocicpi.GenericRepositorySpec{}
 	}
+
 	a.OCIRepositories[name] = g
+
 	return nil
 }
 
 func (a *Config) AddOCMRepository(name string, spec ocmcpi.RepositorySpec) error {
 	g, err := ocmcpi.ToGenericRepositorySpec(spec)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to convert ocm repository spec to generic spec: %w", err)
 	}
+
 	if a.OCMRepositories == nil {
 		a.OCMRepositories = map[string]*ocmcpi.GenericRepositorySpec{}
 	}
 
 	a.OCMRepositories[name] = g
+
 	return nil
 }
 

--- a/pkg/contexts/config/config/type.go
+++ b/pkg/contexts/config/config/type.go
@@ -50,9 +50,11 @@ func New() *Config {
 func (c *Config) AddConfig(cfg cpi.Config) error {
 	g, err := cpi.ToGenericConfig(cfg)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to convert cpi config to generic: %w", err)
 	}
+
 	c.Configurations = append(c.Configurations, g)
+
 	return nil
 }
 

--- a/pkg/contexts/credentials/config/type.go
+++ b/pkg/contexts/credentials/config/type.go
@@ -15,6 +15,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/open-component-model/ocm/pkg/common"
 	cfgcpi "github.com/open-component-model/ocm/pkg/contexts/config/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/cpi"
@@ -83,7 +85,7 @@ func (a *Config) MapCredentialsChain(creds ...cpi.CredentialsSpec) ([]cpi.Generi
 func (a *Config) AddConsumer(id cpi.ConsumerIdentity, creds ...cpi.CredentialsSpec) error {
 	cgens, err := a.MapCredentialsChain(creds...)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to map credentials chain: %w", err)
 	}
 
 	spec := &ConsumerSpec{
@@ -114,16 +116,18 @@ func (a *Config) MapRepository(repo cpi.RepositorySpec, creds ...cpi.Credentials
 func (a *Config) AddRepository(repo cpi.RepositorySpec, creds ...cpi.CredentialsSpec) error {
 	spec, err := a.MapRepository(repo, creds...)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to map repository: %w", err)
 	}
+
 	a.Repositories = append(a.Repositories, *spec)
+
 	return nil
 }
 
 func (a *Config) AddAlias(name string, repo cpi.RepositorySpec, creds ...cpi.CredentialsSpec) error {
 	spec, err := a.MapRepository(repo, creds...)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to map repository: %w", err)
 	}
 
 	if a.Aliases == nil {

--- a/pkg/contexts/credentials/core/credentialsspec.go
+++ b/pkg/contexts/credentials/core/credentialsspec.go
@@ -16,6 +16,7 @@ package core
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/modern-go/reflect2"
 
@@ -74,7 +75,7 @@ func (s DefaultCredentialsSpec) MarshalJSON() ([]byte, error) {
 func (s *DefaultCredentialsSpec) UnmarshalJSON(data []byte) error {
 	repo, err := DefaultContext.RepositoryTypes().Decode(data, runtime.DefaultJSONEncoding)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to decode data: %w", err)
 	}
 
 	specdata := &struct {
@@ -82,7 +83,7 @@ func (s *DefaultCredentialsSpec) UnmarshalJSON(data []byte) error {
 	}{}
 	err = json.Unmarshal(data, specdata)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed ot unmarshal spec data: %w", err)
 	}
 
 	s.RepositorySpec = repo.(RepositorySpec)
@@ -160,9 +161,11 @@ func (s *GenericCredentialsSpec) UnmarshalJSON(data []byte) error {
 
 	err := json.Unmarshal(data, spec)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to unmarshal spec data: %w", err)
 	}
+
 	s.CredentialsName = ""
+
 	if name, ok := spec.Object["credentialsName"]; ok {
 		if n, ok := name.(string); ok {
 			s.CredentialsName = n

--- a/pkg/contexts/credentials/repositories/dockerconfig/repository.go
+++ b/pkg/contexts/credentials/repositories/dockerconfig/repository.go
@@ -99,13 +99,14 @@ func (r *Repository) Read(force bool) error {
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read file '%s': %w", path, err)
 	}
 
 	cfg, err := config.LoadFromReader(bytes.NewBuffer(data))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to load config: %w", err)
 	}
+
 	defaultStore := dockercred.DetectDefaultStore(cfg.CredentialsStore)
 	store := dockercred.NewNativeStore(cfg, defaultStore)
 	// get default native credential store

--- a/pkg/contexts/credentials/repositories/memory/config/type.go
+++ b/pkg/contexts/credentials/repositories/memory/config/type.go
@@ -71,24 +71,30 @@ func (a *Config) AddCredentials(name string, props common.Properties) error {
 func (a *Config) AddCredentialsRef(name string, refname string, spec cpi.RepositorySpec) error {
 	repo, err := cpi.ToGenericRepositorySpec(spec)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to convert cpi repository spec to generic: %w", err)
 	}
+
 	ref := cpi.NewGenericCredentialsSpec(refname, repo)
 	a.Credentials = append(a.Credentials, CredentialsSpec{CredentialsName: name, Reference: ref})
+
 	return nil
 }
 
 func (a *Config) ApplyTo(ctx cfgcpi.Context, target interface{}) error {
 	list := errors.ErrListf("applying config")
+
 	t, ok := target.(cpi.Context)
 	if !ok {
 		return cfgcpi.ErrNoContext(ConfigType)
 	}
+
 	repo, err := t.RepositoryForSpec(memory.NewRepositorySpec(a.RepoName))
 	if err != nil {
-		return err
+		return fmt.Errorf("unabel to get repository for spec: %w", err)
 	}
+
 	mem := repo.(*memory.Repository)
+
 	for i, e := range a.Credentials {
 		var creds cpi.Credentials
 		if e.Reference != nil {

--- a/pkg/contexts/oci/ociutils/helm/artefact.go
+++ b/pkg/contexts/oci/ociutils/helm/artefact.go
@@ -37,16 +37,19 @@ func SynthesizeArtefactBlob(path string, fss ...vfs.FileSystem) (artefactset.Art
 	return artefactset.SythesizeArtefactSet(artdesc.MediaTypeImageManifest, func(set *artefactset.ArtefactSet) error {
 		chart, blob, err := TransferAsArtefact(path, set, fss...)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to transfer as artefact: %w", err)
 		}
+
 		if chart.Metadata.Version != "" {
 			err = set.AddTags(blob.Digest, chart.Metadata.Version)
 			if err != nil {
-				return err
+				return fmt.Errorf("unable to add tag: %w", err)
 			}
 		}
+
 		set.Annotate(artefactset.MAINARTEFACT_ANNOTATION, blob.Digest.String())
-		return err
+
+		return nil
 	})
 }
 func TransferAsArtefact(path string, ns oci.NamespaceAccess, fss ...vfs.FileSystem) (*chart.Chart, *artdesc.Descriptor, error) {

--- a/pkg/contexts/oci/ociutils/helm/ignore/rules.go
+++ b/pkg/contexts/oci/ociutils/helm/ignore/rules.go
@@ -19,6 +19,7 @@ package ignore
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -152,7 +153,7 @@ func (r *Rules) parseRule(rule string) error {
 	// Fail any patterns that can't compile. A non-empty string must be
 	// given to Match() to avoid optimization that skips rule evaluation.
 	if _, err := filepath.Match(rule, "abc"); err != nil {
-		return err
+		return fmt.Errorf("failed to match rule: %w", err)
 	}
 
 	p := &pattern{raw: rule}

--- a/pkg/contexts/oci/ociutils/helm/loader/directory.go
+++ b/pkg/contexts/oci/ociutils/helm/loader/directory.go
@@ -79,6 +79,7 @@ func LoadDir(fs vfs.FileSystem, dir string) (*chart.Chart, error) {
 		if err != nil {
 			return err
 		}
+
 		if fi.IsDir() {
 			// Directory-based ignore rules should involve skipping the entire
 			// contents of that directory.

--- a/pkg/contexts/oci/repositories/artefactset/error.go
+++ b/pkg/contexts/oci/repositories/artefactset/error.go
@@ -1,0 +1,21 @@
+package artefactset
+
+import "fmt"
+
+type GetArtifactError struct {
+	Original error
+	Ref      string
+}
+
+func (e GetArtifactError) Error() string {
+	message := fmt.Sprintf("failed to get artifact '%s'", e.Ref)
+
+	if e.Original != nil {
+		message = fmt.Sprintf("%s: %s", message, e.Original.Error())
+	}
+
+	return message
+}
+func (e GetArtifactError) Unwrap() error {
+	return e.Original
+}

--- a/pkg/contexts/oci/repositories/docker/namespace.go
+++ b/pkg/contexts/oci/repositories/docker/namespace.go
@@ -15,6 +15,7 @@
 package docker
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 
@@ -71,12 +72,16 @@ func (n *NamespaceContainer) IsClosed() bool {
 
 func (n *NamespaceContainer) Close() error {
 	n.lock.Lock()
+
 	defer n.lock.Unlock()
+
 	if n.cache != nil {
 		err := n.cache.Unref()
 		n.cache = nil
-		return err
+
+		return fmt.Errorf("failed to unref: %w", err)
 	}
+
 	return nil
 }
 
@@ -120,8 +125,11 @@ func (n *NamespaceContainer) GetBlobData(digest digest.Digest) (int64, cpi.DataA
 }
 
 func (n *NamespaceContainer) AddBlob(blob cpi.BlobAccess) error {
-	_, _, err := n.cache.AddBlob(blob)
-	return err
+	if _, _, err := n.cache.AddBlob(blob); err != nil {
+		return fmt.Errorf("failed to add blob to cache: %w", err)
+	}
+
+	return nil
 }
 
 func (n *NamespaceContainer) GetArtefact(vers string) (cpi.ArtefactAccess, error) {
@@ -210,17 +218,21 @@ func (n *NamespaceContainer) AddTags(digest digest.Digest, tags ...string) error
 	if ok, _ := artdesc.IsDigest(digest.String()); ok {
 		return errors.ErrNotSupported("image access by digest")
 	}
+
 	src := n.namespace + ":" + digest.String()
+
 	if pattern.MatchString(digest.String()) {
 		// this definately no digest, but the library expects it this way
 		src = digest.String()
 	}
+
 	for _, tag := range tags {
 		err := n.repo.client.ImageTag(dummyContext, src, n.namespace+":"+tag)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to add image tag: %w", err)
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/contexts/oci/repositories/ocireg/utils.go
+++ b/pkg/contexts/oci/repositories/ocireg/utils.go
@@ -113,14 +113,17 @@ func pushData(ctx context.Context, p resolve.Pusher, desc artdesc.Descriptor, da
 	if desc.Size == 0 {
 		desc.Size = -1
 	}
+
 	fmt.Printf("*** push %s %s: %s\n", desc.MediaType, desc.Digest, key)
 	req, err := p.Push(ctx, desc, data)
 	if err != nil {
 		if errdefs.IsAlreadyExists(err) {
 			fmt.Printf("*** %s %s: already exists\n", desc.MediaType, desc.Digest)
+
 			return nil
 		}
-		return err
+
+		return fmt.Errorf("failed to push: %w", err)
 	}
 	return req.Commit(ctx, desc.Size, desc.Digest)
 }

--- a/pkg/contexts/ocm/cpi/support/error.go
+++ b/pkg/contexts/ocm/cpi/support/error.go
@@ -1,0 +1,56 @@
+package support
+
+import "fmt"
+
+type UpdateComponentVersionContainerError struct {
+	Name    string
+	Version string
+	Type    string
+
+	Original error
+}
+
+func (e UpdateComponentVersionContainerError) Error() string {
+	message := fmt.Sprintf(
+		"unable to update '%s:%s' base component container",
+		e.Name,
+		e.Version,
+	)
+
+	if e.Original != nil {
+		message = fmt.Sprintf("%s: %s", message, e.Original.Error())
+	}
+
+	return message
+}
+
+func (e UpdateComponentVersionContainerError) Unwrap() error {
+	return e.Original
+}
+
+type AccessCheckError struct {
+	Name    string
+	Version string
+	Type    string
+
+	Original error
+}
+
+func (e AccessCheckError) Error() string {
+	message := fmt.Sprintf(
+		"failed access spec check on '%s:%s' with type '%s'",
+		e.Name,
+		e.Version,
+		e.Type,
+	)
+
+	if e.Original != nil {
+		message = fmt.Sprintf("%s: %s", message, e.Original.Error())
+	}
+
+	return message
+}
+
+func (e AccessCheckError) Unwrap() error {
+	return e.Original
+}

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -15,6 +15,8 @@
 package env
 
 import (
+	"fmt"
+
 	"github.com/mandelsoft/vfs/pkg/composefs"
 	"github.com/mandelsoft/vfs/pkg/osfs"
 	"github.com/mandelsoft/vfs/pkg/projectionfs"
@@ -93,14 +95,20 @@ func TestData(paths ...string) tdOpt {
 func (o tdOpt) Mount(cfs *composefs.ComposedFileSystem) error {
 	fs, err := projectionfs.New(osfs.New(), o.source)
 	if err != nil {
-		return err
+		return fmt.Errorf("faild to create new project fs: %w", err)
 	}
+
 	fs = readonlyfs.New(fs)
-	err = cfs.MkdirAll(o.path, vfs.ModePerm)
-	if err != nil {
-		return err
+
+	if err := cfs.MkdirAll(o.path, vfs.ModePerm); err != nil {
+		return fmt.Errorf("faild to create directories '%s': %w", o.path, err)
 	}
-	return cfs.Mount(o.path, fs)
+
+	if err := cfs.Mount(o.path, fs); err != nil {
+		return fmt.Errorf("faild to mount cfs: %w", err)
+	}
+
+	return nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pkg/signing/handlers/rsa/handler.go
+++ b/pkg/signing/handlers/rsa/handler.go
@@ -87,10 +87,12 @@ func (h Handler) Sign(digest string, hash crypto.Hash, issuer string, key interf
 // Verify checks the signature, returns an error on verification failure
 func (h Handler) Verify(digest string, hash crypto.Hash, signature *signing.Signature, key interface{}) (err error) {
 	var signatureBytes []byte
+
 	publicKey, names, err := GetPublicKey(key)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get public key: %w", err)
 	}
+
 	switch signature.MediaType {
 	case MediaType:
 		signatureBytes, err = hex.DecodeString(signature.Value)
@@ -118,12 +120,14 @@ func (h Handler) Verify(digest string, hash crypto.Hash, signature *signing.Sign
 	if names != nil {
 		if signature.Issuer != "" {
 			found := false
+
 			for _, n := range names {
 				if n == signature.Issuer {
 					found = true
 					break
 				}
 			}
+
 			if !found {
 				return fmt.Errorf("issuer %q does not match %v", signature.Issuer, names)
 			}
@@ -136,6 +140,7 @@ func (h Handler) Verify(digest string, hash crypto.Hash, signature *signing.Sign
 	if err := rsa.VerifyPKCS1v15(publicKey, hash, decodedHash, signatureBytes); err != nil {
 		return fmt.Errorf("signature verification failed, %w", err)
 	}
+
 	return nil
 }
 

--- a/pkg/toi/support/app.go
+++ b/pkg/toi/support/app.go
@@ -102,19 +102,22 @@ func (o *BootstrapperCLIOptions) AddFlags(fs *pflag.FlagSet) {
 }
 
 func (o *BootstrapperCLIOptions) Complete() error {
-	err := o.ExecutorOptions.Complete()
-	if err != nil {
-		return err
+	if err := o.ExecutorOptions.Complete(); err != nil {
+		return fmt.Errorf("unable to complete options: %w", err)
 	}
+
 	id := credentials.ConsumerIdentity{}
 	attrs := common.Properties{}
+
 	for _, s := range o.CredentialSettings {
 		i := strings.Index(s, "=")
 		if i < 0 {
 			return errors.ErrInvalid("credential setting", s)
 		}
+
 		name := s[:i]
 		value := s[i+1:]
+
 		if strings.HasPrefix(name, ":") {
 			if len(attrs) != 0 {
 				o.Context.CredentialsContext().SetCredentialsForConsumer(id, credentials.NewCredentials(attrs))
@@ -126,10 +129,12 @@ func (o *BootstrapperCLIOptions) Complete() error {
 		} else {
 			attrs[name] = value
 		}
+
 		if len(name) == 0 {
 			return errors.ErrInvalid("credential setting", s)
 		}
 	}
+
 	if len(attrs) != 0 {
 		o.Context.CredentialsContext().SetCredentialsForConsumer(id, credentials.NewCredentials(attrs))
 	} else {
@@ -155,7 +160,12 @@ func (o *BootstrapperCLIOptions) Complete() error {
 		}
 		err = ctx.ApplyConfig(spec, "cli")
 	}
-	return err
+
+	if err != nil {
+		return fmt.Errorf("unable to parse labels: %w", err)
+	}
+
+	return nil
 }
 
 func NewVersionCommand() *cobra.Command {

--- a/pkg/toi/support/support.go
+++ b/pkg/toi/support/support.go
@@ -66,32 +66,40 @@ func (o *ExecutorOptions) Complete() error {
 	}
 	compvers, err := common.ParseNameVersion(o.ComponentVersionName)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to parse component name and version: %w", err)
 	}
+
 	if o.OutputContext == nil {
 		o.OutputContext = out.New()
 	}
+
 	if o.Action == "" {
 		o.Action = "install"
 	}
+
 	if o.Root == "" {
 		o.Root = install.PathTOI
 	}
+
 	if o.Inputs == "" {
 		o.Inputs = o.Root + "/" + install.Inputs
 	}
+
 	if o.Outputs == "" {
 		o.Outputs = o.Root + "/" + install.Outputs
 	}
+
 	if o.RepoPath == "" {
 		o.RepoPath = o.Inputs + "/" + install.InputOCMRepo
 	}
+
 	if o.Config == "" {
 		cfg := o.Inputs + "/" + install.InputConfig
 		if ok, err := vfs.FileExists(o.FileSystem(), cfg); ok && err == nil {
 			o.Config = cfg
 		}
 	}
+
 	if o.Config != "" && o.ConfigData == nil {
 		o.ConfigData, err = vfs.ReadFile(o.FileSystem(), o.Config)
 		if err != nil {
@@ -105,9 +113,10 @@ func (o *ExecutorOptions) Complete() error {
 			o.OCMConfig = cfg
 		}
 	}
+
 	o.Context, err = ocmutils.Configure(o.Context, o.OCMConfig)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to configure context: %w", err)
 	}
 
 	if o.Parameters == "" {
@@ -116,6 +125,7 @@ func (o *ExecutorOptions) Complete() error {
 			o.Parameters = p
 		}
 	}
+
 	if o.Parameters != "" && o.ParameterData == nil {
 		o.ParameterData, err = vfs.ReadFile(o.FileSystem(), o.Parameters)
 		if err != nil {
@@ -138,7 +148,7 @@ func (o *ExecutorOptions) Complete() error {
 	if o.ComponentVersion == nil {
 		cv, err := o.Repository.LookupComponentVersion(compvers.GetName(), compvers.GetVersion())
 		if err != nil {
-			return err
+			return fmt.Errorf("failed component version lookup: %w", err)
 		}
 		o.ComponentVersion = cv
 		versCloser = cv
@@ -183,7 +193,7 @@ func (e *Executor) Execute() error {
 	if !e.Completed {
 		err := e.Options.Complete()
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to complete options: %w", err)
 		}
 	}
 	list := errors.ErrListf("executor:")


### PR DESCRIPTION
Part 1 because a we have a lot of unwrapped errors and don't want to create huge PRs.

Under the issue there was a comment about using the `errors.Wrapf` (where
errors` is an ocm package) function instead of `fmt.Errorf`.

I don't even know why that function exists, and that's why I did not use it. The
standard built-in error wrapping with `fmt.Errorf()`, the build-in
`errors.Unwrap()` does exactly the same thing.

Let's see in an example:

```go
package main

import (
  builtinerrors "errors"
  "fmt"

  ocmerrors "github.com/open-component-model/ocm/pkg/errors"
)

type MyError struct{}

func (e MyError) Error() string {
  return "my error"
}

func main() {
  fmt.Println("built-in:")
  builtin()

  fmt.Printf("\n---\n\n")

  fmt.Println("ocm version:")
  ocmversion()
}

func builtin() {
  err1 := MyError{}
  err2 := fmt.Errorf("wrapped: %w", err1)

  fmt.Println(err1)
  fmt.Println(err2)
  fmt.Println(builtinerrors.Unwrap(err2))
}

func ocmversion() {
  err1 := MyError{}
  err2 := ocmerrors.Wrapf(err1, "wrapper")

  fmt.Println(err1)
  fmt.Println(err2)
  fmt.Println(builtinerrors.Unwrap(err2))
}
```

and the output:

```
built-in:
my error
wrapped: my error
my error

---

ocm version:
my error
wrapper: my error
my error
```

The only two reason to use `Wrapf`:
1. it forces the standard `msg: err` format.
2. it handles nil automatically and returns with a nil if the error was nil.

The format shouldn't be an issue, that's standard and that's why we have pull
request reviews.

On the 2nd point.

Let's see what that function does:

```go
type wrappedError struct {
  wrapped error
  msg     string
}

func Wrapf(err error, msg string, args ...interface{}) error {
    if err == nil {
        return nil
    }

    if len(args) > 0 {
        msg = fmt.Sprintf(msg, args...)
    }

    return &wrappedError{
        wrapped: err,
        msg:     msg,
    }
}

func (e *wrappedError) Error() string {
    return fmt.Sprintf("%s: %s", e.msg, e.wrapped)
}

func (e *wrappedError) Unwrap() error {
    return e.wrapped
}
```

That whole cose can be replaced by:

```go
func Wrapf(err error, msg string, args ...interface{}) error {
    if err == nil {
        return nil
    }

    if len(args) > 0 {
        msg = fmt.Sprintf(msg, args...)
    }

    return fmt.Errorf("%s: %w", msg, err)
}
```

We could remove the whole `wrappedError` struct.

So technically we can use `Wrapf`

```go
return Wrapf(err, "unable to read '%s'", filename)
```

or use built-in options:

```go
if err != nil {
  return fmt.Errorf("unable to read '%s': %w", filename, err)
}

return nil
```

in both cases we get the same output:

```
unable to read '/tmp/stuff': file not found
```

We could save 3 lines of code and, but we have a code we have to maintain, and
anyone who will read the `Wrapf` line has to check what it does to fully
understand what's happening.

References:
* Built-in errors package: https://pkg.go.dev/errors#Unwrap
* Issue: https://github.com/gardener/ocm/issues/54

Related to #54

```other developer

```
