### PR TITLE
extend blobhandler context/registration with artifact type

### DIFF
--- a/cmds/ocm/commands/ocmcmds/common/resources.go
+++ b/cmds/ocm/commands/ocmcmds/common/resources.go
@@ -75,6 +75,13 @@ func (r *resource) Input() *ResourceInput {
 	return r.input
 }
 
+func (r *resource) Type() string {
+	if c, ok := r.spec.(interface{ GetType() string }); ok {
+		return c.GetType()
+	}
+	return ""
+}
+
 func NewResource(spec ResourceSpec, input *ResourceInput, path string, indices ...int) *resource {
 	id := path
 	for _, i := range indices {
@@ -435,7 +442,7 @@ func (o *ResourceAdderCommand) ProcessResourceDescriptions(listkey string, h Res
 				if berr != nil {
 					return errors.Wrapf(berr, "cannot get resource blob for %q(%s)", r.spec.GetName(), r.source)
 				}
-				acc, err = obj.AddBlob(blob, hint, nil)
+				acc, err = obj.AddBlob(blob, r.Type(), hint, nil)
 				if err == nil {
 					err = h.Set(obj, r, acc)
 				}

--- a/pkg/contexts/ocm/cpi/dummy.go
+++ b/pkg/contexts/ocm/cpi/dummy.go
@@ -75,7 +75,7 @@ func (d *DummyComponentVersionAccess) AccessMethod(spec AccessSpec) (AccessMetho
 	panic("implement me")
 }
 
-func (d *DummyComponentVersionAccess) AddBlob(blob BlobAccess, refName string, global AccessSpec) (AccessSpec, error) {
+func (d *DummyComponentVersionAccess) AddBlob(blob BlobAccess, arttype, refName string, global AccessSpec) (AccessSpec, error) {
 	panic("implement me")
 }
 

--- a/pkg/contexts/ocm/cpi/support/compversaccess.go
+++ b/pkg/contexts/ocm/cpi/support/compversaccess.go
@@ -98,12 +98,12 @@ func (a *componentVersionAccessImpl) GetVersion() string {
 	return a.base.GetDescriptor().GetVersion()
 }
 
-func (a *componentVersionAccessImpl) AddBlob(blob cpi.BlobAccess, refName string, global cpi.AccessSpec) (cpi.AccessSpec, error) {
+func (a *componentVersionAccessImpl) AddBlob(blob cpi.BlobAccess, artType, refName string, global cpi.AccessSpec) (cpi.AccessSpec, error) {
 	if blob == nil {
 		return nil, errors.New("a resource has to be defined")
 	}
 	storagectx := a.base.GetStorageContext(a)
-	h := a.GetContext().BlobHandlers().GetHandler(storagectx.GetImplementationRepositoryType(), blob.MimeType())
+	h := a.GetContext().BlobHandlers().GetHandler(storagectx.GetImplementationRepositoryType(), artType, blob.MimeType())
 	if h != nil {
 		acc, err := h.StoreBlob(blob, refName, nil, storagectx)
 		if err != nil {
@@ -336,7 +336,7 @@ func (c *componentVersionAccessImpl) SetSource(meta *cpi.SourceMeta, acc compdes
 
 // AddResource adds a blob resource to the current archive.
 func (c *componentVersionAccessImpl) SetResourceBlob(meta *cpi.ResourceMeta, blob cpi.BlobAccess, refName string, global cpi.AccessSpec) error {
-	acc, err := c.AddBlob(blob, refName, global)
+	acc, err := c.AddBlob(blob, meta.Type, refName, global)
 	if err != nil {
 		return fmt.Errorf("unable to add blob: %w", err)
 	}
@@ -349,7 +349,7 @@ func (c *componentVersionAccessImpl) SetResourceBlob(meta *cpi.ResourceMeta, blo
 }
 
 func (c *componentVersionAccessImpl) SetSourceBlob(meta *cpi.SourceMeta, blob cpi.BlobAccess, refName string, global cpi.AccessSpec) error {
-	acc, err := c.AddBlob(blob, refName, global)
+	acc, err := c.AddBlob(blob, meta.Type, refName, global)
 	if err != nil {
 		return fmt.Errorf("unable to add blob: %w", err)
 	}

--- a/pkg/contexts/ocm/cpi/support/container.go
+++ b/pkg/contexts/ocm/cpi/support/container.go
@@ -25,7 +25,8 @@ type BlobContainer interface {
 	// potentially provides a global reference according to the OCI distribution spec
 	// if the blob described an oci artefact.
 	// The resulting access information (global and local) is provided as
-	// an access method specification usable in a component descriptor
+	// an access method specification usable in a component descriptor.
+	// This is the direct technical storage, without caring about any handler.
 	AddBlobFor(storagectx cpi.StorageContext, blob cpi.BlobAccess, refName string, global cpi.AccessSpec) (cpi.AccessSpec, error)
 }
 

--- a/pkg/contexts/ocm/internal/repository.go
+++ b/pkg/contexts/ocm/internal/repository.go
@@ -101,7 +101,7 @@ type ComponentVersionAccess interface {
 	AccessMethod(AccessSpec) (AccessMethod, error)
 
 	// AddBlob adds a local blob and returns an appropriate local access spec
-	AddBlob(blob BlobAccess, refName string, global AccessSpec) (AccessSpec, error)
+	AddBlob(blob BlobAccess, artType, refName string, global AccessSpec) (AccessSpec, error)
 
 	SetResourceBlob(meta *ResourceMeta, blob BlobAccess, refname string, global AccessSpec) error
 	SetResource(*ResourceMeta, compdesc.AccessSpec) error

--- a/pkg/contexts/ocm/repositories/genericocireg/repo_test.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/repo_test.go
@@ -117,7 +117,7 @@ var _ = Describe("component repository mapping", func() {
 		vers, err := comp.NewVersion("v1")
 		Expect(err).To(Succeed())
 
-		acc, err := vers.AddBlob(blob, "", nil)
+		acc, err := vers.AddBlob(blob, "", "", nil)
 		Expect(err).To(Succeed())
 
 		// check provided actual access to be local blob
@@ -172,7 +172,7 @@ var _ = Describe("component repository mapping", func() {
 		defer vers.Close()
 		blob := accessio.BlobAccessForFile(mime, "test.tgz", tempfs)
 
-		acc, err := vers.AddBlob(blob, "artefact1", nil)
+		acc, err := vers.AddBlob(blob, "", "artefact1", nil)
 		Expect(err).To(Succeed())
 		Expect(acc.GetKind()).To(Equal(ociartefact.Type))
 		o := acc.(*ociartefact.AccessSpec)
@@ -180,7 +180,7 @@ var _ = Describe("component repository mapping", func() {
 		err = comp.AddVersion(vers)
 		Expect(err).To(Succeed())
 
-		acc, err = vers.AddBlob(blob, "artefact2:v1", nil)
+		acc, err = vers.AddBlob(blob, "", "artefact2:v1", nil)
 		Expect(err).To(Succeed())
 		Expect(acc.GetKind()).To(Equal(ociartefact.Type))
 		o = acc.(*ociartefact.AccessSpec)


### PR DESCRIPTION
**What this PR does / why we need it**:

A blob handler is responsible for storing local blobs in an alternate way.
For example, in a OCI registry backend for OCM repositories, local blobs describing an OCI artifact are exploded and stored as regular OCI artifacts, again. The access spec in the CD is adapted accordingly.

Therefore a blob handler gets a storage context describing the technical target repository and the blob (including its mime type). It then decides whether it will handle the blob or not. If yes, it has to return an appropriate access spec usable to access the content. 

Similar is the registration, handlers are registered for implementation repositories types and mime types.
Both is optional. Even if a registration constraint matches, the handler may reject the handling of a given blob.
To solve this all matching handler are called in a prioritized order until a handler feels responsible.

All this is sufficient, to support backing technologies to provide appropriate blobs in their native formats (like the OCI artifacts) if transported content reaches it.

To support more specific handlers with the plugin concept, it would be useful to support matches for dedicated artifact types, also. This would enable automatically upload imported content directly to intended target repositories (not equal to the OCM repository) (for example a maven repo GAV content could be propagated to a local Maven repository. This is introduced with this PR, in preparation for the connections with plugins.



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
