### PR TITLE
switch workflow trigger to pull_request_target

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -1,7 +1,6 @@
 name: lint-and-test
 
-on:
-  pull_request: {}
+on: [ pull_request, push, workflow_dispatch ]
 
 jobs:
   test:


### PR DESCRIPTION
**What this PR does / why we need it**:

According to the Github Action Docu

> This event runs in the context of the base of the pull request, rather than in the context of the merge commit, as the pull_request event does. This prevents execution of unsafe code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. This event allows your workflow to do things like label or comment on pull requests from forks. Avoid using this event if you need to build or run code from the pull request.

the trigger option for the linter and test workflow should be set to `pull_request_target` to run the workflow for PRs originating from forks based on the workflow definition of the base branch, instead of the provided content.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
