### PR TITLE
fix adding git sources without configured credentials

### DIFF
--- a/components/helmdemo/Makefile
+++ b/components/helmdemo/Makefile
@@ -30,8 +30,9 @@ version:
 .PHONY: ca
 ca: $(GEN)/ca
 
-$(GEN)/ca: $(GEN)/.exists resources.yaml references.yaml $(CHARTSRCS) packagespec.yaml helmconfig.yaml
+$(GEN)/ca: $(GEN)/.exists sources.yaml resources.yaml references.yaml $(CHARTSRCS) packagespec.yaml helmconfig.yaml
 	$(OCM) create ca -f $(COMPONENT) "$(VERSION)" $(PROVIDER) $(GEN)/ca
+	$(OCM) add sources $(GEN)/ca VERSION="$(VERSION)" COMMIT="$(COMMIT)" IMAGE="$(IMAGE):$(VERSION)" sources.yaml
 	$(OCM) add resources $(GEN)/ca VERSION="$(VERSION)" COMMIT="$(COMMIT)" IMAGE="$(IMAGE):$(VERSION)" resources.yaml
 	$(OCM) add references $(GEN)/ca VERSION="$(VERSION)" COMMIT="$(COMMIT)" IMAGE="$(IMAGE):$(VERSION)" HELMINSTCOMP=$(HELMINSTCOMP) references.yaml
 	@touch $(GEN)/ca

--- a/components/helmdemo/sources.yaml
+++ b/components/helmdemo/sources.yaml
@@ -1,0 +1,7 @@
+name: source
+type: filesytem
+access:
+  type: github
+  repoUrl: github.com/open-component-model/ocm
+  commit: ${COMMIT}
+version: ${VERSION}

--- a/pkg/common/accessio/downloader/http/downloader.go
+++ b/pkg/common/accessio/downloader/http/downloader.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+
+	"github.com/open-component-model/ocm/pkg/common/accessio/downloader"
 )
 
 // Downloader simply uses the default HTTP client to download the contents of a URL.
@@ -13,7 +15,7 @@ type Downloader struct {
 	link string
 }
 
-func NewDownloader(link string) *Downloader {
+func NewDownloader(link string) downloader.Downloader {
 	return &Downloader{
 		link: link,
 	}


### PR DESCRIPTION
If (re)sources are added to a component archive the access method is created for validation. This must be possible, even if the technical access requires crednetials, which are not yet provided.

Therefore operations requiring credentials (for private repos) for the github access method have been moved to the methods really requesting access to the content.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
