### PR TITLE
Clarify and divide README

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+# Community Code of Conduct
+
+OCM follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).

--- a/README.md
+++ b/README.md
@@ -1,33 +1,42 @@
 # Open Component Model
 
-This project provides a go library binding for working with the
-[Open Component Model (OCM)](docs/README.md) and an [OCM command line client](docs/reference/ocm.md).
+The Open Component Model provides a standard for describing delivery [artefacts](https://github.com/gardener/ocm-spec/tree/main/doc/specification/elements#artifacts) that can be accessed from many types of [component repositories](https://github.com/gardener/ocm-spec/tree/main/doc/specification/elements#repositories).
 
-The library supports an extensible set of repository bindings for OCM repositories:
-- OCI: use a repository prefix path of an OCI repository to implement an OCM
-  repository
-- CTF (Common Transport Format): a file based binding to represent any set of
-  component versions as file system content (directory, tar, tgz)
-- Component Archive: Compose the content of a component version on the
-  filesystem
+## OCM Specifications
+OCM defines a set of semantic, formatting, and other types of specifications that can be found in the [`ocm-spec` repository](https://github.com/gardener/ocm-spec/tree/main/doc/specification). Start learning about the core concepts of OCM elements [here](https://github.com/gardener/ocm-spec/tree/main/doc/specification/elements).
 
-Additionally it provides a generic solution
-- to sign component version in any supported OCM repository implementation and
-  verify signatures based on public keys or verified certificates.
-- to transport component versions, per reference or as value among any of those 
+## OCM Library
+This project provides a Go library containing an API for interacting with the
+[Open Component Model (OCM)](https://github.com/gardener/ocm-spec) elements and mechanisms.
+
+The library currently supports the following [repository mappings](docs/ocm/interoperability.md):
+- **OCI**: Use the repository prefix path of an OCI repository to implement an OCM
+  repository.
+- **CTF (Common Transport Format)**: Use a file-based binding to represent any set of
+  component versions as filesystem content (directory, tar, tgz).
+- **Component Archive**: Compose the content of a component version on the
+  filesystem.
+
+Additionally, OCM provides a generic solution for how to:
+- Sign component versions in any supported OCM repository implementation.
+- Verify signatures based on public keys or verified certificates.
+- Transport component versions, per reference or as values to any of the
   repository implementations.
 
-This functionally is additionally put into a command line tool
-([package `cmds/ocm`](cmds/ocm)), the 
-[`ocm` tool](docs/reference/ocm.md), which provides the
-most of the functionality of the library on the command line. This makes is easy
-to embed the creation of component versions in build processes, for example in a 
-[*makefile*](examples/make/Makefile).
+## OCM CLI
+The [`ocm` CLI](docs/reference/ocm.md) may also be used to interact with OCM mechanisms. It makes it easy to create component versions and embed them in build processes.
+
+The `ocm` CLI documentation can be found [here]((https://github.com/gardener/ocm/blob/main/docs/reference/ocm.md)).
+
+The code for the CLI can be found in [package `cmds/ocm`](https://github.com/gardener/ocm/blob/main/cmds/ocm).
+
+An example of how to use the `ocm` CLI in a Makefile can be found in [`examples/make`](https://github.com/gardener/ocm/blob/main/examples/make/Makefile).
 
 The OCI and OCM support can be found in packages
 [`pkg/contexts/oci`](pkg/contexts/oci) and [`pkg/contexts/ocm`](pkg/contexts/ocm).
 
+## Contributing
 
-There are several specifications:
- - [Naming Schemes](docs/names/README.md)
- - [Element Specifications](docs/formats/README.md)
+Code contributions, feature requests, bug reports, and help requests are very welcome.
+
+OCM follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).


### PR DESCRIPTION
**What this PR does / why we need it**: 

This PR:
- Clarifies and divides the README into logical sections to help a new user understand what the project, specification, library, and CLI are about. 
- Adds a link to the CNCF Code of Conduct in a `.md` file. 
- Moves documentation links to `ocm-spec` so that we can make that the SoT (not `ocm/docs`).

**Which issue(s) this PR fixes**:
Fixes part of #98 

**Special notes for your reviewer**:

After the conversation on docs, I split the work that I was doing with editing the docs to do it in 2 PRs. The other changes are being moved to the `ocm-spec` repository rather than the `ocm` repository.

Note: This is just one iteration of adding to the README and we will iterate on it further.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
