### PR TITLE
docs: add comments to the example Makefile

### DIFF
--- a/examples/make/Makefile
+++ b/examples/make/Makefile
@@ -7,7 +7,7 @@ COMMIT                                         = $(shell git rev-parse HEAD)
 EFFECTIVE_VERSION                              = $(VERSION)-$(COMMIT)
 
 .PHONY: ctf
-ctf: ca ## Create CTF from componet archive
+ctf: ca ## Create CTF from component archive
 	ocm transfer ca gen/ca gen/ctf
 	
 .PHONY: ca


### PR DESCRIPTION
Added comments through a new `help` target because that way anyone can use `make help` in the `examples/make` directory and get the full list of targets and a description.

Closes #110

References:
* https://github.com/open-component-model/ocm/issues/110
* https://www.thapaliya.com/en/writings/well-documented-makefiles/