### PR TITLE
distinguish between log and output

### DIFF
--- a/cmds/helminstaller/app/execute.go
+++ b/cmds/helminstaller/app/execute.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/mandelsoft/vfs/pkg/osfs"
-	"github.com/sirupsen/logrus"
 
 	"github.com/open-component-model/ocm/cmds/helminstaller/app/driver"
 	"github.com/open-component-model/ocm/pkg/common"
@@ -60,7 +59,7 @@ func Execute(d driver.Driver, action string, ctx ocm.Context, octx out.Context, 
 	}
 	defer rcv.Close()
 
-	logrus.Infof("Installing helm chart from resource %s@%s", cfg.Chart, common.VersionedElementKey(cv))
+	fmt.Printf("Installing helm chart from resource %s@%s", cfg.Chart, common.VersionedElementKey(cv))
 	if acc.Meta().Type != consts.HelmChart {
 		return errors.Newf("resource type %q required, but found %q", consts.HelmChart, acc.Meta().Type)
 	}

--- a/cmds/ocm/app/app.go
+++ b/cmds/ocm/app/app.go
@@ -17,6 +17,7 @@
 package app
 
 import (
+	"fmt"
 	"strings"
 
 	_ "github.com/open-component-model/ocm/pkg/contexts/clictx/config"
@@ -275,7 +276,7 @@ func NewVersionCommand() *cobra.Command {
 		Short:   "displays the version",
 		Run: func(cmd *cobra.Command, args []string) {
 			v := version.Get()
-			logrus.Infof("%#v", v)
+			fmt.Printf("%#v", v)
 		},
 	}
 }

--- a/cmds/ocm/commands/ocmcmds/components/get/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/get/cmd_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"

--- a/cmds/ocm/commands/ocmcmds/components/transfer/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/transfer/cmd_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"

--- a/cmds/ocm/commands/ocmcmds/components/verify/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/verify/cmd_test.go
@@ -22,9 +22,9 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
 	. "github.com/open-component-model/ocm/pkg/contexts/ocm/signing"
-	"github.com/sirupsen/logrus"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
+	"github.com/sirupsen/logrus"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/common/accessobj"

--- a/cmds/ocm/commands/ocmcmds/resources/get/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/resources/get/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"

--- a/cmds/ocm/commands/ocmcmds/sources/add/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/sources/add/cmd_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/open-component-model/ocm/pkg/common"

--- a/cmds/ocm/pkg/output/output.go
+++ b/cmds/ocm/pkg/output/output.go
@@ -17,10 +17,10 @@ package output
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 
 	. "github.com/open-component-model/ocm/pkg/out"
-	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/yaml"
 
@@ -280,9 +280,9 @@ var log bool
 
 func Print(list []Object, msg string, args ...interface{}) {
 	if log {
-		logrus.Infof(msg+":\n", args...)
+		fmt.Printf(msg+":\n", args...)
 		for i, e := range list {
-			logrus.Infof("  %3d %s\n", i, e)
+			fmt.Printf("  %3d %s\n", i, e)
 		}
 	}
 }

--- a/cmds/ocm/pkg/processing/processing_test.go
+++ b/cmds/ocm/pkg/processing/processing_test.go
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/data"

--- a/cmds/ocm/pkg/tree/tree_test.go
+++ b/cmds/ocm/pkg/tree/tree_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/tree"

--- a/docs/reference/ocm.md
+++ b/docs/reference/ocm.md
@@ -13,6 +13,7 @@ ocm [<options>] <sub command> ...
       --config string           configuration file
   -C, --cred stringArray        credential setting
   -h, --help                    help for ocm
+  -v, --verbose                 enable verbose logging
 ```
 
 ### Description

--- a/hack/generate-docs/main.go
+++ b/hack/generate-docs/main.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -17,7 +18,7 @@ func main() {
 	logrus.Info("> Generate Docs for OCM CLI")
 
 	if len(os.Args) != 2 { // expect 2 as the first one is the programm name
-		logrus.Infof("Expected exactly one argument, but got %d", len(os.Args)-1)
+		fmt.Fprintf(os.Stderr, "Expected exactly one argument, but got %d", len(os.Args)-1)
 		os.Exit(1)
 	}
 	outputDir := os.Args[1]
@@ -34,7 +35,7 @@ func main() {
 
 func check(err error) {
 	if err != nil {
-		logrus.Error(err.Error())
+		fmt.Fprintf(os.Stderr, err.Error())
 		os.Exit(1)
 	}
 }

--- a/pkg/contexts/ocm/blobhandler/ocm/comparch/blobhandler_test.go
+++ b/pkg/contexts/ocm/blobhandler/ocm/comparch/blobhandler_test.go
@@ -20,9 +20,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
+	"github.com/sirupsen/logrus"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"

--- a/pkg/contexts/ocm/compdesc/compdesc_test.go
+++ b/pkg/contexts/ocm/compdesc/compdesc_test.go
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"

--- a/pkg/contexts/ocm/signing/signing_test.go
+++ b/pkg/contexts/ocm/signing/signing_test.go
@@ -19,6 +19,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/pkg/contexts/ocm/signing"
 	. "github.com/open-component-model/ocm/pkg/env/builder"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"

--- a/pkg/runtime/unstructured_test.go
+++ b/pkg/runtime/unstructured_test.go
@@ -20,6 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/open-component-model/ocm/pkg/runtime"

--- a/pkg/signing/normalization_test.go
+++ b/pkg/signing/normalization_test.go
@@ -19,6 +19,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"

--- a/pkg/toi/install/credentials_test.go
+++ b/pkg/toi/install/credentials_test.go
@@ -17,6 +17,7 @@ package install_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/sirupsen/logrus"
 
 	"github.com/open-component-model/ocm/pkg/contexts/config"


### PR DESCRIPTION
**What this PR does / why we need it**:

We should distinguish between the output of a command (and appropriate methods providing output)
and logging information.

Logging info will be enabled or disabled and formatted according to some log formatter. This is something completely 
different than the output of a command.

Therefore, some occurrences of `logrus.Infof` have to be switched back to `fmt.Printf` methods.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Unfortunately the actual state of main was not formatted correctly according to the chosen formatter, therefore
`make prepare` also changed some files not directly related to this PR.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
