### PR TITLE
generalize a common handling for optional arguments

### DIFF
--- a/cmds/ocm/commands/common/options/closureoption/option.go
+++ b/cmds/ocm/commands/common/options/closureoption/option.go
@@ -15,6 +15,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/transfer/transferhandler"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/transfer/transferhandler/standard"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 func From(o options.OptionSetProvider) *Option {
@@ -166,10 +167,7 @@ func AddChain(opts *output.Options, chain, add processing.ProcessChain) processi
 }
 
 func TableOutput(in *output.TableOutput, closure ...ClosureFunction) *output.TableOutput {
-	var cf ClosureFunction
-	if len(closure) > 0 {
-		cf = closure[0]
-	}
+	cf := utils.Optional(closure...)
 	chain := processing.Append(in.Chain, processing.Explode(cf.Exploder(in.Options)))
 	copts := From(in.Options)
 	return &output.TableOutput{

--- a/cmds/ocm/pkg/tree/tree.go
+++ b/cmds/ocm/pkg/tree/tree.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/open-component-model/ocm/pkg/common"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 type Object interface {
@@ -63,12 +64,9 @@ var (
 // is not desired, pass an empty symbol string.
 func MapToTree(objs Objects, creator NodeCreator, symbols ...string) TreeObjects {
 	result := TreeObjects{}
-	nodeSym := " " + node
-	if len(symbols) > 0 {
-		nodeSym = symbols[0]
-		if nodeSym != "" && !strings.HasPrefix(nodeSym, " ") {
-			nodeSym = " " + nodeSym
-		}
+	nodeSym := utils.OptionalDefaulted(node, symbols...)
+	if nodeSym != "" && !strings.HasPrefix(nodeSym, " ") {
+		nodeSym = " " + nodeSym
 	}
 	handleLevel(objs, "", nil, 0, creator, &result, nodeSym)
 	return result

--- a/pkg/common/walk.go
+++ b/pkg/common/walk.go
@@ -4,15 +4,15 @@
 
 package common
 
+import (
+	"github.com/open-component-model/ocm/pkg/utils"
+)
+
 type NameVersionInfo map[NameVersion]interface{}
 
 func (s NameVersionInfo) Add(nv NameVersion, data ...interface{}) bool {
-	var d interface{}
-	if len(data) > 0 {
-		d = data[0]
-	}
 	if _, ok := s[nv]; !ok {
-		s[nv] = d
+		s[nv] = utils.Optional(data...)
 		return true
 	}
 	return false

--- a/pkg/contexts/clictx/builder.go
+++ b/pkg/contexts/clictx/builder.go
@@ -10,39 +10,39 @@ import (
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
 
-	core2 "github.com/open-component-model/ocm/pkg/contexts/clictx/core"
+	"github.com/open-component-model/ocm/pkg/contexts/clictx/core"
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 )
 
-func WithContext(ctx context.Context) core2.Builder {
-	return core2.Builder{}.WithContext(ctx)
+func WithContext(ctx context.Context) core.Builder {
+	return core.Builder{}.WithContext(ctx)
 }
 
-func WithSharedAttributes(ctx datacontext.AttributesContext) core2.Builder {
-	return core2.Builder{}.WithSharedAttributes(ctx)
+func WithSharedAttributes(ctx datacontext.AttributesContext) core.Builder {
+	return core.Builder{}.WithSharedAttributes(ctx)
 }
 
-func WithOCM(ctx ocm.Context) core2.Builder {
-	return core2.Builder{}.WithOCM(ctx)
+func WithOCM(ctx ocm.Context) core.Builder {
+	return core.Builder{}.WithOCM(ctx)
 }
 
-func WithFileSystem(fs vfs.FileSystem) core2.Builder {
-	return core2.Builder{}.WithFileSystem(fs)
+func WithFileSystem(fs vfs.FileSystem) core.Builder {
+	return core.Builder{}.WithFileSystem(fs)
 }
 
-func WithOutput(w io.Writer) core2.Builder {
-	return core2.Builder{}.WithOutput(w)
+func WithOutput(w io.Writer) core.Builder {
+	return core.Builder{}.WithOutput(w)
 }
 
-func WithErrorOutput(w io.Writer) core2.Builder {
-	return core2.Builder{}.WithErrorOutput(w)
+func WithErrorOutput(w io.Writer) core.Builder {
+	return core.Builder{}.WithErrorOutput(w)
 }
 
-func WithInput(r io.Reader) core2.Builder {
-	return core2.Builder{}.WithInput(r)
+func WithInput(r io.Reader) core.Builder {
+	return core.Builder{}.WithInput(r)
 }
 
-func New(mode ...datacontext.BuilderMode) core2.Context {
-	return core2.Builder{}.New(mode...)
+func New(mode ...datacontext.BuilderMode) core.Context {
+	return core.Builder{}.New(mode...)
 }

--- a/pkg/contexts/datacontext/context.go
+++ b/pkg/contexts/datacontext/context.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/errors"
 	ocmlog "github.com/open-component-model/ocm/pkg/logging"
 	"github.com/open-component-model/ocm/pkg/runtime"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 const OCM_CONTEXT_SUFFIX = ".context" + common.OCM_TYPE_GROUP_SUFFIX
@@ -40,11 +41,7 @@ const (
 )
 
 func Mode(m ...BuilderMode) BuilderMode {
-	mode := MODE_DEFAULTED
-	if len(m) > 0 {
-		mode = m[0]
-	}
-	return mode
+	return utils.OptionalDefaulted(MODE_DEFAULTED, m...)
 }
 
 // Context describes a common interface for a data context used for a dedicated
@@ -251,12 +248,7 @@ func (c *_attributes) GetAttribute(name string, def ...interface{}) interface{} 
 			return a
 		}
 	}
-	for _, d := range def {
-		if d != nil {
-			return d
-		}
-	}
-	return nil
+	return utils.Optional(def...)
 }
 
 func (c *_attributes) SetEncodedAttribute(name string, data []byte, unmarshaller runtime.Unmarshaler) error {

--- a/pkg/contexts/oci/repositories/docker/type.go
+++ b/pkg/contexts/oci/repositories/docker/type.go
@@ -8,6 +8,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/cpi"
 	"github.com/open-component-model/ocm/pkg/runtime"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 const (
@@ -28,13 +29,9 @@ type RepositorySpec struct {
 
 // NewRepositorySpec creates a new RepositorySpec for an optional host.
 func NewRepositorySpec(host ...string) *RepositorySpec {
-	h := ""
-	if len(host) > 0 {
-		h = host[0]
-	}
 	return &RepositorySpec{
 		ObjectVersionedType: runtime.NewVersionedObjectType(Type),
-		DockerHost:          h,
+		DockerHost:          utils.Optional(host...),
 	}
 }
 

--- a/pkg/contexts/ocm/cpi/accessspecs_converted.go
+++ b/pkg/contexts/ocm/cpi/accessspecs_converted.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/core"
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/runtime"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 type AccessSpecConverter interface {
@@ -64,7 +65,7 @@ func NewConvertedAccessSpecType(name string, v AccessSpecVersion, desc string, h
 			ObjectVersionedType: runtime.NewVersionedObjectType(name),
 			TypedObjectDecoder:  v,
 			description:         desc,
-			handler:             _handler(handler),
+			handler:             utils.Optional(handler...),
 		},
 		AccessSpecVersion: v,
 	}

--- a/pkg/contexts/ocm/cpi/accessspecs_simple.go
+++ b/pkg/contexts/ocm/cpi/accessspecs_simple.go
@@ -10,14 +10,8 @@ import (
 	"github.com/open-component-model/ocm/pkg/cobrautils/flagsets"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/core"
 	"github.com/open-component-model/ocm/pkg/runtime"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
-
-func _handler(handler []flagsets.ConfigOptionTypeSetHandler) flagsets.ConfigOptionTypeSetHandler {
-	if len(handler) > 0 {
-		return handler[0]
-	}
-	return nil
-}
 
 type accessType struct {
 	runtime.ObjectVersionedType
@@ -31,7 +25,7 @@ func NewAccessSpecType(name string, proto core.AccessSpec, desc string, handler 
 		ObjectVersionedType: runtime.NewVersionedObjectType(name),
 		TypedObjectDecoder:  runtime.MustNewDirectDecoder(proto),
 		description:         desc,
-		handler:             _handler(handler),
+		handler:             utils.Optional(handler...),
 	}
 }
 

--- a/pkg/contexts/ocm/repositories/genericocireg/component.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/component.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/oci"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 type ComponentAccess struct {
@@ -138,12 +139,8 @@ func (c *componentAccessImpl) NewVersion(version string, overrides ...bool) (cpi
 		return nil, err
 	}
 	defer v.Close()
-	override := false
-	for _, o := range overrides {
-		if o {
-			override = o
-		}
-	}
+
+	override := utils.Optional(overrides...)
 	acc, err := c.namespace.GetArtefact(version)
 	if err == nil {
 		if override {

--- a/pkg/contexts/ocm/signing/options.go
+++ b/pkg/contexts/ocm/signing/options.go
@@ -14,18 +14,11 @@ import (
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/signing"
 	"github.com/open-component-model/ocm/pkg/signing/hasher/sha256"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 type Option interface {
 	ApplySigningOption(o *Options)
-}
-
-func evalFlag(flags ...bool) bool {
-	flag := len(flags) == 0
-	for _, f := range flags {
-		flag = flag || f
-	}
-	return flag
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -35,7 +28,7 @@ type recursive struct {
 }
 
 func Recursive(flags ...bool) Option {
-	return &recursive{evalFlag(flags...)}
+	return &recursive{utils.GetOptionFlag(flags...)}
 }
 
 func (o *recursive) ApplySigningOption(opts *Options) {
@@ -49,7 +42,7 @@ type update struct {
 }
 
 func Update(flags ...bool) Option {
-	return &update{evalFlag(flags...)}
+	return &update{utils.GetOptionFlag(flags...)}
 }
 
 func (o *update) ApplySigningOption(opts *Options) {
@@ -63,7 +56,7 @@ type verify struct {
 }
 
 func VerifyDigests(flags ...bool) Option {
-	return &verify{evalFlag(flags...)}
+	return &verify{utils.GetOptionFlag(flags...)}
 }
 
 func (o *verify) ApplySigningOption(opts *Options) {

--- a/pkg/contexts/ocm/transfer/transferhandler/standard/options.go
+++ b/pkg/contexts/ocm/transfer/transferhandler/standard/options.go
@@ -8,6 +8,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/transfer/transferhandler"
 	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 type Options struct {
@@ -67,19 +68,6 @@ func (o *Options) GetResolver() ocm.ComponentVersionResolver {
 
 ///////////////////////////////////////////////////////////////////////////////
 
-func GetFlag(args ...bool) bool {
-	flag := len(args) == 0
-	for _, f := range args {
-		if f {
-			flag = true
-			break
-		}
-	}
-	return flag
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
 type OverwriteOption interface {
 	SetOverwrite(bool)
 	IsOverwrite() bool
@@ -100,7 +88,7 @@ func (o *overwriteOption) ApplyTransferOption(to transferhandler.TransferOptions
 
 func Overwrite(args ...bool) transferhandler.TransferOption {
 	return &overwriteOption{
-		overwrite: GetFlag(args...),
+		overwrite: utils.GetOptionFlag(args...),
 	}
 }
 
@@ -126,7 +114,7 @@ func (o *recursiveOption) ApplyTransferOption(to transferhandler.TransferOptions
 
 func Recursive(args ...bool) transferhandler.TransferOption {
 	return &recursiveOption{
-		recursive: GetFlag(args...),
+		recursive: utils.GetOptionFlag(args...),
 	}
 }
 
@@ -152,7 +140,7 @@ func (o *resourcesByValueOption) ApplyTransferOption(to transferhandler.Transfer
 
 func ResourcesByValue(args ...bool) transferhandler.TransferOption {
 	return &resourcesByValueOption{
-		flag: GetFlag(args...),
+		flag: utils.GetOptionFlag(args...),
 	}
 }
 
@@ -178,7 +166,7 @@ func (o *sourcesByValueOption) ApplyTransferOption(to transferhandler.TransferOp
 
 func SourcesByValue(args ...bool) transferhandler.TransferOption {
 	return &sourcesByValueOption{
-		flag: GetFlag(args...),
+		flag: utils.GetOptionFlag(args...),
 	}
 }
 

--- a/pkg/env/builder/builder.go
+++ b/pkg/env/builder/builder.go
@@ -13,6 +13,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	"github.com/open-component-model/ocm/pkg/env"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 type element interface {
@@ -106,11 +107,7 @@ func (b *Builder) expect(p interface{}, msg string, tests ...func() bool) {
 
 func (b *Builder) failOn(err error, callerSkip ...int) {
 	if err != nil {
-		skip := 2
-		if len(callerSkip) > 0 {
-			skip = callerSkip[0]
-		}
-		Fail(err.Error(), skip)
+		Fail(err.Error(), utils.Optional(callerSkip...)+2)
 	}
 }
 
@@ -142,11 +139,7 @@ func (b *Builder) configure(e element, funcs []func(), skip ...int) interface{} 
 	}
 	err := b.pop().Close()
 	if err != nil {
-		cs := 2
-		if len(skip) > 0 {
-			cs += skip[0]
-		}
-		Fail(err.Error(), cs)
+		Fail(err.Error(), utils.Optional(skip...)+2)
 	}
 	return e.Result()
 }

--- a/pkg/env/builder/oci_artefact.go
+++ b/pkg/env/builder/oci_artefact.go
@@ -80,7 +80,7 @@ func (b *Builder) artefact(tag string, ns cpi.NamespaceAccess, t func(access oci
 	if v != nil {
 		k, err = t(v)
 	}
-	b.failOn(err, 2)
+	b.failOn(err, 1)
 	tags := []string{}
 	if tag != "" {
 		tags = append(tags, tag)

--- a/pkg/signing/handlers/rsa/format.go
+++ b/pkg/signing/handlers/rsa/format.go
@@ -11,6 +11,8 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 func GetPublicKey(key interface{}) (*rsa.PublicKey, []string, error) {
@@ -63,7 +65,7 @@ func KeyData(key interface{}) ([]byte, error) {
 func PemBlockForKey(priv interface{}, gen ...bool) *pem.Block {
 	switch k := priv.(type) {
 	case *rsa.PublicKey:
-		if len(gen) > 0 && gen[0] {
+		if utils.Optional(gen...) {
 			bytes, err := x509.MarshalPKIXPublicKey(k)
 			if err != nil {
 				panic(err)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
+	"github.com/modern-go/reflect2"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/yaml"
 
@@ -254,4 +255,46 @@ func StringMapKeys(m interface{}) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// Optional returns the first optional non-zero element given as variadic argument,
+// if given, or the zero element as default.
+func Optional[T any](list ...T) T {
+	var zero T
+	for _, e := range list {
+		if !reflect.DeepEqual(e, zero) {
+			return e
+		}
+	}
+	return zero
+}
+
+// OptionalDefaulted returns the first optional non-nil element given as variadic
+// argument, or the given default element. For value types a given zero
+// argument is excepted, also.
+func OptionalDefaulted[T any](def T, list ...T) T {
+	for _, e := range list {
+		if !reflect2.IsNil(e) {
+			return e
+		}
+	}
+	return def
+}
+
+// OptionalDefaultedBool checks all args for true. If no true is given
+// the given default is returned.
+func OptionalDefaultedBool(def bool, list ...bool) bool {
+	for _, e := range list {
+		if e {
+			return e
+		}
+	}
+	return def
+}
+
+// GetOptionFlag returns the flag value used to set a bool option
+// based on optionally specified explicit value(s).
+// The default value is to enable the option (true).
+func GetOptionFlag(list ...bool) bool {
+	return OptionalDefaultedBool(len(list) == 0, list...)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

There are several implementation to handle a variadic parameters to default an optional argument.
Using generics these different implementations can be harmonized by central oe.
This assures always the same behaviour of the currently different implementations.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Unfortunately with go generics it is not possible to differentiate between value types and nil-able
types. 

If we choose `comparable` as type parameters which would include pointer types, `interfaces` cannot be passed.
If we choose `any` we cannot compare and would need `reflect.DeepEqual` to select the first non-zero element.

Therefore this generalization is not possible without using reflection and various variants. which makes it a little bit ugly.

