### PR TITLE
better scheme solution avoiding error unnecessary error boilerplate

### DIFF
--- a/cmds/ocm/commands/ocmcmds/common/inputs/inputtype.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/inputtype.go
@@ -77,7 +77,7 @@ type InputTypeScheme interface {
 }
 
 type inputTypeScheme struct {
-	runtime.Scheme
+	runtime.SchemeBase
 }
 
 func NewInputTypeScheme(defaultRepoDecoder runtime.TypedObjectDecoder) InputTypeScheme {
@@ -86,8 +86,8 @@ func NewInputTypeScheme(defaultRepoDecoder runtime.TypedObjectDecoder) InputType
 	return &inputTypeScheme{scheme}
 }
 
-func (t *inputTypeScheme) AddKnowntypes(s InputTypeScheme) {
-	t.Scheme.AddKnownTypes(s)
+func (t *inputTypeScheme) AddKnownTypes(s InputTypeScheme) {
+	t.SchemeBase.AddKnownTypes(s)
 }
 
 func (t *inputTypeScheme) GetInputType(name string) InputType {
@@ -102,23 +102,11 @@ func (t *inputTypeScheme) RegisterByDecoder(name string, decoder runtime.TypedOb
 	if _, ok := decoder.(InputType); !ok {
 		return errors.ErrInvalid("type", reflect.TypeOf(decoder).String())
 	}
-	return t.Scheme.RegisterByDecoder(name, decoder)
-}
-
-func (t *inputTypeScheme) AddKnownTypes(scheme runtime.Scheme) error {
-	if _, ok := scheme.(InputTypeScheme); !ok {
-		return errors.ErrInvalid("type", reflect.TypeOf(scheme).String(), "expected", "InputTypeScheme")
-	}
-
-	if err := t.Scheme.AddKnownTypes(scheme); err != nil {
-		return fmt.Errorf("failed to add known type in inputTypeScheme: %w", err)
-	}
-
-	return nil
+	return t.SchemeBase.RegisterByDecoder(name, decoder)
 }
 
 func (t *inputTypeScheme) Register(name string, rtype InputType) {
-	t.Scheme.RegisterByDecoder(name, rtype)
+	t.SchemeBase.RegisterByDecoder(name, rtype)
 }
 
 func (t *inputTypeScheme) DecodeInputSpec(data []byte, unmarshaler runtime.Unmarshaler) (InputSpec, error) {
@@ -134,7 +122,7 @@ func (t *inputTypeScheme) DecodeInputSpec(data []byte, unmarshaler runtime.Unmar
 
 func (t *inputTypeScheme) CreateInputSpec(obj runtime.TypedObject) (InputSpec, error) {
 	if s, ok := obj.(InputSpec); ok {
-		r, err := t.Scheme.Convert(s)
+		r, err := t.SchemeBase.Convert(s)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/contexts/config/core/configtypes.go
+++ b/pkg/contexts/config/core/configtypes.go
@@ -34,6 +34,7 @@ type ConfigType interface {
 
 type ConfigTypeScheme interface {
 	runtime.Scheme
+	AddKnownTypes(s ConfigTypeScheme)
 
 	GetConfigType(name string) ConfigType
 	Register(name string, atype ConfigType)
@@ -45,7 +46,7 @@ type ConfigTypeScheme interface {
 }
 
 type configTypeScheme struct {
-	runtime.Scheme
+	runtime.SchemeBase
 }
 
 func NewConfigTypeScheme(defaultRepoDecoder runtime.TypedObjectDecoder) ConfigTypeScheme {
@@ -54,8 +55,8 @@ func NewConfigTypeScheme(defaultRepoDecoder runtime.TypedObjectDecoder) ConfigTy
 	return &configTypeScheme{scheme}
 }
 
-func (t *configTypeScheme) AddKnowntypes(s ConfigTypeScheme) {
-	t.Scheme.AddKnownTypes(s)
+func (t *configTypeScheme) AddKnownTypes(s ConfigTypeScheme) {
+	t.SchemeBase.AddKnownTypes(s)
 }
 
 func (t *configTypeScheme) GetConfigType(name string) ConfigType {
@@ -70,23 +71,11 @@ func (t *configTypeScheme) RegisterByDecoder(name string, decoder runtime.TypedO
 	if _, ok := decoder.(ConfigType); !ok {
 		return errors.ErrInvalid("type", reflect.TypeOf(decoder).String())
 	}
-	return t.Scheme.RegisterByDecoder(name, decoder)
-}
-
-func (t *configTypeScheme) AddKnownTypes(scheme runtime.Scheme) error {
-	if _, ok := scheme.(ConfigTypeScheme); !ok {
-		return errors.ErrInvalid("type", reflect.TypeOf(scheme).String(), "expected", "ConfigTypeScheme")
-	}
-
-	if err := t.Scheme.AddKnownTypes(scheme); err != nil {
-		return fmt.Errorf("failed to add known type in config type scheme: %w", err)
-	}
-
-	return nil
+	return t.SchemeBase.RegisterByDecoder(name, decoder)
 }
 
 func (t *configTypeScheme) Register(name string, rtype ConfigType) {
-	t.Scheme.RegisterByDecoder(name, rtype)
+	t.SchemeBase.RegisterByDecoder(name, rtype)
 }
 
 func (t *configTypeScheme) DecodeConfig(data []byte, unmarshaler runtime.Unmarshaler) (Config, error) {

--- a/pkg/contexts/credentials/core/repotypes.go
+++ b/pkg/contexts/credentials/core/repotypes.go
@@ -38,6 +38,7 @@ type RepositorySpec interface {
 
 type RepositoryTypeScheme interface {
 	runtime.Scheme
+	AddKnownTypes(s RepositoryTypeScheme)
 
 	GetRepositoryType(name string) RepositoryType
 	Register(name string, atype RepositoryType)
@@ -47,7 +48,7 @@ type RepositoryTypeScheme interface {
 }
 
 type repositoryTypeScheme struct {
-	runtime.Scheme
+	runtime.SchemeBase
 }
 
 func NewRepositoryTypeScheme(defaultRepoDecoder runtime.TypedObjectDecoder) RepositoryTypeScheme {
@@ -56,8 +57,8 @@ func NewRepositoryTypeScheme(defaultRepoDecoder runtime.TypedObjectDecoder) Repo
 	return &repositoryTypeScheme{scheme}
 }
 
-func (t *repositoryTypeScheme) AddKnowntypes(s RepositoryTypeScheme) {
-	t.Scheme.AddKnownTypes(s)
+func (t *repositoryTypeScheme) AddKnownTypes(s RepositoryTypeScheme) {
+	t.SchemeBase.AddKnownTypes(s)
 }
 
 func (t *repositoryTypeScheme) GetRepositoryType(name string) RepositoryType {
@@ -72,23 +73,11 @@ func (t *repositoryTypeScheme) RegisterByDecoder(name string, decoder runtime.Ty
 	if _, ok := decoder.(RepositoryType); !ok {
 		return errors.ErrInvalid("type", reflect.TypeOf(decoder).String())
 	}
-	return t.Scheme.RegisterByDecoder(name, decoder)
-}
-
-func (t *repositoryTypeScheme) AddKnownTypes(scheme runtime.Scheme) error {
-	if _, ok := scheme.(RepositoryTypeScheme); !ok {
-		return errors.ErrInvalid("type", reflect.TypeOf(scheme).String())
-	}
-
-	if err := t.Scheme.AddKnownTypes(scheme); err != nil {
-		return fmt.Errorf("failed to add known type: %w", err)
-	}
-
-	return nil
+	return t.SchemeBase.RegisterByDecoder(name, decoder)
 }
 
 func (t *repositoryTypeScheme) Register(name string, rtype RepositoryType) {
-	t.Scheme.RegisterByDecoder(name, rtype)
+	t.SchemeBase.RegisterByDecoder(name, rtype)
 }
 
 func (t *repositoryTypeScheme) DecodeRepositorySpec(data []byte, unmarshaler runtime.Unmarshaler) (RepositorySpec, error) {

--- a/pkg/contexts/ocm/core/repotypes.go
+++ b/pkg/contexts/ocm/core/repotypes.go
@@ -48,6 +48,7 @@ type RepositorySpec interface {
 
 type RepositoryTypeScheme interface {
 	runtime.Scheme
+	AddKnownTypes(s RepositoryTypeScheme)
 
 	GetRepositoryType(name string) RepositoryType
 	Register(name string, atype RepositoryType)
@@ -57,7 +58,7 @@ type RepositoryTypeScheme interface {
 }
 
 type repositoryTypeScheme struct {
-	runtime.Scheme
+	runtime.SchemeBase
 }
 
 func NewRepositoryTypeScheme(defaultRepoDecoder runtime.TypedObjectDecoder) RepositoryTypeScheme {
@@ -66,8 +67,8 @@ func NewRepositoryTypeScheme(defaultRepoDecoder runtime.TypedObjectDecoder) Repo
 	return &repositoryTypeScheme{scheme}
 }
 
-func (t *repositoryTypeScheme) AddKnowntypes(s RepositoryTypeScheme) {
-	t.Scheme.AddKnownTypes(s)
+func (t *repositoryTypeScheme) AddKnownTypes(s RepositoryTypeScheme) {
+	t.SchemeBase.AddKnownTypes(s)
 }
 
 func (t *repositoryTypeScheme) GetRepositoryType(name string) RepositoryType {
@@ -82,23 +83,11 @@ func (t *repositoryTypeScheme) RegisterByDecoder(name string, decoder runtime.Ty
 	if _, ok := decoder.(RepositoryType); !ok {
 		return errors.ErrInvalid("type", reflect.TypeOf(decoder).String())
 	}
-	return t.Scheme.RegisterByDecoder(name, decoder)
-}
-
-func (t *repositoryTypeScheme) AddKnownTypes(scheme runtime.Scheme) error {
-	if _, ok := scheme.(RepositoryTypeScheme); !ok {
-		return errors.ErrInvalid("type", reflect.TypeOf(scheme).String(), "expected", "RepositoryTypeScheme")
-	}
-
-	if err := t.Scheme.AddKnownTypes(scheme); err != nil {
-		return fmt.Errorf("failed to add known type in repository type scheme: %w", err)
-	}
-
-	return nil
+	return t.SchemeBase.RegisterByDecoder(name, decoder)
 }
 
 func (t *repositoryTypeScheme) Register(name string, rtype RepositoryType) {
-	t.Scheme.RegisterByDecoder(name, rtype)
+	t.SchemeBase.RegisterByDecoder(name, rtype)
 }
 
 func (t *repositoryTypeScheme) DecodeRepositorySpec(data []byte, unmarshaler runtime.Unmarshaler) (RepositorySpec, error) {

--- a/pkg/runtime/scheme.go
+++ b/pkg/runtime/scheme.go
@@ -186,11 +186,14 @@ type Scheme interface {
 	Decode(data []byte, unmarshaler Unmarshaler) (TypedObject, error)
 	Encode(obj TypedObject, marshaler Marshaler) ([]byte, error)
 	EnforceDecode(data []byte, unmarshaler Unmarshaler) (TypedObject, error)
-	AddKnownTypes(scheme Scheme) error
 	KnownTypes() KnownTypes
 	KnownTypeNames() []string
 }
 
+type SchemeBase interface {
+	AddKnownTypes(scheme Scheme)
+	Scheme
+}
 type defaultScheme struct {
 	lock           sync.RWMutex
 	instance       reflect.Type
@@ -200,7 +203,7 @@ type defaultScheme struct {
 	types          KnownTypes
 }
 
-func MustNewDefaultScheme(protoIfce interface{}, protoUnstr Unstructured, acceptUnknown bool, defaultdecoder TypedObjectDecoder) Scheme {
+func MustNewDefaultScheme(protoIfce interface{}, protoUnstr Unstructured, acceptUnknown bool, defaultdecoder TypedObjectDecoder) SchemeBase {
 	s, err := NewDefaultScheme(protoIfce, protoUnstr, acceptUnknown, defaultdecoder)
 	if err != nil {
 		panic(err)
@@ -208,7 +211,7 @@ func MustNewDefaultScheme(protoIfce interface{}, protoUnstr Unstructured, accept
 	return s
 }
 
-func NewDefaultScheme(protoIfce interface{}, protoUnstr Unstructured, acceptUnknown bool, defaultdecoder TypedObjectDecoder) (Scheme, error) {
+func NewDefaultScheme(protoIfce interface{}, protoUnstr Unstructured, acceptUnknown bool, defaultdecoder TypedObjectDecoder) (SchemeBase, error) {
 	if protoIfce == nil {
 		return nil, fmt.Errorf("object interface must be given by pointer to interace (is nil)")
 	}
@@ -243,13 +246,12 @@ func NewDefaultScheme(protoIfce interface{}, protoUnstr Unstructured, acceptUnkn
 	}, nil
 }
 
-func (d *defaultScheme) AddKnownTypes(s Scheme) error {
+func (d *defaultScheme) AddKnownTypes(s Scheme) {
 	d.lock.Lock()
 	defer d.lock.Unlock()
 	for k, v := range s.KnownTypes() {
 		d.types[k] = v
 	}
-	return nil
 }
 
 func (d *defaultScheme) KnownTypes() KnownTypes {


### PR DESCRIPTION
**What this PR does / why we need it**:

Some proposal to find a better way, based on the semantics of the operations, for the `Scheme.AddKnownTypes` handling.

It completely avoids this code pollution with the unnecessary formal error handling, and drastically simplifies the code.
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
