### PR TITLE
switch to string compare function in test

### DIFF
--- a/cmds/ocm/commands/misccmds/credentials/get/cmd_test.go
+++ b/cmds/ocm/commands/misccmds/credentials/get/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
@@ -64,11 +65,11 @@ var _ = Describe("Test Environment", func() {
 	It("get unknown type with partial matcher", func() {
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("get", "credentials", credentials.CONSUMER_ATTR_TYPE+"=test", identity.ID_HOSTNAME+"=ghcr.io")).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(`
+		ExpectTrimmedStringEqual(buf.String(), `
 ATTRIBUTE VALUE
 pass      testpass
 user      testuser
-`))
+`)
 	})
 	It("fail with partial matcher", func() {
 		buf := bytes.NewBuffer(nil)
@@ -80,10 +81,10 @@ user      testuser
 	It("get oci type with oci matcher", func() {
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("get", "credentials", credentials.CONSUMER_ATTR_TYPE+"="+identity.CONSUMER_TYPE, identity.ID_HOSTNAME+"=ghcr.io", identity.ID_PATHPREFIX+"=a/b")).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(`
+		ExpectTrimmedStringEqual(buf.String(), `
 ATTRIBUTE VALUE
 password  testpass
 username  testuser
-`))
+`)
 	})
 })

--- a/cmds/ocm/commands/misccmds/rsakeypair/cmd_test.go
+++ b/cmds/ocm/commands/misccmds/rsakeypair/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/opencontainers/go-digest"
 
@@ -43,9 +44,9 @@ var _ = Describe("Test Environment", func() {
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("create", "rsakeypair", "key.priv")).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(`
+		ExpectTrimmedStringEqual(buf.String(), `
 created rsa key pair key.priv[key.pub]
-`))
+`)
 		priv, err := env.ReadFile("key.priv")
 		Expect(err).To(Succeed())
 		pub, err := env.ReadFile("key.pub")
@@ -66,9 +67,9 @@ created rsa key pair key.priv[key.pub]
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("create", "rsakeypair", "key.priv", "CN=mandelsoft")).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(`
+		ExpectTrimmedStringEqual(buf.String(), `
 created rsa key pair key.priv[key.cert]
-`))
+`)
 		priv, err := env.ReadFile("key.priv")
 		Expect(err).To(Succeed())
 		pub, err := env.ReadFile("key.cert")

--- a/cmds/ocm/commands/ocicmds/artefacts/download/cmd_test.go
+++ b/cmds/ocm/commands/ocicmds/artefacts/download/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/grammar"
@@ -59,10 +60,10 @@ var _ = Describe("Test Environment", func() {
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("download", "artefact", "-O", OUT, "-r", ARCH, NS+grammar.TagSeparator+VERSION)).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(
+		ExpectTrimmedStringEqual(buf.String(),
 			`
 /tmp/res: downloaded
-`))
+`)
 		Expect(env.DirExists(OUT)).To(BeTrue())
 		Expect(env.ReadFile(OUT + "/" + artefactset.ArtefactSetDescriptorFileName)).To(Equal([]byte("{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.index.v1+json\",\"manifests\":[{\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\",\"digest\":\"sha256:2c3e2c59e0ac9c99864bf0a9f9727c09f21a66080f9f9b03b36a2dad3cce6ff9\",\"size\":342,\"annotations\":{\"cloud.gardener.ocm/tags\":\"v1\"}}],\"annotations\":{\"cloud.gardener.ocm/main\":\"sha256:2c3e2c59e0ac9c99864bf0a9f9727c09f21a66080f9f9b03b36a2dad3cce6ff9\"}}")))
 	})

--- a/cmds/ocm/commands/ocicmds/artefacts/get/cmd_test.go
+++ b/cmds/ocm/commands/ocicmds/artefacts/get/cmd_test.go
@@ -20,8 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
-
-	"github.com/sirupsen/logrus"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocicmds/common/handlers/artefacthdlr"
 	"github.com/open-component-model/ocm/pkg/common/accessio"
@@ -100,69 +99,69 @@ var _ = Describe("Test Environment", func() {
 
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "artefact", ARCH+"//"+NS1+":"+VERSION1)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 REGISTRY REPOSITORY      KIND     TAG DIGEST
 /tmp/ctf mandelsoft/test manifest v1  sha256:2c3e2c59e0ac9c99864bf0a9f9727c09f21a66080f9f9b03b36a2dad3cce6ff9
-`))
+`)
 		})
 		It("get all artefacts in namespace", func() {
 
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "artefact", ARCH+"//"+NS1)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 REGISTRY REPOSITORY      KIND     TAG DIGEST
 /tmp/ctf mandelsoft/test manifest v1  sha256:2c3e2c59e0ac9c99864bf0a9f9727c09f21a66080f9f9b03b36a2dad3cce6ff9
 /tmp/ctf mandelsoft/test manifest v2  sha256:60b245b3de64c43b18489e9c3cf177402f9bd18ab62f8cc6653e2fc2e3a5fc39
-`))
+`)
 		})
 
 		It("get all artefacts in other namespace", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "artefact", ARCH+"//"+NS2)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 REGISTRY REPOSITORY       KIND     TAG DIGEST
 /tmp/ctf mandelsoft/index index    v1  sha256:d6c3ddc587296fd09f56d2f4c8482f05575306a64705b06fae1d5695cb88d627
 /tmp/ctf mandelsoft/index manifest v2  sha256:e51c2165e00ec22eba0b6d18fe7b136491edce1fa4d286549fb35bd5538c03df
-`))
+`)
 		})
 
 		It("get closure of all artefacts in other namespace", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "artefact", "-c", ARCH+"//"+NS2)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 REFERENCEPATH                                                           REGISTRY REPOSITORY       KIND     TAG DIGEST
                                                                         /tmp/ctf mandelsoft/index index    v1  sha256:d6c3ddc587296fd09f56d2f4c8482f05575306a64705b06fae1d5695cb88d627
 sha256:d6c3ddc587296fd09f56d2f4c8482f05575306a64705b06fae1d5695cb88d627 /tmp/ctf mandelsoft/index manifest -   sha256:2c3e2c59e0ac9c99864bf0a9f9727c09f21a66080f9f9b03b36a2dad3cce6ff9
 sha256:d6c3ddc587296fd09f56d2f4c8482f05575306a64705b06fae1d5695cb88d627 /tmp/ctf mandelsoft/index manifest -   sha256:60b245b3de64c43b18489e9c3cf177402f9bd18ab62f8cc6653e2fc2e3a5fc39
                                                                         /tmp/ctf mandelsoft/index manifest v2  sha256:e51c2165e00ec22eba0b6d18fe7b136491edce1fa4d286549fb35bd5538c03df
-`))
+`)
 		})
 		It("get tree of all tagged artefacts in other namespace", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "artefact", "-o", "tree", ARCH+"//"+NS2)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 NESTING REGISTRY REPOSITORY       KIND     TAG DIGEST
 ├─      /tmp/ctf mandelsoft/index index    v1  sha256:d6c3ddc587296fd09f56d2f4c8482f05575306a64705b06fae1d5695cb88d627
 └─      /tmp/ctf mandelsoft/index manifest v2  sha256:e51c2165e00ec22eba0b6d18fe7b136491edce1fa4d286549fb35bd5538c03df
-`))
+`)
 		})
 
 		It("get tree of all artefacts in other namespace", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "artefact", "-c", "-o", "tree", ARCH+"//"+NS2)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 NESTING     REGISTRY REPOSITORY       KIND     TAG DIGEST
 ├─ ⊗        /tmp/ctf mandelsoft/index index    v1  sha256:d6c3ddc587296fd09f56d2f4c8482f05575306a64705b06fae1d5695cb88d627
 │  ├─       /tmp/ctf mandelsoft/index manifest -   sha256:2c3e2c59e0ac9c99864bf0a9f9727c09f21a66080f9f9b03b36a2dad3cce6ff9
 │  └─       /tmp/ctf mandelsoft/index manifest -   sha256:60b245b3de64c43b18489e9c3cf177402f9bd18ab62f8cc6653e2fc2e3a5fc39
 └─          /tmp/ctf mandelsoft/index manifest v2  sha256:e51c2165e00ec22eba0b6d18fe7b136491edce1fa4d286549fb35bd5538c03df
-`))
+`)
 		})
 	})
 
@@ -246,32 +245,28 @@ NESTING     REGISTRY REPOSITORY       KIND     TAG DIGEST
 		It("get single artefact and attachment", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "artefact", "-a", ARCH+"//"+NS2+":"+VERSION1)).To(Succeed())
-			logrus.Infof("%s\n", buf.String())
-			Expect("\n" + buf.String()).To(Equal(
-				`
+			ExpectTrimmedStringEqual(buf.String(), `
 REGISTRY REPOSITORY       KIND     TAG                                                                          DIGEST
 /tmp/ctf mandelsoft/index index    v1                                                                           sha256:d6c3ddc587296fd09f56d2f4c8482f05575306a64705b06fae1d5695cb88d627
 /tmp/ctf mandelsoft/index manifest sha256-d6c3ddc587296fd09f56d2f4c8482f05575306a64705b06fae1d5695cb88d627.test sha256:439d433cd85eac706b86e39d3d9dbbd5f1ff19acd1bcb7aa3549f5d7b11777d9
-`))
+`)
 		})
 
 		It("get single artefact attachment tree", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "artefact", "-a", "-o", "tree", ARCH+"//"+NS2+":"+VERSION1)).To(Succeed())
-			logrus.Infof("%s\n", buf.String())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 NESTING        REGISTRY REPOSITORY       KIND     TAG                                                                          DIGEST
 └─ ⊗           /tmp/ctf mandelsoft/index index    v1                                                                           sha256:d6c3ddc587296fd09f56d2f4c8482f05575306a64705b06fae1d5695cb88d627
    └─ test     /tmp/ctf mandelsoft/index manifest sha256-d6c3ddc587296fd09f56d2f4c8482f05575306a64705b06fae1d5695cb88d627.test sha256:439d433cd85eac706b86e39d3d9dbbd5f1ff19acd1bcb7aa3549f5d7b11777d9
-`))
+`)
 		})
 
 		It("get single artefact attachment tree with closure", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "artefact", "-a", "-c", "-o", "tree", ARCH+"//"+NS2+":"+VERSION1)).To(Succeed())
-			logrus.Debug(buf.String())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 NESTING             REGISTRY REPOSITORY       KIND     TAG                                                                          DIGEST
 └─ ⊗                /tmp/ctf mandelsoft/index index    v1                                                                           sha256:d6c3ddc587296fd09f56d2f4c8482f05575306a64705b06fae1d5695cb88d627
@@ -279,7 +274,7 @@ NESTING             REGISTRY REPOSITORY       KIND     TAG                      
    ├─ ⊗             /tmp/ctf mandelsoft/index manifest -                                                                            sha256:2c3e2c59e0ac9c99864bf0a9f9727c09f21a66080f9f9b03b36a2dad3cce6ff9
    │  └─ test       /tmp/ctf mandelsoft/index manifest sha256-2c3e2c59e0ac9c99864bf0a9f9727c09f21a66080f9f9b03b36a2dad3cce6ff9.test sha256:efbfe2c665fc93690911d74e8e7dcf7fb01524545c7b87cb14d5febf1613eaba
    └─               /tmp/ctf mandelsoft/index manifest -                                                                            sha256:60b245b3de64c43b18489e9c3cf177402f9bd18ab62f8cc6653e2fc2e3a5fc39
-`))
+`)
 		})
 
 	})

--- a/cmds/ocm/commands/ocicmds/artefacts/transfer/cmd_test.go
+++ b/cmds/ocm/commands/ocicmds/artefacts/transfer/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/repositories/ctf"
@@ -59,11 +60,11 @@ var _ = Describe("Test Environment", func() {
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("transfer", "artefact", ARCH+"//"+NS+":"+VERSION, "directory::"+OUT)).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(
+		ExpectTrimmedStringEqual(buf.String(),
 			`
-copying /tmp/ctf//mandelsoft/test:v1 to directory::` + OUT + `//mandelsoft/test:v1...
+copying /tmp/ctf//mandelsoft/test:v1 to directory::`+OUT+`//mandelsoft/test:v1...
 copied 1 from 1 artefact(s) and 1 repositories
-`))
+`)
 		Expect(env.ReadFile(OUT + "/" + ctf.ArtefactIndexFileName)).To(Equal([]byte("{\"schemaVersion\":1,\"artefacts\":[{\"repository\":\"mandelsoft/test\",\"tag\":\"v1\",\"digest\":\"sha256:2c3e2c59e0ac9c99864bf0a9f9727c09f21a66080f9f9b03b36a2dad3cce6ff9\"}]}")))
 	})
 
@@ -83,11 +84,11 @@ copied 1 from 1 artefact(s) and 1 repositories
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("transfer", "artefact", ARCH+"//"+NS+":"+VERSION, "directory::"+OUT+"//changed")).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(
+		ExpectTrimmedStringEqual(buf.String(),
 			`
-copying /tmp/ctf//mandelsoft/test:v1 to directory::` + OUT + `//changed:v1...
+copying /tmp/ctf//mandelsoft/test:v1 to directory::`+OUT+`//changed:v1...
 copied 1 from 1 artefact(s) and 1 repositories
-`))
+`)
 		Expect(env.ReadFile(OUT + "/" + ctf.ArtefactIndexFileName)).To(Equal([]byte("{\"schemaVersion\":1,\"artefacts\":[{\"repository\":\"changed\",\"tag\":\"v1\",\"digest\":\"sha256:2c3e2c59e0ac9c99864bf0a9f9727c09f21a66080f9f9b03b36a2dad3cce6ff9\"}]}")))
 	})
 
@@ -107,11 +108,11 @@ copied 1 from 1 artefact(s) and 1 repositories
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("transfer", "artefact", "-R", ARCH+"//"+NS+":"+VERSION, "directory::"+OUT+"//sub")).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(
+		ExpectTrimmedStringEqual(buf.String(),
 			`
-copying /tmp/ctf//mandelsoft/test:v1 to directory::` + OUT + `//sub/mandelsoft/test:v1...
+copying /tmp/ctf//mandelsoft/test:v1 to directory::`+OUT+`//sub/mandelsoft/test:v1...
 copied 1 from 1 artefact(s) and 1 repositories
-`))
+`)
 		Expect(env.ReadFile(OUT + "/" + ctf.ArtefactIndexFileName)).To(Equal([]byte("{\"schemaVersion\":1,\"artefacts\":[{\"repository\":\"sub/mandelsoft/test\",\"tag\":\"v1\",\"digest\":\"sha256:2c3e2c59e0ac9c99864bf0a9f9727c09f21a66080f9f9b03b36a2dad3cce6ff9\"}]}")))
 	})
 
@@ -129,11 +130,11 @@ copied 1 from 1 artefact(s) and 1 repositories
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("transfer", "artefact", ARCH, "directory::"+OUT+"//"+NS)).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(
+		ExpectTrimmedStringEqual(buf.String(),
 			`
-copying ArtefactSet::/tmp/ctf//:v1 to directory::` + OUT + `//mandelsoft/test:v1...
+copying ArtefactSet::/tmp/ctf//:v1 to directory::`+OUT+`//mandelsoft/test:v1...
 copied 1 from 1 artefact(s) and 1 repositories
-`))
+`)
 		Expect(env.ReadFile(OUT + "/" + ctf.ArtefactIndexFileName)).To(Equal([]byte("{\"schemaVersion\":1,\"artefacts\":[{\"repository\":\"mandelsoft/test\",\"tag\":\"v1\",\"digest\":\"sha256:2c3e2c59e0ac9c99864bf0a9f9727c09f21a66080f9f9b03b36a2dad3cce6ff9\"}]}")))
 	})
 })

--- a/cmds/ocm/commands/ocicmds/tags/show/cmd_test.go
+++ b/cmds/ocm/commands/ocicmds/tags/show/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/mime"
@@ -87,7 +88,7 @@ var _ = Describe("Show OCI Tags", func() {
 	It("lists tags", func() {
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("oci", "tags", "show", "--repo", ARCH, NAMESAPCE)).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(`
+		ExpectTrimmedStringEqual(buf.String(), `
 sometag
 v1.3
 v1.3.1
@@ -95,38 +96,38 @@ v1.3.2
 v1.3.2-beta.1
 v1.4
 v2.0
-`))
+`)
 	})
 
 	It("lists tags for same artefact", func() {
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("oci", "tags", "show", "--repo", ARCH, NAMESAPCE+":"+V13)).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(`
+		ExpectTrimmedStringEqual(buf.String(), `
 sometag
 v1.3
 v1.3.1
-`))
+`)
 	})
 
 	It("lists semver tags", func() {
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("oci", "tags", "show", "--semver", "--repo", ARCH, NAMESAPCE)).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(`
+		ExpectTrimmedStringEqual(buf.String(), `
 v1.3
 v1.3.1
 v1.3.2-beta.1
 v1.3.2
 v1.4
 v2.0
-`))
+`)
 	})
 
 	It("lists semver tags for same artefact", func() {
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("oci", "tags", "show", "--semver", "--repo", ARCH, NAMESAPCE+":"+V13)).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(`
+		ExpectTrimmedStringEqual(buf.String(), `
 v1.3
 v1.3.1
-`))
+`)
 	})
 })

--- a/cmds/ocm/commands/ocmcmds/components/download/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/download/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
 
@@ -61,10 +62,10 @@ var _ = Describe("Download Component Version", func() {
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("download", "component", "-O", OUT, "-r", ARCH, COMPONENT+grammar.VersionSeparator+VERSION)).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(
+		ExpectTrimmedStringEqual(buf.String(),
 			`
 /tmp/res: downloaded
-`))
+`)
 		Expect(env.DirExists(OUT)).To(BeTrue())
 		Expect(env.ReadFile(vfs.Join(env, OUT, comparch.BlobsDirectoryName, "sha256.810ff2fb242a5dee4220f2cb0e6a519891fb67f2f828a6cab4ef8894633b1f50"))).To(Equal([]byte("testdata")))
 

--- a/cmds/ocm/commands/ocmcmds/components/get/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/get/cmd_test.go
@@ -21,8 +21,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
-
-	"github.com/sirupsen/logrus"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	compdescv3 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/ocm.gardener.cloud/v3alpha1"
@@ -54,11 +53,11 @@ var _ = Describe("Test Environment", func() {
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("get", "components", ARCH, "-o", "wide")).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(
+		ExpectTrimmedStringEqual(buf.String(),
 			`
 COMPONENT VERSION PROVIDER   REPOSITORY
 test.de/x v1      mandelsoft /tmp/ca
-`))
+`)
 	})
 
 	It("get component archive with refs", func() {
@@ -69,13 +68,12 @@ test.de/x v1      mandelsoft /tmp/ca
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("get", "components", ARCH, "-c")).To(Succeed())
-		logrus.Infof("%s", buf)
-		Expect("\n" + buf.String()).To(Equal(
+		ExpectTrimmedStringEqual(buf.String(),
 			`
 REFERENCEPATH COMPONENT VERSION PROVIDER                    IDENTITY
               test.de/x v1      mandelsoft                  
 test.de/x:v1  test.de/y v1      <unknown component version> "name"="ref"
-`))
+`)
 	})
 
 	It("get component archive with refs as tree", func() {
@@ -86,13 +84,12 @@ test.de/x:v1  test.de/y v1      <unknown component version> "name"="ref"
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("get", "components", ARCH, "-c", "-o", "tree")).To(Succeed())
-		logrus.Infof("%s", buf)
-		Expect("\n" + buf.String()).To(Equal(
+		ExpectTrimmedStringEqual(buf.String(),
 			`
 NESTING    COMPONENT VERSION PROVIDER                    IDENTITY
 └─ ⊗       test.de/x v1      mandelsoft                  
    └─      test.de/y v1      <unknown component version> "name"="ref"
-`))
+`)
 	})
 
 	It("lists ctf file", func() {
@@ -106,11 +103,11 @@ NESTING    COMPONENT VERSION PROVIDER                    IDENTITY
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("get", "components", ARCH, "-o", "wide")).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(
+		ExpectTrimmedStringEqual(buf.String(),
 			`
 COMPONENT VERSION PROVIDER   REPOSITORY
 test.de/x v1      mandelsoft /tmp/ca
-`))
+`)
 	})
 
 	Context("ctf", func() {
@@ -135,40 +132,40 @@ test.de/x v1      mandelsoft /tmp/ca
 
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "components", "--lookup", ARCH2, "-c", "--repo", ARCH, COMP2)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 REFERENCEPATH COMPONENT VERSION PROVIDER   IDENTITY
               test.de/y v1      mandelsoft 
 test.de/y:v1  test.de/x v1      mandelsoft "name"="xx"
-`))
+`)
 		})
 		It("lists flat ctf file", func() {
 
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "components", "-o", "tree", "--repo", ARCH, COMP2)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 NESTING COMPONENT VERSION PROVIDER
 └─      test.de/y v1      mandelsoft
-`))
+`)
 		})
 		It("lists flat ctf file with closure", func() {
 
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "components", "-o", "tree", "--lookup", ARCH2, "-c", "--repo", ARCH, COMP2)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 NESTING    COMPONENT VERSION PROVIDER   IDENTITY
 └─ ⊗       test.de/y v1      mandelsoft 
    └─      test.de/x v1      mandelsoft "name"="xx"
-`))
+`)
 		})
 
 		It("lists converted yaml", func() {
 
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "components", "-S", compdescv3.SchemaVersion, "-o", "yaml", "--repo", ARCH, COMP2)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				fmt.Sprintf(`
 ---
 apiVersion: ocm.gardener.cloud/%s
@@ -184,7 +181,7 @@ spec:
   - componentName: test.de/x
     name: xx
     version: v1
-`, compdescv3.SchemaVersion)))
+`, compdescv3.SchemaVersion))
 		})
 	})
 })

--- a/cmds/ocm/commands/ocmcmds/components/sign/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/sign/cmd_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
 
@@ -85,7 +86,7 @@ var _ = Describe("access method", func() {
 			digest := "05c4edd25661703e0c5caec8b0680c93738d8a8126d825adb755431fec29b7cb"
 			Expect(env.CatchOutput(buf).Execute("sign", "components", "-s", SIGNATURE, "-K", PRIVKEY, "--repo", ARCH, COMPONENTB+":"+VERSION)).To(Succeed())
 
-			Expect("\n" + buf.String()).To(Equal(`
+			ExpectTrimmedStringEqual(buf.String(), `
 applying to version "github.com/mandelsoft/ref:v1"...
   applying to version "github.com/mandelsoft/test:v1"...
     resource 0:  "name"="testdata": digest sha256:810ff2fb242a5dee4220f2cb0e6a519891fb67f2f828a6cab4ef8894633b1f50[genericBlobDigest/v1]
@@ -93,8 +94,8 @@ applying to version "github.com/mandelsoft/ref:v1"...
     resource 2:  "name"="ref": digest sha256:c2d2dca275c33c1270dea6168a002d67c0e98780d7a54960758139ae19984bd7[ociArtifactDigest/v1]
   reference 0:  github.com/mandelsoft/test:v1: digest sha256:39ea26ac4391052a638319f64b8da2628acb51d304c3a1ac8f920a46f2d6dce7[jsonNormalisation/v1]
   resource 0:  "name"="otherdata": digest sha256:54b8007913ec5a907ca69001d59518acfd106f7b02f892eabf9cae3f8b2414b4[genericBlobDigest/v1]
-successfully signed github.com/mandelsoft/ref:v1 (digest sha256:` + digest + `)
-`))
+successfully signed github.com/mandelsoft/ref:v1 (digest sha256:`+digest+`)
+`)
 
 			session := datacontext.NewSession()
 			defer session.Close()
@@ -115,7 +116,7 @@ successfully signed github.com/mandelsoft/ref:v1 (digest sha256:` + digest + `)
 			digest := "05c4edd25661703e0c5caec8b0680c93738d8a8126d825adb755431fec29b7cb"
 			Expect(env.CatchOutput(buf).Execute("sign", "components", "--lookup", ARCH2, "-s", SIGNATURE, "-K", PRIVKEY, "--repo", ARCH, COMPONENTB+":"+VERSION)).To(Succeed())
 
-			Expect("\n" + buf.String()).To(Equal(`
+			ExpectTrimmedStringEqual(buf.String(), `
 applying to version "github.com/mandelsoft/ref:v1"...
   applying to version "github.com/mandelsoft/test:v1"...
     resource 0:  "name"="testdata": digest sha256:810ff2fb242a5dee4220f2cb0e6a519891fb67f2f828a6cab4ef8894633b1f50[genericBlobDigest/v1]
@@ -123,8 +124,8 @@ applying to version "github.com/mandelsoft/ref:v1"...
     resource 2:  "name"="ref": digest sha256:c2d2dca275c33c1270dea6168a002d67c0e98780d7a54960758139ae19984bd7[ociArtifactDigest/v1]
   reference 0:  github.com/mandelsoft/test:v1: digest sha256:39ea26ac4391052a638319f64b8da2628acb51d304c3a1ac8f920a46f2d6dce7[jsonNormalisation/v1]
   resource 0:  "name"="otherdata": digest sha256:54b8007913ec5a907ca69001d59518acfd106f7b02f892eabf9cae3f8b2414b4[genericBlobDigest/v1]
-successfully signed github.com/mandelsoft/ref:v1 (digest sha256:` + digest + `)
-`))
+successfully signed github.com/mandelsoft/ref:v1 (digest sha256:`+digest+`)
+`)
 
 			session := datacontext.NewSession()
 			defer session.Close()
@@ -158,17 +159,17 @@ successfully signed github.com/mandelsoft/ref:v1 (digest sha256:` + digest + `)
 		It("sign version", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchErrorOutput(buf).Execute("sign", "components", "-s", SIGNATURE, "-K", PRIVKEY, "--repo", ARCH, COMPONENTB+":"+VERSION)).To(HaveOccurred())
-			Expect("\n" + buf.String()).To(Equal(`
+			ExpectTrimmedStringEqual(buf.String(), `
 Error: {signing: failed resolving component reference ref[github.com/mandelsoft/test:v1] in github.com/mandelsoft/ref:v1: ocm reference "github.com/mandelsoft/test:v1" not found}
-`))
+`)
 		})
 
 		It("sign archive", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchErrorOutput(buf).Execute("sign", "components", "-s", SIGNATURE, "-K", PRIVKEY, ARCH)).To(HaveOccurred())
-			Expect("\n" + buf.String()).To(Equal(`
+			ExpectTrimmedStringEqual(buf.String(), `
 Error: {signing: failed resolving component reference ref[github.com/mandelsoft/test:v1] in github.com/mandelsoft/ref:v1: ocm reference "github.com/mandelsoft/test:v1" not found}
-`))
+`)
 		})
 	})
 
@@ -186,17 +187,17 @@ Error: {signing: failed resolving component reference ref[github.com/mandelsoft/
 		It("sign version", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchErrorOutput(buf).Execute("sign", "components", "-s", SIGNATURE, "-K", PRIVKEY, "--repo", ARCH, COMPONENTB+":"+VERSION)).To(HaveOccurred())
-			Expect("\n" + buf.String()).To(Equal(`
+			ExpectTrimmedStringEqual(buf.String(), `
 Error: {signing: failed resolving component reference ref[github.com/mandelsoft/test:v1] in github.com/mandelsoft/ref:v1: ocm reference "github.com/mandelsoft/test:v1" not found}
-`))
+`)
 		})
 
 		It("sign archive", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchErrorOutput(buf).Execute("sign", "components", "-s", SIGNATURE, "-K", PRIVKEY, ARCH)).To(HaveOccurred())
-			Expect("\n" + buf.String()).To(Equal(`
+			ExpectTrimmedStringEqual(buf.String(), `
 Error: {signing: failed resolving component reference ref[github.com/mandelsoft/test:v1] in github.com/mandelsoft/ref:v1: ocm reference "github.com/mandelsoft/test:v1" not found}
-`))
+`)
 		})
 	})
 })

--- a/cmds/ocm/commands/ocmcmds/components/transfer/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/transfer/cmd_test.go
@@ -21,8 +21,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
-
-	"github.com/sirupsen/logrus"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/common/accessobj"
@@ -162,15 +161,14 @@ var _ = Describe("Test Environment", func() {
 	It("transfers ctf", func() {
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("transfer", "components", "--resourcesByValue", ARCH, ARCH, OUT)).To(Succeed())
-		logrus.Infof("%s\n", buf)
-		Expect("\n" + buf.String()).To(Equal(`
+		ExpectTrimmedStringEqual(buf.String(), `
 transferring version "github.com/mandelsoft/test:v1"...
 ...resource 0...
 ...resource 1(ocm/value:v2.0)...
 ...resource 2(ocm/ref:v2.0)...
 ...adding component version...
 1 versions transferred
-`))
+`)
 
 		Expect(env.DirExists(OUT)).To(BeTrue())
 		Check(env, ldesc, OUT)
@@ -180,8 +178,7 @@ transferring version "github.com/mandelsoft/test:v1"...
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("transfer", "components", "--resourcesByValue", "--closure", "--lookup", ARCH, ARCH2, ARCH2, OUT)).To(Succeed())
 		str := buf.String()
-		logrus.Infof("%s\n", str)
-		Expect("\n" + str).To(Equal(`
+		ExpectTrimmedStringEqual(str, `
 transferring version "github.com/mandelsoft/test2:v1"...
   transferring version "github.com/mandelsoft/test:v1"...
   ...resource 0...
@@ -190,7 +187,7 @@ transferring version "github.com/mandelsoft/test2:v1"...
   ...adding component version...
 ...adding component version...
 2 versions transferred
-`))
+`)
 
 		Expect(env.DirExists(OUT)).To(BeTrue())
 		tgt, err := ctfocm.Open(env.OCMContext(), accessobj.ACC_READONLY, OUT, 0, accessio.PathFileSystem(env.FileSystem()))
@@ -210,14 +207,14 @@ transferring version "github.com/mandelsoft/test2:v1"...
 	It("transfers ctf to tgz", func() {
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("transfer", "components", "--resourcesByValue", ARCH, ARCH, accessio.FormatTGZ.String()+"::"+OUT)).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(`
+		ExpectTrimmedStringEqual(buf.String(), `
 transferring version "github.com/mandelsoft/test:v1"...
 ...resource 0...
 ...resource 1(ocm/value:v2.0)...
 ...resource 2(ocm/ref:v2.0)...
 ...adding component version...
 1 versions transferred
-`))
+`)
 
 		Expect(env.FileExists(OUT)).To(BeTrue())
 		Check(env, ldesc, OUT)
@@ -226,14 +223,14 @@ transferring version "github.com/mandelsoft/test:v1"...
 	It("transfers ctf to ctf+tgz", func() {
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("transfer", "components", "--resourcesByValue", ARCH, ARCH, "ctf+"+accessio.FormatTGZ.String()+"::"+OUT)).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(`
+		ExpectTrimmedStringEqual(buf.String(), `
 transferring version "github.com/mandelsoft/test:v1"...
 ...resource 0...
 ...resource 1(ocm/value:v2.0)...
 ...resource 2(ocm/ref:v2.0)...
 ...adding component version...
 1 versions transferred
-`))
+`)
 
 		Expect(env.FileExists(OUT)).To(BeTrue())
 		Check(env, ldesc, OUT)

--- a/cmds/ocm/commands/ocmcmds/components/verify/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/verify/cmd_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
 	. "github.com/open-component-model/ocm/pkg/contexts/ocm/signing"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
 	"github.com/sirupsen/logrus"
@@ -170,7 +171,7 @@ var _ = Describe("access method", func() {
 
 		Expect(env.CatchOutput(buf).Execute("verify", "components", "-V", "-s", SIGNATURE, "-k", PUBKEY, "--repo", ARCH, COMPONENTB+":"+VERSION)).To(Succeed())
 
-		Expect("\n" + buf.String()).To(Equal(`
+		ExpectTrimmedStringEqual(buf.String(), `
 applying to version "github.com/mandelsoft/ref:v1"...
   applying to version "github.com/mandelsoft/test:v1"...
     resource 0:  "name"="testdata": digest sha256:810ff2fb242a5dee4220f2cb0e6a519891fb67f2f828a6cab4ef8894633b1f50[genericBlobDigest/v1]
@@ -178,7 +179,7 @@ applying to version "github.com/mandelsoft/ref:v1"...
     resource 2:  "name"="ref": digest sha256:c2d2dca275c33c1270dea6168a002d67c0e98780d7a54960758139ae19984bd7[ociArtifactDigest/v1]
   reference 0:  github.com/mandelsoft/test:v1: digest sha256:39ea26ac4391052a638319f64b8da2628acb51d304c3a1ac8f920a46f2d6dce7[jsonNormalisation/v1]
   resource 0:  "name"="otherdata": digest sha256:54b8007913ec5a907ca69001d59518acfd106f7b02f892eabf9cae3f8b2414b4[genericBlobDigest/v1]
-successfully verified github.com/mandelsoft/ref:v1 (digest sha256:` + digest + `)
-`))
+successfully verified github.com/mandelsoft/ref:v1 (digest sha256:`+digest+`)
+`)
 	})
 })

--- a/cmds/ocm/commands/ocmcmds/ctf/transfer/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/ctf/transfer/cmd_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/common/accessobj"
@@ -107,12 +108,12 @@ var _ = Describe("Test Environment", func() {
 	It("transfers ctf", func() {
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("transfer", "ctf", ARCH, OUT)).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(`
+		ExpectTrimmedStringEqual(buf.String(), `
 transferring component "github.com/mandelsoft/test"...
   transferring version "github.com/mandelsoft/test:v1"...
   ...resource 0...
   ...adding component version...
-`))
+`)
 
 		Expect(env.DirExists(OUT)).To(BeTrue())
 

--- a/cmds/ocm/commands/ocmcmds/references/get/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/references/get/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 )
@@ -54,12 +55,12 @@ var _ = Describe("Test Environment", func() {
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("get", "references", "-o", "wide", CA)).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(
+		ExpectTrimmedStringEqual(buf.String(),
 			`
 NAME   COMPONENT VERSION IDENTITY
 test   test.de/y v1      "name"="test"
 withid test.de/z v1      "id"="test","name"="withid"
-`))
+`)
 	})
 
 	Context("with closure", func() {
@@ -83,34 +84,34 @@ withid test.de/z v1      "id"="test","name"="withid"
 		It("lists single reference in component archive", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "references", "--lookup", CTF, "-c", "-o", "wide", CA)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 REFERENCEPATH              NAME   COMPONENT VERSION IDENTITY
 test.de/x:v1               test   test.de/y v1      "name"="test"
 test.de/x:v1->test.de/y:v1 withid test.de/z v1      "id"="test","name"="withid"
-`))
+`)
 		})
 		It("lists flat tree in ctf file", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "references", "-o", "tree", "--lookup", CTF, CA)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 COMPONENTVERSION    NAME COMPONENT VERSION IDENTITY
 └─ test.de/x:v1                            
    └─               test test.de/y v1      "name"="test"
-`))
+`)
 		})
 
 		It("lits reference closure in ctf file", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "references", "-c", "-o", "tree", "--lookup", CTF, CA)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 COMPONENTVERSION    NAME   COMPONENT VERSION IDENTITY
 └─ test.de/x:v1                              
    └─ ⊗             test   test.de/y v1      "name"="test"
       └─            withid test.de/z v1      "id"="test","name"="withid"
-`))
+`)
 		})
 	})
 })

--- a/cmds/ocm/commands/ocmcmds/resources/download/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/resources/download/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
 
@@ -60,10 +61,10 @@ var _ = Describe("Test Environment", func() {
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("download", "resources", "-O", OUT, ARCH)).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(
+		ExpectTrimmedStringEqual(buf.String(),
 			`
 /tmp/res: 8 byte(s) written
-`))
+`)
 		Expect(env.FileExists(OUT)).To(BeTrue())
 		Expect(env.ReadFile(OUT)).To(Equal([]byte("testdata")))
 	})
@@ -98,11 +99,11 @@ var _ = Describe("Test Environment", func() {
 		It("downloads multiple files", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("download", "resources", "-O", OUT, "--repo", ARCH, COMP2+":"+VERSION)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 /tmp/res/test.de/y/v1/moredata: 8 byte(s) written
 /tmp/res/test.de/y/v1/otherdata-id=test: 9 byte(s) written
-`))
+`)
 
 			Expect(env.FileExists(vfs.Join(env.FileSystem(), OUT, COMP2+"/"+VERSION+"/moredata"))).To(BeTrue())
 			Expect(env.ReadFile(vfs.Join(env.FileSystem(), OUT, COMP2+"/"+VERSION+"/moredata"))).To(Equal([]byte("moredata")))
@@ -113,12 +114,12 @@ var _ = Describe("Test Environment", func() {
 		It("downloads closure", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("download", "resources", "-c", "-O", OUT, "--repo", ARCH, COMP2+":"+VERSION)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 /tmp/res/test.de/y/v1/moredata: 8 byte(s) written
 /tmp/res/test.de/y/v1/otherdata-id=test: 9 byte(s) written
 /tmp/res/test.de/y/v1/test.de/x/v1/testdata: 8 byte(s) written
-`))
+`)
 
 			Expect(env.FileExists(vfs.Join(env.FileSystem(), OUT, COMP2+"/"+VERSION+"/moredata"))).To(BeTrue())
 			Expect(env.ReadFile(vfs.Join(env.FileSystem(), OUT, COMP2+"/"+VERSION+"/moredata"))).To(Equal([]byte("moredata")))

--- a/cmds/ocm/commands/ocmcmds/resources/get/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/resources/get/cmd_test.go
@@ -20,8 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
-
-	"github.com/sirupsen/logrus"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
@@ -57,11 +56,11 @@ var _ = Describe("Test Environment", func() {
 
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "resources", ARCH)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 NAME     VERSION IDENTITY TYPE      RELATION
 testdata v1               PlainText local
-`))
+`)
 		})
 
 		It("lists ambigious resource in component archive", func() {
@@ -79,12 +78,12 @@ testdata v1               PlainText local
 
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "resources", ARCH)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 NAME     VERSION IDENTITY       TYPE      RELATION
 testdata v1      "platform"="a" PlainText local
 testdata v1      "platform"="b" PlainText local
-`))
+`)
 		})
 
 		It("lists single resource in component archive with ref", func() {
@@ -98,12 +97,11 @@ testdata v1      "platform"="b" PlainText local
 
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "resources", ARCH, "-c")).To(Succeed())
-			logrus.Infof("%s", buf)
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 REFERENCEPATH NAME     VERSION IDENTITY TYPE      RELATION
 test.de/x:v1  testdata v1               PlainText local
-`))
+`)
 		})
 		It("tree lists single resource in component archive with ref", func() {
 			env.ComponentArchive(ARCH, accessio.FormatDirectory, COMP, VERSION, func() {
@@ -116,13 +114,12 @@ test.de/x:v1  testdata v1               PlainText local
 
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "resources", ARCH, "-c", "-o", "tree")).To(Succeed())
-			logrus.Infof("%s", buf)
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 COMPONENTVERSION    NAME     VERSION IDENTITY TYPE      RELATION
 └─ test.de/x:v1                                         
    └─               testdata v1               PlainText local
-`))
+`)
 		})
 
 	})
@@ -142,11 +139,11 @@ COMPONENTVERSION    NAME     VERSION IDENTITY TYPE      RELATION
 
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "resources", ARCH)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 NAME     VERSION IDENTITY TYPE      RELATION
 testdata v1               PlainText local
-`))
+`)
 		})
 
 		Context("with closure", func() {
@@ -175,36 +172,36 @@ testdata v1               PlainText local
 			It("lists resource closure in ctf file", func() {
 				buf := bytes.NewBuffer(nil)
 				Expect(env.CatchOutput(buf).Execute("get", "resources", "-c", "--repo", ARCH, COMP2+":"+VERSION)).To(Succeed())
-				Expect("\n" + buf.String()).To(Equal(
+				ExpectTrimmedStringEqual(buf.String(),
 					`
 REFERENCEPATH              NAME     VERSION IDENTITY TYPE      RELATION
 test.de/y:v1               moredata v1               PlainText local
 test.de/y:v1->test.de/x:v1 testdata v1               PlainText local
-`))
+`)
 			})
 
 			It("lists flat tree in ctf file", func() {
 				buf := bytes.NewBuffer(nil)
 				Expect(env.CatchOutput(buf).Execute("get", "resources", "-o", "tree", "--repo", ARCH, COMP2+":"+VERSION)).To(Succeed())
-				Expect("\n" + buf.String()).To(Equal(
+				ExpectTrimmedStringEqual(buf.String(),
 					`
 COMPONENTVERSION    NAME     VERSION IDENTITY TYPE      RELATION
 └─ test.de/y:v1                                         
    └─               moredata v1               PlainText local
-`))
+`)
 			})
 
 			It("lists resource closure in ctf file", func() {
 				buf := bytes.NewBuffer(nil)
 				Expect(env.CatchOutput(buf).Execute("get", "resources", "-c", "-o", "tree", "--repo", ARCH, COMP2+":"+VERSION)).To(Succeed())
-				Expect("\n" + buf.String()).To(Equal(
+				ExpectTrimmedStringEqual(buf.String(),
 					`
 COMPONENTVERSION       NAME     VERSION IDENTITY TYPE      RELATION
 └─ test.de/y:v1                                            
    ├─                  moredata v1               PlainText local
    └─ test.de/x:v1                                         
       └─               testdata v1               PlainText local
-`))
+`)
 			})
 		})
 
@@ -240,38 +237,36 @@ COMPONENTVERSION       NAME     VERSION IDENTITY TYPE      RELATION
 			It("lists resource closure in ctf file", func() {
 				buf := bytes.NewBuffer(nil)
 				Expect(env.CatchOutput(buf).Execute("get", "resources", "-c", "--repo", ARCH, COMP2+":"+VERSION)).To(Succeed())
-				logrus.Infof("%s", buf)
-				Expect("\n" + buf.String()).To(Equal(
+				ExpectTrimmedStringEqual(buf.String(),
 					`
 REFERENCEPATH              NAME     VERSION IDENTITY TYPE      RELATION
 test.de/y:v1->test.de/x:v1 testdata v1               PlainText local
-`))
+`)
 			})
 
 			It("lists flat in ctf file", func() {
 				buf := bytes.NewBuffer(nil)
 				Expect(env.CatchOutput(buf).Execute("get", "resources", "--repo", ARCH, COMP2+":"+VERSION)).To(Succeed())
-				Expect("\n" + buf.String()).To(Equal(
+				ExpectTrimmedStringEqual(buf.String(),
 					`
 no elements found
-`))
+`)
 			})
 
 			It("lists flat tree in ctf file", func() {
 				buf := bytes.NewBuffer(nil)
 				Expect(env.CatchOutput(buf).Execute("get", "resources", "-o", "tree", "--repo", ARCH, COMP2+":"+VERSION)).To(Succeed())
-				Expect("\n" + buf.String()).To(Equal(
+				ExpectTrimmedStringEqual(buf.String(),
 					`
 COMPONENTVERSION    NAME VERSION IDENTITY TYPE RELATION
 └─ test.de/y:v1                                
-`))
+`)
 			})
 
 			It("lists resource closure in ctf file", func() {
 				buf := bytes.NewBuffer(nil)
 				Expect(env.CatchOutput(buf).Execute("get", "resources", "-c", "-o", "tree", "--repo", ARCH, COMP3+":"+VERSION)).To(Succeed())
-				logrus.Infof("%s", buf)
-				Expect("\n" + buf.String()).To(Equal(
+				ExpectTrimmedStringEqual(buf.String(),
 					`
 COMPONENTVERSION          NAME     VERSION IDENTITY TYPE      RELATION
 └─ test.de/z:v1                                               
@@ -279,7 +274,7 @@ COMPONENTVERSION          NAME     VERSION IDENTITY TYPE      RELATION
    └─ test.de/y:v1                                            
       └─ test.de/x:v1                                         
          └─               testdata v1               PlainText local
-`))
+`)
 			})
 		})
 
@@ -306,25 +301,23 @@ COMPONENTVERSION          NAME     VERSION IDENTITY TYPE      RELATION
 			It("lists resource closure in ctf file", func() {
 				buf := bytes.NewBuffer(nil)
 				Expect(env.CatchOutput(buf).Execute("get", "resources", "-c", "--repo", ARCH, COMP2+":"+VERSION)).To(Succeed())
-				logrus.Infof("%s", buf)
-				Expect("\n" + buf.String()).To(Equal(
+				ExpectTrimmedStringEqual(buf.String(),
 					`
 REFERENCEPATH NAME     VERSION IDENTITY TYPE      RELATION
 test.de/y:v1  moredata v1               PlainText local
-`))
+`)
 			})
 
 			It("lists resource closure in ctf file", func() {
 				buf := bytes.NewBuffer(nil)
 				Expect(env.CatchOutput(buf).Execute("get", "resources", "-c", "-o", "tree", "--repo", ARCH, COMP2+":"+VERSION)).To(Succeed())
-				logrus.Infof("%s", buf)
-				Expect("\n" + buf.String()).To(Equal(
+				ExpectTrimmedStringEqual(buf.String(),
 					`
 COMPONENTVERSION       NAME     VERSION IDENTITY TYPE      RELATION
 └─ test.de/y:v1                                            
    ├─                  moredata v1               PlainText local
    └─ test.de/x:v1                                         
-`))
+`)
 			})
 		})
 	})

--- a/cmds/ocm/commands/ocmcmds/sources/get/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/sources/get/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
@@ -55,11 +56,11 @@ var _ = Describe("Test Environment", func() {
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("get", "sources", ARCH)).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(
+		ExpectTrimmedStringEqual(buf.String(),
 			`
 NAME     VERSION IDENTITY TYPE
 testdata v1               git
-`))
+`)
 	})
 
 	It("lists ambigious source in component archive", func() {
@@ -77,12 +78,12 @@ testdata v1               git
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("get", "sources", ARCH)).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(
+		ExpectTrimmedStringEqual(buf.String(),
 			`
 NAME     VERSION IDENTITY       TYPE
 testdata v1      "platform"="a" git
 testdata v1      "platform"="b" git
-`))
+`)
 	})
 
 	It("lists single source in ctf file", func() {
@@ -99,11 +100,11 @@ testdata v1      "platform"="b" git
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("get", "sources", ARCH)).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(
+		ExpectTrimmedStringEqual(buf.String(),
 			`
 NAME     VERSION IDENTITY TYPE
 testdata v1               git
-`))
+`)
 	})
 
 	Context("with closure", func() {
@@ -132,35 +133,35 @@ testdata v1               git
 		It("lists resource closure in ctf file", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "sources", "-c", "--repo", ARCH, COMP2+":"+VERSION)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 REFERENCEPATH              NAME     VERSION IDENTITY TYPE
 test.de/y:v1               source   v1               git
 test.de/y:v1->test.de/x:v1 testdata v1               git
-`))
+`)
 		})
 		It("lists flat tree in ctf file", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "sources", "-o", "tree", "--repo", ARCH, COMP2+":"+VERSION)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 COMPONENTVERSION    NAME   VERSION IDENTITY TYPE
 └─ test.de/y:v1                             
    └─               source v1               git
-`))
+`)
 		})
 
 		It("lists resource closure in ctf file", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("get", "sources", "-c", "-o", "tree", "--repo", ARCH, COMP2+":"+VERSION)).To(Succeed())
-			Expect("\n" + buf.String()).To(Equal(
+			ExpectTrimmedStringEqual(buf.String(),
 				`
 COMPONENTVERSION       NAME     VERSION IDENTITY TYPE
 └─ test.de/y:v1                                  
    ├─                  source   v1               git
    └─ test.de/x:v1                               
       └─               testdata v1               git
-`))
+`)
 		})
 	})
 })

--- a/cmds/ocm/commands/ocmcmds/versions/show/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/versions/show/cmd_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 )
@@ -85,32 +86,32 @@ v2.0
 	It("lists filtered versions", func() {
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("ocm", "versions", "show", "--repo", ARCH, COMPONENT, "1.3.x", "1.4")).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(`
+		ExpectTrimmedStringEqual(buf.String(), `
 v1.3
 v1.3.1
 v1.3.2
 v1.4
-`))
+`)
 	})
 
 	It("lists filtered semantic versions", func() {
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("ocm", "versions", "show", "--semantic", "--repo", ARCH, COMPONENT, "1.3", "1.4")).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(`
+		ExpectTrimmedStringEqual(buf.String(), `
 1.3.0
 1.3.1
 1.3.2
 1.4.0
-`))
+`)
 	})
 
 	It("lists filters latest", func() {
 
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).Execute("ocm", "versions", "show", "--latest", "--repo", ARCH, COMPONENT, "1.3")).To(Succeed())
-		Expect("\n" + buf.String()).To(Equal(`
+		ExpectTrimmedStringEqual(buf.String(), `
 v1.3.2
-`))
+`)
 	})
 })

--- a/pkg/contexts/ocm/compdesc/compdesc_test.go
+++ b/pkg/contexts/ocm/compdesc/compdesc_test.go
@@ -19,8 +19,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/sirupsen/logrus"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	compdescv3 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/ocm.gardener.cloud/v3alpha1"
@@ -177,9 +176,7 @@ spec:
 		data, err := compdesc.Encode(cd)
 		Expect(err).To(Succeed())
 
-		logrus.Infof("%s\n", string(data))
-
-		Expect(string(data)).To(Equal(CDv3))
+		ExpectStringEqual(string(data), CDv3)
 
 		//_ = CDv3
 

--- a/pkg/contexts/ocm/signing/signing_test.go
+++ b/pkg/contexts/ocm/signing/signing_test.go
@@ -19,8 +19,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/pkg/contexts/ocm/signing"
 	. "github.com/open-component-model/ocm/pkg/env/builder"
-
-	"github.com/sirupsen/logrus"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/common/accessobj"
@@ -152,8 +151,7 @@ var _ = Describe("access method", func() {
 			Expect(err).To(Succeed())
 			Expect(closer.Close()).To(Succeed())
 			Expect(archcloser.Close()).To(Succeed())
-			logrus.Infof("%+v\n", dig)
-			Expect(dig.Value).To(Equal(digest))
+			ExpectStringEqual(dig.Value, digest)
 
 			src, err = ctf.Open(env.OCMContext(), accessobj.ACC_READONLY, ARCH, 0, env)
 			Expect(err).To(Succeed())
@@ -202,8 +200,7 @@ var _ = Describe("access method", func() {
 			Expect(err).To(Succeed())
 			closer.Close()
 			archcloser.Close()
-			logrus.Infof("%+v\n", dig)
-			Expect(dig.Value).To(Equal(digest))
+			ExpectStringEqual(dig.Value, digest)
 
 			src, err = ctf.Open(env.OCMContext(), accessobj.ACC_READONLY, ARCH, 0, env)
 			Expect(err).To(Succeed())
@@ -252,8 +249,7 @@ var _ = Describe("access method", func() {
 			Expect(err).To(Succeed())
 			closer.Close()
 			archcloser.Close()
-			logrus.Infof("%+v\n", dig)
-			Expect(dig.Value).To(Equal(digest))
+			ExpectStringEqual(dig.Value, digest)
 
 			src, err = ctf.Open(env.OCMContext(), accessobj.ACC_READONLY, ARCH, 0, env)
 			Expect(err).To(Succeed())

--- a/pkg/signing/normalization_test.go
+++ b/pkg/signing/normalization_test.go
@@ -19,8 +19,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/sirupsen/logrus"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/ociartefact"
@@ -153,14 +152,9 @@ var _ = Describe("normalization", func() {
 		entries, err := signing.PrepareNormalization(cd, signing.NoExcludes{})
 		Expect(err).To(Succeed())
 
-		data, err := signing.Marshal("  ", entries)
+		_, err = signing.Marshal("  ", entries)
 		Expect(err).To(Succeed())
-		logrus.Infof("%s\n", string(data))
-
-		r := entries.ToString("")
-		logrus.Infof("******\n%s\n", r)
-
-		Expect("\n" + r).To(Equal(`
+		ExpectTrimmedStringEqual(entries.ToString(""), `
 {
   component: {
     componentReferences: []
@@ -226,7 +220,7 @@ var _ = Describe("normalization", func() {
       {
         access: {
           imageReference: blob
-          type: ` + ociartefact.Type + `
+          type: `+ociartefact.Type+`
         }
         labels: [
           {
@@ -254,7 +248,7 @@ var _ = Describe("normalization", func() {
   meta: {
     configuredSchemaVersion: v2
   }
-}`))
+}`)
 	})
 
 	It("Normalizes struct without repositoryContexts", func() {
@@ -265,8 +259,7 @@ var _ = Describe("normalization", func() {
 			},
 		})
 		Expect(err).To(Succeed())
-
-		Expect("\n" + entries.ToString("")).To(Equal(`
+		ExpectTrimmedStringEqual(entries.ToString(""), `
 {
   component: {
     componentReferences: []
@@ -326,7 +319,7 @@ var _ = Describe("normalization", func() {
       {
         access: {
           imageReference: blob
-          type: ` + ociartefact.Type + `
+          type: `+ociartefact.Type+`
         }
         labels: [
           {
@@ -354,7 +347,7 @@ var _ = Describe("normalization", func() {
   meta: {
     configuredSchemaVersion: v2
   }
-}`))
+}`)
 	})
 
 	It("Normalizes struct without access", func() {
@@ -369,8 +362,7 @@ var _ = Describe("normalization", func() {
 			},
 		})
 		Expect(err).To(Succeed())
-
-		Expect("\n" + entries.ToString("")).To(Equal(`
+		ExpectTrimmedStringEqual(entries.ToString(""), `
 {
   component: {
     componentReferences: []
@@ -454,7 +446,7 @@ var _ = Describe("normalization", func() {
   meta: {
     configuredSchemaVersion: v2
   }
-}`))
+}`)
 	})
 
 	It("Normalizes struct without resources of type localBlob", func() {
@@ -470,7 +462,7 @@ var _ = Describe("normalization", func() {
 			},
 		})
 		Expect(err).To(Succeed())
-		Expect("\n" + entries.ToString("")).To(Equal(`
+		ExpectTrimmedStringEqual(entries.ToString(""), `
 {
   component: {
     componentReferences: []
@@ -528,7 +520,7 @@ var _ = Describe("normalization", func() {
   meta: {
     configuredSchemaVersion: v2
   }
-}`))
+}`)
 	})
 
 	It("Normalizes struct without no-signing resource labels", func() {
@@ -546,8 +538,7 @@ var _ = Describe("normalization", func() {
 			},
 		})
 		Expect(err).To(Succeed())
-		r := entries.ToString("")
-		Expect("\n" + r).To(Equal(`
+		ExpectTrimmedStringEqual(entries.ToString(""), `
 {
   component: {
     componentReferences: []
@@ -618,17 +609,14 @@ var _ = Describe("normalization", func() {
   meta: {
     configuredSchemaVersion: v2
   }
-}`))
+}`)
 	})
 
 	It("Normalizes cd", func() {
 
 		entries, err := signing.PrepareNormalization(cd, CDExcludes)
 		Expect(err).To(Succeed())
-		r := entries.ToString("")
-		logrus.Infof("%s\n", r)
-
-		Expect("\n" + r).To(Equal(`
+		ExpectTrimmedStringEqual(entries.ToString(""), `
 {
   component: {
     componentReferences: []
@@ -673,7 +661,7 @@ var _ = Describe("normalization", func() {
   meta: {
     configuredSchemaVersion: v2
   }
-}`))
+}`)
 	})
 
 	It("Normalizes with recursive includes", func() {
@@ -685,14 +673,12 @@ var _ = Describe("normalization", func() {
 		}
 		entries, err := signing.PrepareNormalization(cd, rules)
 		Expect(err).To(Succeed())
-		logrus.Infof("%s\n", entries.ToString(""))
-
-		Expect("\n" + entries.ToString("")).To(Equal(`
+		ExpectTrimmedStringEqual(entries.ToString(""), `
 {
   component: {
     name: test
   }
-}`))
+}`)
 	})
 
 	It("Normalizes with recursive modifying includes", func() {
@@ -707,13 +693,11 @@ var _ = Describe("normalization", func() {
 		}
 		entries, err := signing.PrepareNormalization(cd, rules)
 		Expect(err).To(Succeed())
-		logrus.Infof("%s\n", entries.ToString(""))
-
-		Expect("\n" + entries.ToString("")).To(Equal(`
+		ExpectTrimmedStringEqual(entries.ToString(""), `
 {
   modified: {
     name: test
   }
-}`))
+}`)
 	})
 })

--- a/pkg/testutils/string.go
+++ b/pkg/testutils/string.go
@@ -1,0 +1,41 @@
+// Copyright 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+package testutils
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/onsi/gomega"
+)
+
+func ExpectStringEqual(found, expected string) {
+	ExpectStringEqualWithOffset(1, found, expected)
+}
+
+func ExpectStringEqualWithOffset(offset int, found, expected string) {
+	if found != expected {
+		fmt.Printf("found: %s\n", found)
+	}
+	gomega.ExpectWithOffset(offset+1, found).To(gomega.Equal(expected))
+}
+
+func ExpectTrimmedStringEqual(found, expected string) {
+	ExpectStringEqualWithOffset(1, strings.TrimSpace(found), strings.TrimSpace(expected))
+}
+
+func ExpectTrimmedStringEqualWithOffset(offset int, found, expected string) {
+	ExpectStringEqualWithOffset(offset+1, strings.TrimSpace(found), strings.TrimSpace(expected))
+}

--- a/pkg/toi/install/credentials_test.go
+++ b/pkg/toi/install/credentials_test.go
@@ -17,8 +17,7 @@ package install_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/sirupsen/logrus"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/contexts/config"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
@@ -93,8 +92,7 @@ credentials:
 		Expect(err).To(Succeed())
 		output, err := runtime.DefaultYAMLEncoding.Marshal(c)
 		Expect(err).To(Succeed())
-		logrus.Infof("%s", output)
-		Expect("\n" + string(output)).To(Equal(cfgdata))
+		ExpectTrimmedStringEqual(string(output), cfgdata)
 	})
 
 	It("reads config data", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR provides a simple solution for the string compare problem in tests for multi-line strings.
It eliminates the  Printf or log statements always printing the actual result string and encapsulates the
complete logic in a testutils function printing the actual value only in case of a mismatch
to support the error analysis of failing tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       other
- target_group:   developer
-->
```other developer
testutils.Expect*StringEqual*() now provides error context for tests comparing long strings
```
