### PR TITLE
differentiate between docker repository name and hostname

### DIFF
--- a/pkg/contexts/oci/grammar/grammar.go
+++ b/pkg/contexts/oci/grammar/grammar.go
@@ -57,6 +57,18 @@ var (
 	// dashes.
 	separatorRegexp = Match(`(?:[._]|__|[-]*)`)
 
+	// dockerOrgSeparatorRegexp defines the separators allowed to be
+	// embedded in a docker organization name.
+	// https://docs.docker.com/docker-hub/repos/
+	dockerOrgSeparatorRegexp = Match(`(?:_|__|[-]*)`)
+
+	// DockerOrgRegexp restricts registry path component names to start
+	// with at least one letter or number, with following parts able to be
+	// separated by one or two underscore and multiple dashes.
+	DockerOrgRegexp = Sequence(
+		AlphaNumericRegexp,
+		Optional(Repeated(dockerOrgSeparatorRegexp, AlphaNumericRegexp)))
+
 	// NameComponentRegexp restricts registry path component names to start
 	// with at least one letter or number, with following parts able to be
 	// separated by one period, one or two underscore and multiple dashes.
@@ -155,7 +167,7 @@ var (
 
 	// DockerReferenceRegexp is a shortened docker reference.
 	DockerReferenceRegexp = Anchored(
-		Capture(NameComponentRegexp, RepositorySeparatorRegexp, NameComponentRegexp),
+		Capture(DockerOrgRegexp, RepositorySeparatorRegexp, NameComponentRegexp),
 		CapturedVersionRegexp)
 
 	TypedRepoRegexp = Anchored(

--- a/pkg/contexts/oci/ref_test.go
+++ b/pkg/contexts/oci/ref_test.go
@@ -48,12 +48,23 @@ var _ = Describe("ref parsing", func() {
 		CheckRef("ubuntu", &oci.RefSpec{UniformRepositorySpec: docker, Repository: "library/ubuntu"})
 		CheckRef("ubuntu:v1", &oci.RefSpec{UniformRepositorySpec: docker, Repository: "library/ubuntu", Tag: &tag})
 		CheckRef("test/ubuntu", &oci.RefSpec{UniformRepositorySpec: docker, Repository: "test/ubuntu"})
+		CheckRef("test_test/ubuntu", &oci.RefSpec{UniformRepositorySpec: docker, Repository: "test_test/ubuntu"})
+		CheckRef("test__test/ubuntu", &oci.RefSpec{UniformRepositorySpec: docker, Repository: "test__test/ubuntu"})
+		CheckRef("test-test/ubuntu", &oci.RefSpec{UniformRepositorySpec: docker, Repository: "test-test/ubuntu"})
+		CheckRef("test--test/ubuntu", &oci.RefSpec{UniformRepositorySpec: docker, Repository: "test--test/ubuntu"})
+		CheckRef("test-----test/ubuntu", &oci.RefSpec{UniformRepositorySpec: docker, Repository: "test-----test/ubuntu"})
 		CheckRef("test/ubuntu:v1", &oci.RefSpec{UniformRepositorySpec: docker, Repository: "test/ubuntu", Tag: &tag})
 		CheckRef("ghcr.io/test/ubuntu", &oci.RefSpec{UniformRepositorySpec: ghcr, Repository: "test/ubuntu"})
+		CheckRef("ghcr.io/test", &oci.RefSpec{UniformRepositorySpec: ghcr, Repository: "test"})
 		CheckRef("ghcr.io:8080/test/ubuntu", &oci.RefSpec{UniformRepositorySpec: oci.UniformRepositorySpec{Host: "ghcr.io:8080"}, Repository: "test/ubuntu"})
 		CheckRef("ghcr.io/test/ubuntu:v1", &oci.RefSpec{UniformRepositorySpec: ghcr, Repository: "test/ubuntu", Tag: &tag})
 		CheckRef("ghcr.io/test/ubuntu@sha256:3d05e105e350edf5be64fe356f4906dd3f9bf442a279e4142db9879bba8e677a", &oci.RefSpec{UniformRepositorySpec: ghcr, Repository: "test/ubuntu", Digest: &digest})
 		CheckRef("ghcr.io/test/ubuntu:v1@sha256:3d05e105e350edf5be64fe356f4906dd3f9bf442a279e4142db9879bba8e677a", &oci.RefSpec{UniformRepositorySpec: ghcr, Repository: "test/ubuntu", Tag: &tag, Digest: &digest})
+		CheckRef("test___test/ubuntu", &oci.RefSpec{
+			UniformRepositorySpec: oci.UniformRepositorySpec{
+				Info: "test___test/ubuntu",
+			},
+		})
 		CheckRef("type::https://ghcr.io/repo/repo:v1@"+digest.String(), &oci.RefSpec{
 			UniformRepositorySpec: oci.UniformRepositorySpec{
 				Type:   "type",


### PR DESCRIPTION
**What this PR does / why we need it**:

The legacy notation for dockerhub based references uses a name restriction for the repository
which can be used to differentiate between dockerhub references and flat image names stored in some
other OCI registry.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

