### PR TITLE
setup modes for context builder

### DIFF
--- a/pkg/contexts/clictx/builder.go
+++ b/pkg/contexts/clictx/builder.go
@@ -53,6 +53,6 @@ func WithInput(r io.Reader) core2.Builder {
 	return core2.Builder{}.WithInput(r)
 }
 
-func New() core2.Context {
-	return core2.Builder{}.New()
+func New(mode ...datacontext.BuilderMode) core2.Context {
+	return core2.Builder{}.New(mode...)
 }

--- a/pkg/contexts/clictx/core/builder.go
+++ b/pkg/contexts/clictx/core/builder.go
@@ -80,10 +80,16 @@ func (b Builder) Bound() (Context, context.Context) {
 	return c, context.WithValue(b.getContext(), key, c)
 }
 
-func (b Builder) New() Context {
+func (b Builder) New(m ...datacontext.BuilderMode) Context {
+	mode := datacontext.Mode(m...)
 	ctx := b.getContext()
+
 	if b.ocm == nil {
-		b.ocm = ocm.ForContext(ctx)
+		var ok bool
+		b.ocm, ok = ocm.DefinedForContext(ctx)
+		if !ok && mode != datacontext.MODE_SHARED {
+			b.ocm = ocm.New(mode)
+		}
 	}
 	if b.shared == nil {
 		b.shared = b.ocm.AttributesContext()

--- a/pkg/contexts/clictx/core/context.go
+++ b/pkg/contexts/clictx/core/context.go
@@ -80,13 +80,22 @@ type Context interface {
 var key = reflect.TypeOf(_context{})
 
 // DefaultContext is the default context initialized by init functions.
-var DefaultContext = Builder{}.New()
+var DefaultContext = Builder{}.New(datacontext.MODE_SHARED)
 
 // ForContext returns the Context to use for context.Context.
 // This is either an explicit context or the default context.
 // The returned context incorporates the given context.
 func ForContext(ctx context.Context) Context {
-	return datacontext.ForContextByKey(ctx, key, DefaultContext).(Context)
+	c, _ := datacontext.ForContextByKey(ctx, key, DefaultContext)
+	return c.(Context)
+}
+
+func DefinedForContext(ctx context.Context) (Context, bool) {
+	c, ok := datacontext.ForContextByKey(ctx, key, DefaultContext)
+	if c != nil {
+		return c.(Context), ok
+	}
+	return nil, ok
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pkg/contexts/config/configutils/configure.go
+++ b/pkg/contexts/config/configutils/configure.go
@@ -27,7 +27,6 @@ import (
 	"github.com/mandelsoft/vfs/pkg/vfs"
 
 	"github.com/open-component-model/ocm/pkg/contexts/config"
-
 	"github.com/open-component-model/ocm/pkg/errors"
 )
 

--- a/pkg/contexts/config/configutils/configure.go
+++ b/pkg/contexts/config/configutils/configure.go
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package config
+package configutils
 
 import (
 	"fmt"
@@ -21,43 +21,51 @@ import (
 
 	_ "github.com/open-component-model/ocm/pkg/contexts/datacontext/config"
 
+	"github.com/mandelsoft/spiff/features"
+	"github.com/mandelsoft/spiff/spiffing"
 	"github.com/mandelsoft/vfs/pkg/osfs"
 	"github.com/mandelsoft/vfs/pkg/vfs"
 
 	"github.com/open-component-model/ocm/pkg/contexts/config"
+
 	"github.com/open-component-model/ocm/pkg/errors"
 )
 
-func Configure(file string) error {
+func Configure(path string) error {
 	h := os.Getenv("HOME")
-	if file == "" {
+	if path == "" {
 		if h != "" {
 			cfg := h + "/.ocmconfig"
 			if ok, err := vfs.FileExists(osfs.New(), cfg); ok && err == nil {
-				file = cfg
+				path = cfg
 			}
 		}
 	}
 
-	if file != "" {
-		if strings.HasPrefix(file, "~"+string(os.PathSeparator)) {
+	if path != "" {
+		if strings.HasPrefix(path, "~"+string(os.PathSeparator)) {
 			if len(h) == 0 {
-				return fmt.Errorf("no home directory found for resolving path of config file %q", file)
+				return fmt.Errorf("no home directory found for resolving path of ocm config file %q", path)
 			}
-			file = h + file[1:]
+			path = h + path[1:]
 		}
-		data, err := os.ReadFile(file)
+		data, err := vfs.ReadFile(osfs.New(), path)
 		if err != nil {
-			return errors.Wrapf(err, "cannot read config file %q", file)
+			return errors.Wrapf(err, "cannot read ocm config file %q", path)
 		}
 
+		sctx := spiffing.New().WithFeatures(features.INTERPOLATION, features.CONTROL)
+		data, err = spiffing.Process(sctx, spiffing.NewSourceData(path, data))
+		if err != nil {
+			return errors.Wrapf(err, "processing ocm config %q", path)
+		}
 		cfg, err := config.DefaultContext().GetConfigForData(data, nil)
 		if err != nil {
-			return errors.Wrapf(err, "invalid config file %q", file)
+			return errors.Wrapf(err, "invalid ocm config file %q", path)
 		}
-		err = config.DefaultContext().ApplyConfig(cfg, file)
+		err = config.DefaultContext().ApplyConfig(cfg, path)
 		if err != nil {
-			return errors.Wrapf(err, "cannot apply config %q", file)
+			return errors.Wrapf(err, "cannot apply ocm config %q", path)
 		}
 	}
 	return nil

--- a/pkg/contexts/config/core/builder.go
+++ b/pkg/contexts/config/core/builder.go
@@ -53,13 +53,29 @@ func (b Builder) Bound() (Context, context.Context) {
 	return c, context.WithValue(b.getContext(), key, c)
 }
 
-func (b Builder) New() Context {
+func (b Builder) New(m ...datacontext.BuilderMode) Context {
+	mode := datacontext.Mode(m...)
 	ctx := b.getContext()
+
 	if b.shared == nil {
-		b.shared = datacontext.ForContext(ctx)
+		if mode == datacontext.MODE_SHARED {
+			b.shared = datacontext.ForContext(ctx)
+		} else {
+			b.shared = datacontext.New(nil)
+		}
 	}
 	if b.reposcheme == nil {
-		b.reposcheme = DefaultConfigTypeScheme
+		switch mode {
+		case datacontext.MODE_INITIAL:
+			b.reposcheme = NewConfigTypeScheme(nil)
+		case datacontext.MODE_CONFIGURED:
+			b.reposcheme = NewConfigTypeScheme(nil)
+			b.reposcheme.AddKnownTypes(DefaultConfigTypeScheme)
+		case datacontext.MODE_DEFAULTED:
+			fallthrough
+		case datacontext.MODE_SHARED:
+			b.reposcheme = DefaultConfigTypeScheme
+		}
 	}
 	return newContext(b.shared, b.reposcheme)
 }

--- a/pkg/contexts/config/core/builder_test.go
+++ b/pkg/contexts/config/core/builder_test.go
@@ -1,0 +1,53 @@
+// Copyright 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package core_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	local "github.com/open-component-model/ocm/pkg/contexts/config/core"
+
+	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
+)
+
+var _ = Describe("builder test", func() {
+	It("creates local", func() {
+		ctx := local.Builder{}.New(datacontext.MODE_SHARED)
+
+		Expect(ctx.AttributesContext()).To(BeIdenticalTo(datacontext.DefaultContext))
+		Expect(ctx).NotTo(BeIdenticalTo(local.DefaultContext))
+		Expect(ctx.ConfigTypes()).To(BeIdenticalTo(local.DefaultConfigTypeScheme))
+	})
+
+	It("creates configured", func() {
+		ctx := local.Builder{}.New(datacontext.MODE_CONFIGURED)
+
+		Expect(ctx.AttributesContext()).NotTo(BeIdenticalTo(datacontext.DefaultContext))
+		Expect(ctx).NotTo(BeIdenticalTo(local.DefaultContext))
+		Expect(ctx.ConfigTypes()).NotTo(BeIdenticalTo(local.DefaultConfigTypeScheme))
+		Expect(ctx.ConfigTypes().KnownTypeNames()).To(Equal(local.DefaultConfigTypeScheme.KnownTypeNames()))
+	})
+
+	It("creates iniial", func() {
+		ctx := local.Builder{}.New(datacontext.MODE_INITIAL)
+
+		Expect(ctx.AttributesContext()).NotTo(BeIdenticalTo(datacontext.DefaultContext))
+		Expect(ctx).NotTo(BeIdenticalTo(local.DefaultContext))
+		Expect(ctx.ConfigTypes()).NotTo(BeIdenticalTo(local.DefaultConfigTypeScheme))
+		Expect(len(ctx.ConfigTypes().KnownTypeNames())).To(Equal(0))
+	})
+
+})

--- a/pkg/contexts/config/core/builder_test.go
+++ b/pkg/contexts/config/core/builder_test.go
@@ -19,7 +19,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	local "github.com/open-component-model/ocm/pkg/contexts/config/core"
-
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 )
 

--- a/pkg/contexts/config/core/context.go
+++ b/pkg/contexts/config/core/context.go
@@ -82,13 +82,22 @@ type Context interface {
 var key = reflect.TypeOf(_context{})
 
 // DefaultContext is the default context initialized by init functions.
-var DefaultContext = Builder{}.New()
+var DefaultContext = Builder{}.New(datacontext.MODE_SHARED)
 
 // ForContext returns the Context to use for context.Context.
 // This is either an explicit context or the default context.
 // The returned context incorporates the given context.
 func ForContext(ctx context.Context) Context {
-	return datacontext.ForContextByKey(ctx, key, DefaultContext).(Context)
+	c, _ := datacontext.ForContextByKey(ctx, key, DefaultContext)
+	return c.(Context)
+}
+
+func DefinedForContext(ctx context.Context) (Context, bool) {
+	c, ok := datacontext.ForContextByKey(ctx, key, DefaultContext)
+	if c != nil {
+		return c.(Context), ok
+	}
+	return nil, ok
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pkg/contexts/config/core/setup_test.go
+++ b/pkg/contexts/config/core/setup_test.go
@@ -12,27 +12,20 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package config
+package core_test
 
 import (
-	"context"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/open-component-model/ocm/pkg/contexts/config/core"
-	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
+
+	"github.com/open-component-model/ocm/pkg/contexts/config"
 )
 
-func WithContext(ctx context.Context) core.Builder {
-	return core.Builder{}.WithContext(ctx)
-}
-
-func WithSharedAttributes(ctx datacontext.AttributesContext) core.Builder {
-	return core.Builder{}.WithSharedAttributes(ctx)
-}
-
-func WithConfigTypeScheme(scheme ConfigTypeScheme) core.Builder {
-	return core.Builder{}.WithConfigTypeScheme(scheme)
-}
-
-func New(mode ...datacontext.BuilderMode) Context {
-	return core.Builder{}.New(mode...)
-}
+var _ = Describe("setup", func() {
+	It("creates initial", func() {
+		Expect(len(config.DefaultContext().ConfigTypes().KnownTypeNames())).To(Equal(2))
+		Expect(len(core.DefaultConfigTypeScheme.KnownTypeNames())).To(Equal(2))
+	})
+})

--- a/pkg/contexts/config/core/setup_test.go
+++ b/pkg/contexts/config/core/setup_test.go
@@ -18,9 +18,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/open-component-model/ocm/pkg/contexts/config/core"
-
 	"github.com/open-component-model/ocm/pkg/contexts/config"
+	"github.com/open-component-model/ocm/pkg/contexts/config/core"
 )
 
 var _ = Describe("setup", func() {

--- a/pkg/contexts/config/core/suite_test.go
+++ b/pkg/contexts/config/core/suite_test.go
@@ -12,27 +12,16 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package config
+package core_test
 
 import (
-	"context"
+	"testing"
 
-	"github.com/open-component-model/ocm/pkg/contexts/config/core"
-	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func WithContext(ctx context.Context) core.Builder {
-	return core.Builder{}.WithContext(ctx)
-}
-
-func WithSharedAttributes(ctx datacontext.AttributesContext) core.Builder {
-	return core.Builder{}.WithSharedAttributes(ctx)
-}
-
-func WithConfigTypeScheme(scheme ConfigTypeScheme) core.Builder {
-	return core.Builder{}.WithConfigTypeScheme(scheme)
-}
-
-func New(mode ...datacontext.BuilderMode) Context {
-	return core.Builder{}.New(mode...)
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Core Test Suite")
 }

--- a/pkg/contexts/config/interface.go
+++ b/pkg/contexts/config/interface.go
@@ -48,6 +48,10 @@ func ForContext(ctx context.Context) Context {
 	return core.ForContext(ctx)
 }
 
+func DefinedForContext(ctx context.Context) (Context, bool) {
+	return core.DefinedForContext(ctx)
+}
+
 func NewGenericConfig(data []byte, unmarshaler runtime.Unmarshaler) (Config, error) {
 	return core.NewGenericConfig(data, unmarshaler)
 }

--- a/pkg/contexts/credentials/builder.go
+++ b/pkg/contexts/credentials/builder.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/open-component-model/ocm/pkg/contexts/config"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/core"
+	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 )
 
 func WithContext(ctx context.Context) core.Builder {
@@ -37,6 +38,6 @@ func WithStandardConumerMatchers(matchers core.IdentityMatcherRegistry) core.Bui
 	return core.Builder{}.WithStandardConumerMatchers(matchers)
 }
 
-func New() Context {
-	return core.Builder{}.New()
+func New(mode ...datacontext.BuilderMode) Context {
+	return core.Builder{}.New(mode...)
 }

--- a/pkg/contexts/credentials/core/builder_test.go
+++ b/pkg/contexts/credentials/core/builder_test.go
@@ -19,9 +19,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/open-component-model/ocm/pkg/contexts/config"
-
 	local "github.com/open-component-model/ocm/pkg/contexts/credentials/core"
-
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 )
 

--- a/pkg/contexts/credentials/core/builder_test.go
+++ b/pkg/contexts/credentials/core/builder_test.go
@@ -1,0 +1,75 @@
+// Copyright 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package core_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/open-component-model/ocm/pkg/contexts/config"
+
+	local "github.com/open-component-model/ocm/pkg/contexts/credentials/core"
+
+	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
+)
+
+var _ = Describe("builder test", func() {
+	It("creates local", func() {
+		ctx := local.Builder{}.New(datacontext.MODE_SHARED)
+
+		Expect(ctx.AttributesContext()).To(BeIdenticalTo(datacontext.DefaultContext))
+		Expect(ctx).NotTo(BeIdenticalTo(local.DefaultContext))
+		Expect(ctx.RepositoryTypes()).To(BeIdenticalTo(local.DefaultRepositoryTypeScheme))
+
+		Expect(ctx.ConfigContext()).To(BeIdenticalTo(config.DefaultContext()))
+	})
+
+	It("creates defaulted", func() {
+		ctx := local.Builder{}.New(datacontext.MODE_DEFAULTED)
+
+		Expect(ctx.AttributesContext()).NotTo(BeIdenticalTo(datacontext.DefaultContext))
+		Expect(ctx).NotTo(BeIdenticalTo(local.DefaultContext))
+		Expect(ctx.RepositoryTypes()).To(BeIdenticalTo(local.DefaultRepositoryTypeScheme))
+
+		Expect(ctx.ConfigContext()).NotTo(BeIdenticalTo(config.DefaultContext()))
+		Expect(ctx.ConfigContext().ConfigTypes()).To(BeIdenticalTo(config.DefaultContext().ConfigTypes()))
+	})
+
+	It("creates configured", func() {
+		ctx := local.Builder{}.New(datacontext.MODE_CONFIGURED)
+
+		Expect(ctx.AttributesContext()).NotTo(BeIdenticalTo(datacontext.DefaultContext))
+		Expect(ctx).NotTo(BeIdenticalTo(local.DefaultContext))
+		Expect(ctx.RepositoryTypes()).NotTo(BeIdenticalTo(local.DefaultRepositoryTypeScheme))
+		Expect(ctx.RepositoryTypes().KnownTypeNames()).To(Equal(local.DefaultRepositoryTypeScheme.KnownTypeNames()))
+
+		Expect(ctx.ConfigContext()).NotTo(BeIdenticalTo(config.DefaultContext()))
+		Expect(ctx.ConfigContext().ConfigTypes()).NotTo(BeIdenticalTo(config.DefaultContext().ConfigTypes()))
+		Expect(ctx.ConfigContext().ConfigTypes().KnownTypeNames()).To(Equal(config.DefaultContext().ConfigTypes().KnownTypeNames()))
+	})
+
+	It("creates iniial", func() {
+		ctx := local.Builder{}.New(datacontext.MODE_INITIAL)
+
+		Expect(ctx.AttributesContext()).NotTo(BeIdenticalTo(datacontext.DefaultContext))
+		Expect(ctx).NotTo(BeIdenticalTo(local.DefaultContext))
+		Expect(ctx.RepositoryTypes()).NotTo(BeIdenticalTo(local.DefaultRepositoryTypeScheme))
+		Expect(len(ctx.RepositoryTypes().KnownTypeNames())).To(Equal(0))
+
+		Expect(ctx.ConfigContext()).NotTo(BeIdenticalTo(config.DefaultContext()))
+		Expect(len(ctx.ConfigContext().ConfigTypes().KnownTypeNames())).To(Equal(0))
+	})
+
+})

--- a/pkg/contexts/credentials/core/context.go
+++ b/pkg/contexts/credentials/core/context.go
@@ -54,12 +54,21 @@ type Context interface {
 var key = reflect.TypeOf(_context{})
 
 // DefaultContext is the default context initialized by init functions.
-var DefaultContext = Builder{}.New()
+var DefaultContext = Builder{}.New(datacontext.MODE_SHARED)
 
 // ForContext returns the Context to use for context.Context.
 // This is either an explicit context or the default context.
 func ForContext(ctx context.Context) Context {
-	return datacontext.ForContextByKey(ctx, key, DefaultContext).(Context)
+	c, _ := datacontext.ForContextByKey(ctx, key, DefaultContext)
+	return c.(Context)
+}
+
+func DefinedForContext(ctx context.Context) (Context, bool) {
+	c, ok := datacontext.ForContextByKey(ctx, key, DefaultContext)
+	if c != nil {
+		return c.(Context), ok
+	}
+	return nil, ok
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pkg/contexts/credentials/core/suite_test.go
+++ b/pkg/contexts/credentials/core/suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestConfig(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "CTF Test Suite")
+	RunSpecs(t, "Credentials Core Suite")
 }

--- a/pkg/contexts/credentials/cpi/interface.go
+++ b/pkg/contexts/credentials/cpi/interface.go
@@ -19,6 +19,7 @@ package cpi
 import (
 	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/core"
+	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 )
 
 const (
@@ -47,6 +48,10 @@ type (
 )
 
 var DefaultContext = core.DefaultContext
+
+func New(m ...datacontext.BuilderMode) Context {
+	return core.Builder{}.New(m...)
+}
 
 func NewGenericCredentialsSpec(name string, repospec *GenericRepositorySpec) *GenericCredentialsSpec {
 	return core.NewGenericCredentialsSpec(name, repospec)

--- a/pkg/contexts/credentials/interface.go
+++ b/pkg/contexts/credentials/interface.go
@@ -64,6 +64,10 @@ func ForContext(ctx context.Context) Context {
 	return core.ForContext(ctx)
 }
 
+func DefinedForContext(ctx context.Context) (Context, bool) {
+	return core.DefinedForContext(ctx)
+}
+
 func NewCredentialsSpec(name string, repospec RepositorySpec) CredentialsSpec {
 	return core.NewCredentialsSpec(name, repospec)
 }

--- a/pkg/contexts/datacontext/context.go
+++ b/pkg/contexts/datacontext/context.go
@@ -29,10 +29,10 @@ import (
 type BuilderMode int
 
 const (
-	// MODE_SHARED uses the default contexts for unset nested context types
+	// MODE_SHARED uses the default contexts for unset nested context types.
 	MODE_SHARED BuilderMode = iota
 	// MODE_DEFAULTED uses dedicated context instances configured with the
-	// context type specific default registrations
+	// context type specific default registrations.
 	MODE_DEFAULTED
 	// MODE_CONFIGURED uses dedicated context instances configured with the
 	// context type registrations configured with the actual state of the

--- a/pkg/contexts/datacontext/context.go
+++ b/pkg/contexts/datacontext/context.go
@@ -24,6 +24,33 @@ import (
 	"github.com/open-component-model/ocm/pkg/runtime"
 )
 
+// BuilderMode controls the handling of unset information in the
+// builder configuration when calling the New method.
+type BuilderMode int
+
+const (
+	// MODE_SHARED uses the default contexts for unset nested context types
+	MODE_SHARED BuilderMode = iota
+	// MODE_DEFAULTED uses dedicated context instances configured with the
+	// context type specific default registrations
+	MODE_DEFAULTED
+	// MODE_CONFIGURED uses dedicated context instances configured with the
+	// context type registrations configured with the actual state of the
+	// default registrations.
+	MODE_CONFIGURED
+	// MODE_INITIAL uses completely new contexts for unset nested context types
+	// and initial registrations.
+	MODE_INITIAL
+)
+
+func Mode(m ...BuilderMode) BuilderMode {
+	mode := MODE_DEFAULTED
+	if len(m) > 0 {
+		mode = m[0]
+	}
+	return mode
+}
+
 // Context describes a common interface for a data context used for a dedicated
 // purpose.
 // Such has a type and always specific attribute store.
@@ -69,7 +96,11 @@ var DefaultContext = New(nil)
 // ForContext returns the Context to use for context.Context.
 // This is either an explicit context or the default context.
 func ForContext(ctx context.Context) AttributesContext {
-	return ForContextByKey(ctx, key, DefaultContext).(AttributesContext)
+	c, _ := ForContextByKey(ctx, key, DefaultContext)
+	if c == nil {
+		return nil
+	}
+	return c.(AttributesContext)
 }
 
 // WithContext create a new Context bound to a context.Context.

--- a/pkg/contexts/datacontext/util.go
+++ b/pkg/contexts/datacontext/util.go
@@ -18,13 +18,12 @@ import (
 	"context"
 )
 
-func ForContextByKey(ctx context.Context, key interface{}, def Context) Context {
+// ForContextByKey retrieves the context for a given key to be used for a context.Context.
+// If not defined, it returns the given default context and false.
+func ForContextByKey(ctx context.Context, key interface{}, def Context) (Context, bool) {
 	c := ctx.Value(key)
 	if c == nil {
-		c = def
+		return def, false
 	}
-	if c == nil {
-		return nil
-	}
-	return c.(Context)
+	return c.(Context), true
 }

--- a/pkg/contexts/oci/builder.go
+++ b/pkg/contexts/oci/builder.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
+	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/core"
 )
 
@@ -37,6 +38,6 @@ func WithRepositorySpecHandlers(reg RepositorySpecHandlers) core.Builder {
 	return core.Builder{}.WithRepositorySpecHandlers(reg)
 }
 
-func New() Context {
-	return core.Builder{}.New()
+func New(mode ...datacontext.BuilderMode) Context {
+	return core.Builder{}.New(mode...)
 }

--- a/pkg/contexts/oci/core/builder_test.go
+++ b/pkg/contexts/oci/core/builder_test.go
@@ -1,0 +1,88 @@
+// Copyright 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package core_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/open-component-model/ocm/pkg/contexts/config"
+	"github.com/open-component-model/ocm/pkg/contexts/credentials"
+
+	local "github.com/open-component-model/ocm/pkg/contexts/oci/core"
+
+	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
+)
+
+var _ = Describe("builder test", func() {
+	It("creates local", func() {
+		ctx := local.Builder{}.New(datacontext.MODE_SHARED)
+
+		Expect(ctx.AttributesContext()).To(BeIdenticalTo(datacontext.DefaultContext))
+		Expect(ctx).NotTo(BeIdenticalTo(local.DefaultContext))
+		Expect(ctx.RepositoryTypes()).To(BeIdenticalTo(local.DefaultRepositoryTypeScheme))
+
+		Expect(ctx.ConfigContext()).To(BeIdenticalTo(config.DefaultContext()))
+
+		Expect(ctx.CredentialsContext()).To(BeIdenticalTo(credentials.DefaultContext()))
+	})
+
+	It("creates defaulted", func() {
+		ctx := local.Builder{}.New(datacontext.MODE_DEFAULTED)
+
+		Expect(ctx.AttributesContext()).NotTo(BeIdenticalTo(datacontext.DefaultContext))
+		Expect(ctx).NotTo(BeIdenticalTo(local.DefaultContext))
+		Expect(ctx.RepositoryTypes()).To(BeIdenticalTo(local.DefaultRepositoryTypeScheme))
+
+		Expect(ctx.ConfigContext()).NotTo(BeIdenticalTo(config.DefaultContext()))
+		Expect(ctx.ConfigContext().ConfigTypes()).To(BeIdenticalTo(config.DefaultContext().ConfigTypes()))
+
+		Expect(ctx.CredentialsContext()).NotTo(BeIdenticalTo(credentials.DefaultContext()))
+		Expect(ctx.CredentialsContext().RepositoryTypes()).To(BeIdenticalTo(credentials.DefaultContext().RepositoryTypes()))
+	})
+
+	It("creates configured", func() {
+		ctx := local.Builder{}.New(datacontext.MODE_CONFIGURED)
+
+		Expect(ctx.AttributesContext()).NotTo(BeIdenticalTo(datacontext.DefaultContext))
+		Expect(ctx).NotTo(BeIdenticalTo(local.DefaultContext))
+		Expect(ctx.RepositoryTypes()).NotTo(BeIdenticalTo(local.DefaultRepositoryTypeScheme))
+		Expect(ctx.RepositoryTypes().KnownTypeNames()).To(Equal(local.DefaultRepositoryTypeScheme.KnownTypeNames()))
+
+		Expect(ctx.ConfigContext()).NotTo(BeIdenticalTo(config.DefaultContext()))
+		Expect(ctx.ConfigContext().ConfigTypes()).NotTo(BeIdenticalTo(config.DefaultContext().ConfigTypes()))
+		Expect(ctx.ConfigContext().ConfigTypes().KnownTypeNames()).To(Equal(config.DefaultContext().ConfigTypes().KnownTypeNames()))
+
+		Expect(ctx.CredentialsContext()).NotTo(BeIdenticalTo(config.DefaultContext()))
+		Expect(ctx.CredentialsContext().RepositoryTypes()).NotTo(BeIdenticalTo(credentials.DefaultContext().RepositoryTypes()))
+		Expect(ctx.CredentialsContext().RepositoryTypes().KnownTypeNames()).To(Equal(credentials.DefaultContext().RepositoryTypes().KnownTypeNames()))
+	})
+
+	It("creates iniial", func() {
+		ctx := local.Builder{}.New(datacontext.MODE_INITIAL)
+
+		Expect(ctx.AttributesContext()).NotTo(BeIdenticalTo(datacontext.DefaultContext))
+		Expect(ctx).NotTo(BeIdenticalTo(local.DefaultContext))
+		Expect(ctx.RepositoryTypes()).NotTo(BeIdenticalTo(local.DefaultRepositoryTypeScheme))
+		Expect(len(ctx.RepositoryTypes().KnownTypeNames())).To(Equal(0))
+
+		Expect(ctx.ConfigContext()).NotTo(BeIdenticalTo(config.DefaultContext()))
+		Expect(len(ctx.ConfigContext().ConfigTypes().KnownTypeNames())).To(Equal(0))
+
+		Expect(ctx.CredentialsContext()).NotTo(BeIdenticalTo(credentials.DefaultContext()))
+		Expect(len(ctx.CredentialsContext().RepositoryTypes().KnownTypeNames())).To(Equal(0))
+	})
+
+})

--- a/pkg/contexts/oci/core/builder_test.go
+++ b/pkg/contexts/oci/core/builder_test.go
@@ -20,10 +20,8 @@ import (
 
 	"github.com/open-component-model/ocm/pkg/contexts/config"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
-
-	local "github.com/open-component-model/ocm/pkg/contexts/oci/core"
-
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
+	local "github.com/open-component-model/ocm/pkg/contexts/oci/core"
 )
 
 var _ = Describe("builder test", func() {

--- a/pkg/contexts/oci/core/context.go
+++ b/pkg/contexts/oci/core/context.go
@@ -52,12 +52,21 @@ type Context interface {
 var key = reflect.TypeOf(_context{})
 
 // DefaultContext is the default context initialized by init functions.
-var DefaultContext = Builder{}.New()
+var DefaultContext = Builder{}.New(datacontext.MODE_SHARED)
 
 // ForContext returns the Context to use for context.Context.
 // This is either an explicit context or the default context.
 func ForContext(ctx context.Context) Context {
-	return datacontext.ForContextByKey(ctx, key, DefaultContext).(Context)
+	c, _ := datacontext.ForContextByKey(ctx, key, DefaultContext)
+	return c.(Context)
+}
+
+func DefinedForContext(ctx context.Context) (Context, bool) {
+	c, ok := datacontext.ForContextByKey(ctx, key, DefaultContext)
+	if c != nil {
+		return c.(Context), ok
+	}
+	return nil, ok
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pkg/contexts/oci/core/suite_test.go
+++ b/pkg/contexts/oci/core/suite_test.go
@@ -12,27 +12,16 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-package config
+package core_test
 
 import (
-	"context"
+	"testing"
 
-	"github.com/open-component-model/ocm/pkg/contexts/config/core"
-	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func WithContext(ctx context.Context) core.Builder {
-	return core.Builder{}.WithContext(ctx)
-}
-
-func WithSharedAttributes(ctx datacontext.AttributesContext) core.Builder {
-	return core.Builder{}.WithSharedAttributes(ctx)
-}
-
-func WithConfigTypeScheme(scheme ConfigTypeScheme) core.Builder {
-	return core.Builder{}.WithConfigTypeScheme(scheme)
-}
-
-func New(mode ...datacontext.BuilderMode) Context {
-	return core.Builder{}.New(mode...)
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OCI Core Suite")
 }

--- a/pkg/contexts/oci/cpi/interface.go
+++ b/pkg/contexts/oci/cpi/interface.go
@@ -20,6 +20,8 @@ import (
 	"github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 
+	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
+
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/core"
 )
@@ -57,8 +59,8 @@ type Descriptor = ociv1.Descriptor
 
 var DefaultContext = core.DefaultContext
 
-func New() Context {
-	return core.Builder{}.New()
+func New(m ...datacontext.BuilderMode) Context {
+	return core.Builder{}.New(m...)
 }
 
 func RegisterRepositoryType(name string, atype RepositoryType) {

--- a/pkg/contexts/oci/cpi/interface.go
+++ b/pkg/contexts/oci/cpi/interface.go
@@ -20,9 +20,8 @@ import (
 	"github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 
-	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
-
 	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/core"
 )
 

--- a/pkg/contexts/oci/interface.go
+++ b/pkg/contexts/oci/interface.go
@@ -58,6 +58,10 @@ func ForContext(ctx context.Context) Context {
 	return core.ForContext(ctx)
 }
 
+func DefinedForContext(ctx context.Context) (Context, bool) {
+	return core.DefinedForContext(ctx)
+}
+
 func IsErrBlobNotFound(err error) bool {
 	return accessio.IsErrBlobNotFound(err)
 }

--- a/pkg/contexts/ocm/builder.go
+++ b/pkg/contexts/ocm/builder.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
+	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 	"github.com/open-component-model/ocm/pkg/contexts/oci"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/core"
 )
@@ -54,6 +55,6 @@ func WithBlobDigesters(reg BlobDigesterRegistry) core.Builder {
 	return core.Builder{}.WithBlobDigesters(reg)
 }
 
-func New() Context {
-	return core.Builder{}.New()
+func New(mode ...datacontext.BuilderMode) Context {
+	return core.Builder{}.New(mode...)
 }

--- a/pkg/contexts/ocm/core/blobhandler.go
+++ b/pkg/contexts/ocm/core/blobhandler.go
@@ -173,7 +173,7 @@ type BlobHandlerRegistry interface {
 	Copy() BlobHandlerRegistry
 	// RegisterBlobHandler registers a blob handler. It must specify either a sole mime type,
 	// or a context and repository type, or all three keys
-	RegisterBlobHandler(handler BlobHandler, opts ...BlobHandlerOption) BlobHandlerRegistry
+	Register(handler BlobHandler, opts ...BlobHandlerOption) BlobHandlerRegistry
 	// GetHandler returns handler trying all matches in the following order:
 	//
 	// - a handle matching all keys
@@ -242,7 +242,7 @@ func (r *blobHandlerRegistry) IsInitial() bool {
 	return len(r.handlers) == 0 && len(r.defhandler) == 0
 }
 
-func (r *blobHandlerRegistry) RegisterBlobHandler(handler BlobHandler, olist ...BlobHandlerOption) BlobHandlerRegistry {
+func (r *blobHandlerRegistry) Register(handler BlobHandler, olist ...BlobHandlerOption) BlobHandlerRegistry {
 	opts := &BlobHandlerOptions{}
 	for _, o := range olist {
 		o.ApplyBlobHandlerOptionTo(opts)
@@ -325,5 +325,9 @@ func (r *blobHandlerRegistry) getHandler(key BlobHandlerKey) (BlobHandler, *hand
 }
 
 func RegisterBlobHandler(handler BlobHandler, opts ...BlobHandlerOption) {
-	DefaultBlobHandlerRegistry.RegisterBlobHandler(handler, opts...)
+	DefaultBlobHandlerRegistry.Register(handler, opts...)
+}
+
+func MustRegisterBlobHandler(handler BlobHandler, opts ...BlobHandlerOption) {
+	DefaultBlobHandlerRegistry.Register(handler, opts...)
 }

--- a/pkg/contexts/ocm/core/blobhandler.go
+++ b/pkg/contexts/ocm/core/blobhandler.go
@@ -167,6 +167,8 @@ func ForMimeType(mimetype string) BlobHandlerOption {
 
 // BlobHandlerRegistry registers blob handlers to use in a dedicated ocm context.
 type BlobHandlerRegistry interface {
+	IsInitial() bool
+
 	// Copy provides a new independend copy of the registry
 	Copy() BlobHandlerRegistry
 	// RegisterBlobHandler registers a blob handler. It must specify either a sole mime type,
@@ -234,6 +236,10 @@ func (r *blobHandlerRegistry) Copy() BlobHandlerRegistry {
 		n.handlers[k] = h
 	}
 	return n
+}
+
+func (r *blobHandlerRegistry) IsInitial() bool {
+	return len(r.handlers) == 0 && len(r.defhandler) == 0
 }
 
 func (r *blobHandlerRegistry) RegisterBlobHandler(handler BlobHandler, olist ...BlobHandlerOption) BlobHandlerRegistry {

--- a/pkg/contexts/ocm/core/builder_test.go
+++ b/pkg/contexts/ocm/core/builder_test.go
@@ -1,0 +1,114 @@
+// Copyright 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package core_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/open-component-model/ocm/pkg/contexts/config"
+	"github.com/open-component-model/ocm/pkg/contexts/credentials"
+	"github.com/open-component-model/ocm/pkg/contexts/oci"
+
+	local "github.com/open-component-model/ocm/pkg/contexts/ocm/core"
+
+	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
+)
+
+var _ = Describe("builder test", func() {
+	It("creates local", func() {
+		ctx := local.Builder{}.New(datacontext.MODE_SHARED)
+
+		Expect(ctx.AttributesContext()).To(BeIdenticalTo(datacontext.DefaultContext))
+		Expect(ctx).NotTo(BeIdenticalTo(local.DefaultContext))
+		Expect(ctx.RepositoryTypes()).To(BeIdenticalTo(local.DefaultRepositoryTypeScheme))
+		Expect(ctx.AccessMethods()).To(BeIdenticalTo(local.DefaultAccessTypeScheme))
+		Expect(ctx.RepositorySpecHandlers()).To(BeIdenticalTo(local.DefaultRepositorySpecHandlers))
+		Expect(ctx.BlobHandlers()).To(BeIdenticalTo(local.DefaultBlobHandlerRegistry))
+		Expect(ctx.BlobDigesters()).To(BeIdenticalTo(local.DefaultBlobDigesterRegistry))
+
+		Expect(ctx.ConfigContext()).To(BeIdenticalTo(config.DefaultContext()))
+
+		Expect(ctx.CredentialsContext()).To(BeIdenticalTo(credentials.DefaultContext()))
+
+		Expect(ctx.OCIContext()).To(BeIdenticalTo(oci.DefaultContext()))
+	})
+
+	It("creates defaulted", func() {
+		ctx := local.Builder{}.New(datacontext.MODE_DEFAULTED)
+
+		Expect(ctx.AttributesContext()).NotTo(BeIdenticalTo(datacontext.DefaultContext))
+		Expect(ctx).NotTo(BeIdenticalTo(local.DefaultContext))
+		Expect(ctx.RepositoryTypes()).To(BeIdenticalTo(local.DefaultRepositoryTypeScheme))
+		Expect(ctx.AccessMethods()).To(BeIdenticalTo(local.DefaultAccessTypeScheme))
+		Expect(ctx.RepositorySpecHandlers()).To(BeIdenticalTo(local.DefaultRepositorySpecHandlers))
+		Expect(ctx.BlobHandlers()).To(BeIdenticalTo(local.DefaultBlobHandlerRegistry))
+		Expect(ctx.BlobDigesters()).To(BeIdenticalTo(local.DefaultBlobDigesterRegistry))
+
+		Expect(ctx.ConfigContext()).NotTo(BeIdenticalTo(config.DefaultContext()))
+		Expect(ctx.ConfigContext().ConfigTypes()).To(BeIdenticalTo(config.DefaultContext().ConfigTypes()))
+
+		Expect(ctx.CredentialsContext()).NotTo(BeIdenticalTo(credentials.DefaultContext()))
+		Expect(ctx.CredentialsContext().RepositoryTypes()).To(BeIdenticalTo(credentials.DefaultContext().RepositoryTypes()))
+
+		Expect(ctx.OCIContext()).NotTo(BeIdenticalTo(oci.DefaultContext()))
+		Expect(ctx.OCIContext().RepositoryTypes()).To(BeIdenticalTo(oci.DefaultContext().RepositoryTypes()))
+	})
+
+	It("creates configured", func() {
+		ctx := local.Builder{}.New(datacontext.MODE_CONFIGURED)
+
+		Expect(ctx.AttributesContext()).NotTo(BeIdenticalTo(datacontext.DefaultContext))
+		Expect(ctx).NotTo(BeIdenticalTo(local.DefaultContext))
+		Expect(ctx.RepositoryTypes()).NotTo(BeIdenticalTo(local.DefaultRepositoryTypeScheme))
+		Expect(ctx.RepositoryTypes().KnownTypeNames()).To(Equal(local.DefaultRepositoryTypeScheme.KnownTypeNames()))
+		Expect(ctx.AccessMethods()).NotTo(BeIdenticalTo(local.DefaultAccessTypeScheme))
+		Expect(ctx.RepositorySpecHandlers()).NotTo(BeIdenticalTo(local.DefaultRepositorySpecHandlers))
+		Expect(ctx.BlobHandlers()).NotTo(BeIdenticalTo(local.DefaultBlobHandlerRegistry))
+		Expect(ctx.BlobDigesters()).NotTo(BeIdenticalTo(local.DefaultBlobDigesterRegistry))
+
+		Expect(ctx.ConfigContext()).NotTo(BeIdenticalTo(config.DefaultContext()))
+		Expect(ctx.ConfigContext().ConfigTypes()).NotTo(BeIdenticalTo(config.DefaultContext().ConfigTypes()))
+		Expect(ctx.ConfigContext().ConfigTypes().KnownTypeNames()).To(Equal(config.DefaultContext().ConfigTypes().KnownTypeNames()))
+
+		Expect(ctx.CredentialsContext()).NotTo(BeIdenticalTo(config.DefaultContext()))
+		Expect(ctx.CredentialsContext().RepositoryTypes()).NotTo(BeIdenticalTo(credentials.DefaultContext().RepositoryTypes()))
+		Expect(ctx.CredentialsContext().RepositoryTypes().KnownTypeNames()).To(Equal(credentials.DefaultContext().RepositoryTypes().KnownTypeNames()))
+
+		Expect(ctx.OCIContext()).NotTo(BeIdenticalTo(config.DefaultContext()))
+		Expect(ctx.OCIContext().RepositoryTypes()).NotTo(BeIdenticalTo(oci.DefaultContext().RepositoryTypes()))
+		Expect(ctx.OCIContext().RepositoryTypes().KnownTypeNames()).To(Equal(oci.DefaultContext().RepositoryTypes().KnownTypeNames()))
+	})
+
+	It("creates iniial", func() {
+		ctx := local.Builder{}.New(datacontext.MODE_INITIAL)
+
+		Expect(ctx.AttributesContext()).NotTo(BeIdenticalTo(datacontext.DefaultContext))
+		Expect(ctx).NotTo(BeIdenticalTo(local.DefaultContext))
+		Expect(ctx.RepositoryTypes()).NotTo(BeIdenticalTo(local.DefaultRepositoryTypeScheme))
+		Expect(len(ctx.RepositoryTypes().KnownTypeNames())).To(Equal(0))
+		Expect(len(ctx.AccessMethods().KnownTypeNames())).To(Equal(0))
+		Expect(len(ctx.RepositorySpecHandlers().KnownTypeNames())).To(Equal(0))
+		Expect(ctx.BlobHandlers().IsInitial()).To(Equal(true))
+		Expect(ctx.BlobDigesters().IsInitial()).To(Equal(true))
+
+		Expect(ctx.ConfigContext()).NotTo(BeIdenticalTo(config.DefaultContext()))
+		Expect(len(ctx.ConfigContext().ConfigTypes().KnownTypeNames())).To(Equal(0))
+
+		Expect(ctx.CredentialsContext()).NotTo(BeIdenticalTo(credentials.DefaultContext()))
+		Expect(len(ctx.CredentialsContext().RepositoryTypes().KnownTypeNames())).To(Equal(0))
+	})
+
+})

--- a/pkg/contexts/ocm/core/builder_test.go
+++ b/pkg/contexts/ocm/core/builder_test.go
@@ -20,11 +20,9 @@ import (
 
 	"github.com/open-component-model/ocm/pkg/contexts/config"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
-	"github.com/open-component-model/ocm/pkg/contexts/oci"
-
-	local "github.com/open-component-model/ocm/pkg/contexts/ocm/core"
-
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
+	"github.com/open-component-model/ocm/pkg/contexts/oci"
+	local "github.com/open-component-model/ocm/pkg/contexts/ocm/core"
 )
 
 var _ = Describe("builder test", func() {

--- a/pkg/contexts/ocm/core/context.go
+++ b/pkg/contexts/ocm/core/context.go
@@ -66,12 +66,21 @@ type Context interface {
 var key = reflect.TypeOf(_context{})
 
 // DefaultContext is the default context initialized by init functions.
-var DefaultContext = Builder{}.New()
+var DefaultContext = Builder{}.New(datacontext.MODE_SHARED)
 
 // ForContext returns the Context to use for context.Context.
 // This is either an explicit context or the default context.
 func ForContext(ctx context.Context) Context {
-	return datacontext.ForContextByKey(ctx, key, DefaultContext).(Context)
+	c, _ := datacontext.ForContextByKey(ctx, key, DefaultContext)
+	return c.(Context)
+}
+
+func DefinedForContext(ctx context.Context) (Context, bool) {
+	c, ok := datacontext.ForContextByKey(ctx, key, DefaultContext)
+	if c != nil {
+		return c.(Context), ok
+	}
+	return nil, ok
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pkg/contexts/ocm/core/digesthandler.go
+++ b/pkg/contexts/ocm/core/digesthandler.go
@@ -51,11 +51,13 @@ type BlobDigester interface {
 // BlobDigesterRegistry registers blob handlers to use in a dedicated ocm context.
 type BlobDigesterRegistry interface {
 	IsInitial() bool
-	// RegisterDigester registers a blob digester for a dedicated exact mime type
+	// MustRegisterDigester registers a blob digester for a dedicated exact mime type
 	//
-	RegisterDigester(handler BlobDigester, restypes ...string)
+	Register(handler BlobDigester, restypes ...string) error
 	// GetDigester returns the digester for a given type
 	GetDigester(typ DigesterType) BlobDigester
+
+	GetDigesterForType(t string) []BlobDigester
 	DetermineDigests(typ string, preferred signing.Hasher, registry signing.Registry, acc AccessMethod, typs ...DigesterType) ([]DigestDescriptor, error)
 
 	Copy() BlobDigesterRegistry
@@ -84,14 +86,14 @@ func (r *blobDigesterRegistry) IsInitial() bool {
 	return len(r.typehandlers) == 0 && len(r.normhandlers) == 0 && len(r.digesters) == 0
 }
 
-func (r *blobDigesterRegistry) RegisterDigester(digester BlobDigester, restypes ...string) {
+func (r *blobDigesterRegistry) Register(digester BlobDigester, restypes ...string) error {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
 	t := digester.GetType()
 	old := r.digesters[t]
 	if old != nil && old != digester {
-		panic(fmt.Errorf("duplicate digester type %q: %T and %T", t, old, digester))
+		return fmt.Errorf("duplicate digester type %q: %T and %T", t, old, digester)
 	}
 	r.digesters[t] = digester
 
@@ -116,6 +118,7 @@ outer:
 		old = append(old, digester)
 		r.typehandlers[t] = old
 	}
+	return nil
 }
 
 func (r *blobDigesterRegistry) GetDigester(typ DigesterType) BlobDigester {
@@ -124,16 +127,22 @@ func (r *blobDigesterRegistry) GetDigester(typ DigesterType) BlobDigester {
 	return r.digesters[typ]
 }
 
+func (r *blobDigesterRegistry) GetDigesterForType(typ string) []BlobDigester {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return append(r.typehandlers[typ][:0:0], r.typehandlers[typ]...)
+}
+
 func (r *blobDigesterRegistry) Copy() BlobDigesterRegistry {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 
 	n := NewBlobDigesterRegistry().(*blobDigesterRegistry)
 	for k, v := range r.typehandlers {
-		n.typehandlers[k] = append(v[:0:len(v)], v...)
+		n.typehandlers[k] = append(v[:0:0], v...)
 	}
 	for k, v := range r.normhandlers {
-		n.normhandlers[k] = append(v[:0:len(v)], v...)
+		n.normhandlers[k] = append(v[:0:0], v...)
 	}
 	for k, v := range r.digesters {
 		n.digesters[k] = v
@@ -225,8 +234,11 @@ func (r *blobDigesterRegistry) DetermineDigests(restype string, preferred signin
 	return result, nil
 }
 
-func RegisterDigester(digester BlobDigester, arttypes ...string) {
-	DefaultBlobDigesterRegistry.RegisterDigester(digester, arttypes...)
+func MustRegisterDigester(digester BlobDigester, arttypes ...string) {
+	err := DefaultBlobDigesterRegistry.Register(digester, arttypes...)
+	if err != nil {
+		panic(err)
+	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -234,7 +246,7 @@ func RegisterDigester(digester BlobDigester, arttypes ...string) {
 const GenericBlobDigestV1 = "genericBlobDigest/v1"
 
 func init() {
-	RegisterDigester(&defaultDigester{})
+	MustRegisterDigester(&defaultDigester{})
 }
 
 type defaultDigester struct{}

--- a/pkg/contexts/ocm/core/digesthandler_test.go
+++ b/pkg/contexts/ocm/core/digesthandler_test.go
@@ -18,9 +18,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/open-component-model/ocm/pkg/signing"
-
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/core"
+	"github.com/open-component-model/ocm/pkg/signing"
 )
 
 type DigestHandler struct {

--- a/pkg/contexts/ocm/core/digesthandler_test.go
+++ b/pkg/contexts/ocm/core/digesthandler_test.go
@@ -1,0 +1,73 @@
+// Copyright 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package core_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/open-component-model/ocm/pkg/signing"
+
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/core"
+)
+
+type DigestHandler struct {
+	typ core.DigesterType
+}
+
+var _ core.BlobDigester = (*DigestHandler)(nil)
+
+func (d *DigestHandler) GetType() core.DigesterType {
+	return d.typ
+}
+
+func (d *DigestHandler) DetermineDigest(resType string, meth core.AccessMethod, preferred signing.Hasher) (*core.DigestDescriptor, error) {
+	return nil, nil
+}
+
+var _ = Describe("blob digester registry test", func() {
+	var reg core.BlobDigesterRegistry
+
+	BeforeEach(func() {
+		reg = core.NewBlobDigesterRegistry()
+	})
+
+	It("copies registries", func() {
+		mine := &DigestHandler{core.DigesterType{
+			HashAlgorithm:          "hash",
+			NormalizationAlgorithm: "norm",
+		}}
+
+		reg.Register(mine, "arttype")
+
+		h := reg.GetDigesterForType("arttype")
+		Expect(h).To(Equal([]core.BlobDigester{mine}))
+
+		copy := reg.Copy()
+		new := &DigestHandler{core.DigesterType{
+			HashAlgorithm:          "other",
+			NormalizationAlgorithm: "norm",
+		}}
+		copy.Register(new, "arttype")
+
+		h = reg.GetDigesterForType("arttype")
+		Expect(h).To(Equal([]core.BlobDigester{mine}))
+
+		h = copy.GetDigesterForType("arttype")
+		Expect(h).To(Equal([]core.BlobDigester{mine, new}))
+
+	})
+
+})

--- a/pkg/contexts/ocm/core/uniform.go
+++ b/pkg/contexts/ocm/core/uniform.go
@@ -116,7 +116,7 @@ func (s *specHandlers) Copy() RepositorySpecHandlers {
 
 	n := NewRepositorySpecHandlers().(*specHandlers)
 	for typ, hdlrs := range s.handlers {
-		n.handlers[typ] = append(hdlrs[:0:len(hdlrs)], hdlrs...)
+		n.handlers[typ] = append(hdlrs[:0:0], hdlrs...)
 	}
 	return n
 }

--- a/pkg/contexts/ocm/core/uniform.go
+++ b/pkg/contexts/ocm/core/uniform.go
@@ -21,6 +21,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/oci/repositories/ocireg"
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/runtime"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 const (
@@ -77,6 +78,9 @@ type RepositorySpecHandler interface {
 
 type RepositorySpecHandlers interface {
 	Register(hdlr RepositorySpecHandler, types ...string)
+	Copy() RepositorySpecHandlers
+	KnownTypeNames() []string
+	GetHandlers(typ string) []RepositorySpecHandler
 	MapUniformRepositorySpec(ctx Context, u *UniformRepositorySpec) (RepositorySpec, error)
 }
 
@@ -104,6 +108,37 @@ func (s *specHandlers) Register(hdlr RepositorySpecHandler, types ...string) {
 			s.handlers[typ] = append(s.handlers[typ], hdlr)
 		}
 	}
+}
+
+func (s *specHandlers) Copy() RepositorySpecHandlers {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	n := NewRepositorySpecHandlers().(*specHandlers)
+	for typ, hdlrs := range s.handlers {
+		n.handlers[typ] = append(hdlrs[:0:len(hdlrs)], hdlrs...)
+	}
+	return n
+}
+
+func (s *specHandlers) KnownTypeNames() []string {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	return utils.StringMapKeys(s.handlers)
+}
+
+func (s *specHandlers) GetHandlers(typ string) []RepositorySpecHandler {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+
+	hdlrs := s.handlers[typ]
+	if len(hdlrs) == 0 {
+		return nil
+	}
+	result := make([]RepositorySpecHandler, len(hdlrs))
+	copy(result, hdlrs)
+	return result
 }
 
 func (s *specHandlers) MapUniformRepositorySpec(ctx Context, u *UniformRepositorySpec) (RepositorySpec, error) {

--- a/pkg/contexts/ocm/core/uniform_test.go
+++ b/pkg/contexts/ocm/core/uniform_test.go
@@ -1,0 +1,59 @@
+// Copyright 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package core_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/core"
+)
+
+type SpecHandler struct {
+	name string
+}
+
+var _ core.RepositorySpecHandler = (*SpecHandler)(nil)
+
+func (s SpecHandler) MapReference(ctx core.Context, u *core.UniformRepositorySpec) (core.RepositorySpec, error) {
+	return nil, nil
+}
+
+var _ = Describe("spec handlers test", func() {
+	var reg core.RepositorySpecHandlers
+
+	BeforeEach(func() {
+		reg = core.NewRepositorySpecHandlers()
+	})
+
+	It("copies registries", func() {
+		mine := &SpecHandler{"mine"}
+
+		reg.Register(mine, "arttype")
+
+		h := reg.GetHandlers("arttype")
+		Expect(h).To(Equal([]core.RepositorySpecHandler{mine}))
+
+		copy := reg.Copy()
+		new := &SpecHandler{"copy"}
+		copy.Register(new, "arttype")
+
+		h = reg.GetHandlers("arttype")
+		Expect(h).To(Equal([]core.RepositorySpecHandler{mine}))
+
+		h = copy.GetHandlers("arttype")
+		Expect(h).To(Equal([]core.RepositorySpecHandler{mine, new}))
+	})
+})

--- a/pkg/contexts/ocm/cpi/interface.go
+++ b/pkg/contexts/ocm/cpi/interface.go
@@ -103,6 +103,10 @@ func RegisterBlobHandler(handler BlobHandler, opts ...BlobHandlerOption) {
 	core.RegisterBlobHandler(handler, opts...)
 }
 
+func MustRegisterDigester(digester BlobDigester, arttypes ...string) {
+	core.MustRegisterDigester(digester, arttypes...)
+}
+
 func RegisterRepositoryType(name string, atype RepositoryType) {
 	core.DefaultRepositoryTypeScheme.Register(name, atype)
 }

--- a/pkg/contexts/ocm/digester/digesters/artefact/digester.go
+++ b/pkg/contexts/ocm/digester/digesters/artefact/digester.go
@@ -36,8 +36,8 @@ import (
 const OciArtifactDigestV1 string = "ociArtifactDigest/v1"
 
 func init() {
-	cpi.DefaultBlobDigesterRegistry().RegisterDigester(New(digest.SHA256), "")
-	cpi.DefaultBlobDigesterRegistry().RegisterDigester(New(digest.SHA512), "")
+	cpi.MustRegisterDigester(New(digest.SHA256), "")
+	cpi.MustRegisterDigester(New(digest.SHA512), "")
 }
 
 func New(algo digest.Algorithm) cpi.BlobDigester {

--- a/pkg/contexts/ocm/interface.go
+++ b/pkg/contexts/ocm/interface.go
@@ -93,6 +93,10 @@ func ForContext(ctx context.Context) Context {
 	return core.ForContext(ctx)
 }
 
+func DefinedForContext(ctx context.Context) (Context, bool) {
+	return core.DefinedForContext(ctx)
+}
+
 func NewGenericAccessSpec(spec string) (AccessSpec, error) {
 	return core.NewGenericAccessSpec(spec)
 }

--- a/pkg/contexts/ocm/repositories/genericocireg/repo_test.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/repo_test.go
@@ -111,7 +111,7 @@ var _ = Describe("component repository mapping", func() {
 		base := func(ctx *storagecontext.StorageContext) string {
 			return TESTBASE
 		}
-		ctx := ocm.WithBlobHandlers(ocm.DefaultBlobHandlers().Copy().RegisterBlobHandler(ocirepo.NewBlobHandler(base))).New()
+		ctx := ocm.WithBlobHandlers(ocm.DefaultBlobHandlers().Copy().Register(ocirepo.NewBlobHandler(base))).New()
 
 		blob := accessio.BlobAccessForString(mime.MIME_OCTET, "anydata")
 
@@ -152,7 +152,7 @@ var _ = Describe("component repository mapping", func() {
 		base := func(ctx *storagecontext.StorageContext) string {
 			return TESTBASE
 		}
-		ctx := ocm.WithBlobHandlers(ocm.DefaultBlobHandlers().Copy().RegisterBlobHandler(ocirepo.NewArtefactHandler(base), cpi.ForMimeType(mime))).New()
+		ctx := ocm.WithBlobHandlers(ocm.DefaultBlobHandlers().Copy().Register(ocirepo.NewArtefactHandler(base), cpi.ForMimeType(mime))).New()
 
 		// create artefactset
 		r, err := artefactset.FormatTGZ.Create("test.tgz", accessio.AccessOptions(accessio.PathFileSystem(tempfs)), 0700)


### PR DESCRIPTION
**What this PR does / why we need it**:

Support different setup modes for context creation.

`<context package>.New()` by default, now creates a complete fresh context graph, using the default handler registries. 
Additionally, it accepts an optional parameter with the intended setup mode. It relates to all settings not explicitly configured with appropriate `With*` methods:

- `MODE_SHARED`:  the original mode creates a new local context sharing the rest from the default context graph
- `MODE_DEFAULTED`: creates a decoupled graph, but reuses the default handler registries.
- `MODE_CONFIGURED`: creates a decoupled graph, with own registries initialized with the actual settings of the default ones.
- `MODE_INITAL`:  creates a decoupled graph with empty handler registries.

The typical use case to create any number of functional contexts on demand, should be the mode `MODE_DEFAULTED`, which is the default mode for the builders `New` methods, now.

It assure a new, independent environment, featuring all the capabilities of the library, but ready for a new local configuration. For example with credentials, or other specific settings, and with own local caches stored in the context attributes.

If dedicated handlers should be registered for a temporary environment, the mode `MODE_CONFIGURED` must be used
to avoid the pollution of other context graphs. It provided the standard handlers provided by the default registrations, but 
provided local handler registries in the context graph.

As before, dedicated, explicitly configured environments can be composed with the context builders. The setup mode
is used in addition, to decide how to fill the gaps in the configured graph, not explicitly configured by the builder settings.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
