### PR TITLE
By-pass artifact blob for direct OCI2OCI artifact transfer + Provide logging for component transfer

### DIFF
--- a/cmds/ocm/app/app.go
+++ b/cmds/ocm/app/app.go
@@ -291,7 +291,7 @@ func (o *CLIOptions) Complete() error {
 			return errors.Wrapf(err, "cannot read logging config %q", o.LogFile)
 		}
 		if err = config.ConfigureWithData(ocmlog.Context(), cfg); err != nil {
-			return errors.Wrapf(err, "cinvalid logging config: %q", o.LogFile)
+			return errors.Wrapf(err, "invalid logging config: %q", o.LogFile)
 		}
 	}
 

--- a/cmds/ocm/app/app.go
+++ b/cmds/ocm/app/app.go
@@ -65,6 +65,7 @@ import (
 )
 
 type CLIOptions struct {
+	Completed   bool
 	Config      string
 	Credentials []string
 	Context     clictx.Context
@@ -253,6 +254,11 @@ func (o *CLIOptions) Close() error {
 }
 
 func (o *CLIOptions) Complete() error {
+	if o.Completed {
+		return nil
+	}
+	o.Completed = true
+
 	var err error
 	if o.Verbose {
 		logrus.SetLevel(logrus.DebugLevel)

--- a/cmds/ocm/app/app_test.go
+++ b/cmds/ocm/app/app_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Test Environment", func() {
 		oldlog = ocmlog.Context()
 		log.Reset()
 		def := buflogr.NewWithBuffer(&log)
-		n := ocmlog.NewContext(logging.New(def))
+		n := logging.New(def)
 		ocmlog.SetContext(n)
 		env = NewTestEnv(TestData())
 	})
@@ -66,8 +66,8 @@ var _ = Describe("Test Environment", func() {
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).ExecuteModified(addTestCommands, "logtest")).To(Succeed())
 		Expect(log.String()).To(StringEqualTrimmedWithContext(`
-ERROR <nil> test error
-ERROR <nil> test ctxerror
+ERROR <nil> ocm/test error
+ERROR <nil> ocm/test ctxerror
 `))
 	})
 
@@ -75,14 +75,14 @@ ERROR <nil> test ctxerror
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).ExecuteModified(addTestCommands, "-X", "plugindir=xxx", "-l", "Debug", "logtest")).To(Succeed())
 		Expect(log.String()).To(StringEqualTrimmedWithContext(`
-V[4] test debug
-V[3] test info
-V[2] test warn
-ERROR <nil> test error
-V[4] test ctxdebug
-V[3] test ctxinfo
-V[2] test ctxwarn
-ERROR <nil> test ctxerror
+V[4] ocm/test debug
+V[3] ocm/test info
+V[2] ocm/test warn
+ERROR <nil> ocm/test error
+V[4] ocm/test ctxdebug
+V[3] ocm/test ctxinfo
+V[2] ocm/test ctxwarn
+ERROR <nil> ocm/test ctxerror
 `))
 	})
 
@@ -90,14 +90,14 @@ ERROR <nil> test ctxerror
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).ExecuteModified(addTestCommands, "--logconfig", "testdata/logcfg.yaml", "logtest")).To(Succeed())
 		Expect(log.String()).To(StringEqualTrimmedWithContext(`
-V[4] test debug
-V[3] test info
-V[2] test warn
-ERROR <nil> test error
-V[4] test ctxdebug
-V[3] test ctxinfo
-V[2] test ctxwarn
-ERROR <nil> test ctxerror
+V[4] ocm/test debug
+V[3] ocm/test info
+V[2] ocm/test warn
+ERROR <nil> ocm/test error
+V[4] ocm/test ctxdebug
+V[3] ocm/test ctxinfo
+V[2] ocm/test ctxwarn
+ERROR <nil> ocm/test ctxerror
 `))
 	})
 
@@ -108,7 +108,7 @@ ERROR <nil> test ctxerror
 		data, err := vfs.ReadFile(env.FileSystem(), "logfile")
 		Expect(err).To(Succeed())
 
-		Expect(len(string(data))).To(Equal(183))
+		Expect(len(string(data))).To(Equal(191))
 	})
 
 })

--- a/cmds/ocm/commands/ocicmds/artefacts/describe/cmd.go
+++ b/cmds/ocm/commands/ocicmds/artefacts/describe/cmd.go
@@ -7,8 +7,6 @@ package describe
 import (
 	"fmt"
 
-	common2 "github.com/open-component-model/ocm/pkg/common"
-	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -20,9 +18,11 @@ import (
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/output"
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/processing"
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/utils"
+	common2 "github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/contexts/clictx"
 	"github.com/open-component-model/ocm/pkg/contexts/oci"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/ociutils"
+	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/open-component-model/ocm/pkg/out"
 )
 

--- a/cmds/ocm/commands/ocicmds/artefacts/describe/cmd.go
+++ b/cmds/ocm/commands/ocicmds/artefacts/describe/cmd.go
@@ -7,6 +7,8 @@ package describe
 import (
 	"fmt"
 
+	common2 "github.com/open-component-model/ocm/pkg/common"
+	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -100,7 +102,8 @@ func (o *Command) Run() error {
 var outputs = output.NewOutputs(getRegular, output.Outputs{}).AddChainedManifestOutputs(infoChain)
 
 func getRegular(opts *output.Options) output.Output {
-	return output.NewProcessingFunctionOutput(opts.LogContext(), opts.Context, processing.Chain(opts.LogContext()), outInfo)
+	return output.NewProcessingFunctionOutput(opts.LogContext(), opts.Context, processing.Chain(opts.LogContext()),
+		generics.Conditional(From(opts).BlobFiles, outInfoWithFiles, outInfo))
 }
 
 func infoChain(options *output.Options) processing.ProcessChain {
@@ -109,7 +112,14 @@ func infoChain(options *output.Options) processing.ProcessChain {
 
 func outInfo(ctx out.Context, e interface{}) {
 	p := e.(*artefacthdlr.Object)
-	out.Outf(ctx, "%s", ociutils.PrintArtefact(p.Artefact))
+
+	ociutils.PrintArtefact(common2.NewPrinter(ctx.StdOut()), p.Artefact, false)
+}
+
+func outInfoWithFiles(ctx out.Context, e interface{}) {
+	p := e.(*artefacthdlr.Object)
+
+	ociutils.PrintArtefact(common2.NewPrinter(ctx.StdOut()), p.Artefact, true)
 }
 
 type Info struct {

--- a/cmds/ocm/commands/ocmcmds/components/download/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/components/download/cmd.go
@@ -141,7 +141,7 @@ func (d *action) Save(o *comphdlr.Object, f string) error {
 	nv := common.NewNameVersion(src.GetName(), src.GetVersion())
 	hist := common.History{nv}
 
-	err = transfer.CopyVersion(nil, hist, src, set, nil)
+	err = transfer.CopyVersion(nil, d.cmd.OCMContext().Logger().WithValues("download", f), hist, src, set, nil)
 	if err == nil {
 		out.Outf(d.cmd.Context, "%s: downloaded\n", f)
 	}

--- a/docs/reference/ocm_add_resource-configuration.md
+++ b/docs/reference/ocm_add_resource-configuration.md
@@ -312,7 +312,7 @@ with the field <code>type</code> in the <code>input</code> field:
 
 - Input type <code>spiff</code>
 
-  The path must denote a [spiff](https://github.com/mandelsoft/spiff) template relative the the resources file.
+  The path must denote a [spiff](https://github.com/mandelsoft/spiff) template relative the resources file.
   The content is compressed if the <code>compress</code> field
   is set to <code>true</code>.
   

--- a/docs/reference/ocm_add_resources.md
+++ b/docs/reference/ocm_add_resources.md
@@ -307,7 +307,7 @@ with the field <code>type</code> in the <code>input</code> field:
 
 - Input type <code>spiff</code>
 
-  The path must denote a [spiff](https://github.com/mandelsoft/spiff) template relative the the resources file.
+  The path must denote a [spiff](https://github.com/mandelsoft/spiff) template relative the resources file.
   The content is compressed if the <code>compress</code> field
   is set to <code>true</code>.
   

--- a/docs/reference/ocm_add_source-configuration.md
+++ b/docs/reference/ocm_add_source-configuration.md
@@ -312,7 +312,7 @@ with the field <code>type</code> in the <code>input</code> field:
 
 - Input type <code>spiff</code>
 
-  The path must denote a [spiff](https://github.com/mandelsoft/spiff) template relative the the resources file.
+  The path must denote a [spiff](https://github.com/mandelsoft/spiff) template relative the resources file.
   The content is compressed if the <code>compress</code> field
   is set to <code>true</code>.
   

--- a/docs/reference/ocm_add_sources.md
+++ b/docs/reference/ocm_add_sources.md
@@ -305,7 +305,7 @@ with the field <code>type</code> in the <code>input</code> field:
 
 - Input type <code>spiff</code>
 
-  The path must denote a [spiff](https://github.com/mandelsoft/spiff) template relative the the resources file.
+  The path must denote a [spiff](https://github.com/mandelsoft/spiff) template relative the resources file.
   The content is compressed if the <code>compress</code> field
   is set to <code>true</code>.
   

--- a/docs/reference/ocm_bootstrap_componentversions_toi-bootstrapping.md
+++ b/docs/reference/ocm_bootstrap_componentversions_toi-bootstrapping.md
@@ -155,7 +155,7 @@ that contains the resource reference. It uses the following fields:
 #### *Identity*
 
 An identity specification is a <code>map[string]string</code>. It describes
-the identity attributes of a desired resource in a a component version.
+the identity attributes of a desired resource in a component version.
 It always has at least one identity attribute <code>name</code>, which
 is the resource name field of the desired resource. If this resource
 defines additional identity attributes, the complete set must be specified.
@@ -199,7 +199,7 @@ It has the following format:
   Here the executor may request the provisioning of some credentials with a
   dedicated name/purpose and structure. If specified it will be propagated
   to a using package. It this uses an own credentials section, this one 
-  will be filtered and checked for the the actual executor.
+  will be filtered and checked for the actual executor.
 
 - **<code>outputs</code>** (optional) *map[string]OutputSpecification*
 
@@ -277,7 +277,7 @@ execution and reading provided executor outputs after the execution.
 /
 └── toi
     ├── inputs
-    │   ├── config      config info from package specification
+    │   ├── config      configuration from package specification
     │   ├── ocmrepo     OCM filesystem repository containing the complete
     │   │               component version of the package
     │   └── parameters  merged complete parameter file

--- a/docs/reference/ocm_toi-bootstrapping.md
+++ b/docs/reference/ocm_toi-bootstrapping.md
@@ -155,7 +155,7 @@ that contains the resource reference. It uses the following fields:
 #### *Identity*
 
 An identity specification is a <code>map[string]string</code>. It describes
-the identity attributes of a desired resource in a a component version.
+the identity attributes of a desired resource in a component version.
 It always has at least one identity attribute <code>name</code>, which
 is the resource name field of the desired resource. If this resource
 defines additional identity attributes, the complete set must be specified.
@@ -199,7 +199,7 @@ It has the following format:
   Here the executor may request the provisioning of some credentials with a
   dedicated name/purpose and structure. If specified it will be propagated
   to a using package. It this uses an own credentials section, this one 
-  will be filtered and checked for the the actual executor.
+  will be filtered and checked for the actual executor.
 
 - **<code>outputs</code>** (optional) *map[string]OutputSpecification*
 
@@ -277,7 +277,7 @@ execution and reading provided executor outputs after the execution.
 /
 └── toi
     ├── inputs
-    │   ├── config      config info from package specification
+    │   ├── config      configuration from package specification
     │   ├── ocmrepo     OCM filesystem repository containing the complete
     │   │               component version of the package
     │   └── parameters  merged complete parameter file

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/google/go-github/v45 v45.2.0
 	github.com/klauspost/compress v1.14.4
 	github.com/klauspost/pgzip v1.2.5
-	github.com/mandelsoft/logging v0.0.0-20221114182501-5fdf2428e318
+	github.com/mandelsoft/logging v0.0.0-20221114215048-ab754b164dd6
 	github.com/mandelsoft/vfs v0.0.0-20220805210647-bf14a11bfe31
 	github.com/marstr/guid v1.1.0
 	github.com/mitchellh/copystructure v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/google/go-github/v45 v45.2.0
 	github.com/klauspost/compress v1.14.4
 	github.com/klauspost/pgzip v1.2.5
-	github.com/mandelsoft/logging v0.0.0-20221109072921-61e96e2ac9fd
+	github.com/mandelsoft/logging v0.0.0-20221114182501-5fdf2428e318
 	github.com/mandelsoft/vfs v0.0.0-20220805210647-bf14a11bfe31
 	github.com/marstr/guid v1.1.0
 	github.com/mitchellh/copystructure v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -816,8 +816,8 @@ github.com/mandelsoft/cobra v1.5.1-0.20221030110806-c236cde1e2bd/go.mod h1:IOw/A
 github.com/mandelsoft/filepath v0.0.0-20200909114706-3df73d378d55/go.mod h1:n4xEiUD2HNHnn2w5ZKF0qgjDecHVCWAl5DxZ7+pcFU8=
 github.com/mandelsoft/filepath v0.0.0-20220503095057-4432a2285b68 h1:99GWPlKVS110Cm+/YRVRaUJN5CpTeWFazWg2sXJdf70=
 github.com/mandelsoft/filepath v0.0.0-20220503095057-4432a2285b68/go.mod h1:n4xEiUD2HNHnn2w5ZKF0qgjDecHVCWAl5DxZ7+pcFU8=
-github.com/mandelsoft/logging v0.0.0-20221109072921-61e96e2ac9fd h1:YJ8lwCvIVueAduRGfWjWjtNfOWVTsMvSwrEfQzWL+1A=
-github.com/mandelsoft/logging v0.0.0-20221109072921-61e96e2ac9fd/go.mod h1:vxGpzOesdqLGRSWb4fz5DaH0ekJvkISst4qq6UZ2xFA=
+github.com/mandelsoft/logging v0.0.0-20221114182501-5fdf2428e318 h1:H0xy8mguUevQtUSQiXDEyZ5qTmQ/YriiJU7aedVYFLI=
+github.com/mandelsoft/logging v0.0.0-20221114182501-5fdf2428e318/go.mod h1:vxGpzOesdqLGRSWb4fz5DaH0ekJvkISst4qq6UZ2xFA=
 github.com/mandelsoft/pflag v0.0.0-20221103113840-a15b5f7fa89e h1:XW05FCl7x4ZLYL109cCqZbyF7vq5ihmOWIleT+luIr4=
 github.com/mandelsoft/pflag v0.0.0-20221103113840-a15b5f7fa89e/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/mandelsoft/spiff v1.7.0-beta-3 h1:AvZldpnctpyfQqtAA5uxokD5rlCK52mGAXxg7tnW5Ag=

--- a/go.sum
+++ b/go.sum
@@ -816,8 +816,8 @@ github.com/mandelsoft/cobra v1.5.1-0.20221030110806-c236cde1e2bd/go.mod h1:IOw/A
 github.com/mandelsoft/filepath v0.0.0-20200909114706-3df73d378d55/go.mod h1:n4xEiUD2HNHnn2w5ZKF0qgjDecHVCWAl5DxZ7+pcFU8=
 github.com/mandelsoft/filepath v0.0.0-20220503095057-4432a2285b68 h1:99GWPlKVS110Cm+/YRVRaUJN5CpTeWFazWg2sXJdf70=
 github.com/mandelsoft/filepath v0.0.0-20220503095057-4432a2285b68/go.mod h1:n4xEiUD2HNHnn2w5ZKF0qgjDecHVCWAl5DxZ7+pcFU8=
-github.com/mandelsoft/logging v0.0.0-20221114182501-5fdf2428e318 h1:H0xy8mguUevQtUSQiXDEyZ5qTmQ/YriiJU7aedVYFLI=
-github.com/mandelsoft/logging v0.0.0-20221114182501-5fdf2428e318/go.mod h1:vxGpzOesdqLGRSWb4fz5DaH0ekJvkISst4qq6UZ2xFA=
+github.com/mandelsoft/logging v0.0.0-20221114215048-ab754b164dd6 h1:xlUJPmMJo1IVQVn42ELLDUNY3sfwzKVp4kyuy7Q2QwI=
+github.com/mandelsoft/logging v0.0.0-20221114215048-ab754b164dd6/go.mod h1:vxGpzOesdqLGRSWb4fz5DaH0ekJvkISst4qq6UZ2xFA=
 github.com/mandelsoft/pflag v0.0.0-20221103113840-a15b5f7fa89e h1:XW05FCl7x4ZLYL109cCqZbyF7vq5ihmOWIleT+luIr4=
 github.com/mandelsoft/pflag v0.0.0-20221103113840-a15b5f7fa89e/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/mandelsoft/spiff v1.7.0-beta-3 h1:AvZldpnctpyfQqtAA5uxokD5rlCK52mGAXxg7tnW5Ag=

--- a/pkg/contexts/datacontext/config/logging/config_test.go
+++ b/pkg/contexts/datacontext/config/logging/config_test.go
@@ -28,6 +28,7 @@ var _ = Describe("logging configuration", func() {
 
 	BeforeEach(func() {
 		logging.SetDefaultContext(logging.NewDefault())
+		log.SetContext(nil)
 		ctx = datacontext.New(nil)
 		cfg = config.WithSharedAttributes(ctx).New()
 
@@ -42,9 +43,9 @@ var _ = Describe("logging configuration", func() {
 		LogTest(ctx)
 
 		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[3] info
-V[2] warn
-ERROR <nil> error
+V[3] ocm info
+V[2] ocm warn
+ERROR <nil> ocm error
 `))
 	})
 
@@ -53,10 +54,10 @@ ERROR <nil> error
 		LogTest(ctx)
 
 		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[4] debug
-V[3] info
-V[2] warn
-ERROR <nil> error
+V[4] ocm debug
+V[3] ocm info
+V[2] ocm warn
+ERROR <nil> ocm error
 `))
 	})
 
@@ -65,10 +66,10 @@ ERROR <nil> error
 		LogTest(cfg)
 
 		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[4] debug
-V[3] info
-V[2] warn
-ERROR <nil> error
+V[4] ocm debug
+V[3] ocm info
+V[2] ocm warn
+ERROR <nil> ocm error
 `))
 	})
 
@@ -87,14 +88,14 @@ settings:
 		LogTest(cfg, "cfg")
 
 		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[4] debug
-V[3] info
-V[2] warn
-ERROR <nil> error
-V[4] cfgdebug
-V[3] cfginfo
-V[2] cfgwarn
-ERROR <nil> cfgerror
+V[4] ocm debug
+V[3] ocm info
+V[2] ocm warn
+ERROR <nil> ocm error
+V[4] ocm cfgdebug
+V[3] ocm cfginfo
+V[2] ocm cfgwarn
+ERROR <nil> ocm cfgerror
 `))
 	})
 
@@ -113,14 +114,14 @@ settings:
 		LogTest(cfg, "cfg")
 
 		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[4] debug
-V[3] info
-V[2] warn
-ERROR <nil> error
-V[4] cfgdebug
-V[3] cfginfo
-V[2] cfgwarn
-ERROR <nil> cfgerror
+V[4] ocm debug
+V[3] ocm info
+V[2] ocm warn
+ERROR <nil> ocm error
+V[4] ocm cfgdebug
+V[3] ocm cfginfo
+V[2] ocm cfgwarn
+ERROR <nil> ocm cfgerror
 `))
 	})
 
@@ -140,13 +141,13 @@ settings:
 		LogTest(cfg, "cfg")
 
 		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[3] info
-V[2] warn
-ERROR <nil> error
-V[4] cfgdebug
-V[3] cfginfo
-V[2] cfgwarn
-ERROR <nil> cfgerror
+V[3] ocm info
+V[2] ocm warn
+ERROR <nil> ocm error
+V[4] ocm cfgdebug
+V[3] ocm cfginfo
+V[2] ocm cfgwarn
+ERROR <nil> ocm cfgerror
 `))
 	})
 
@@ -193,10 +194,10 @@ settings:
 			LogTest(ctx)
 
 			Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[4] debug
-V[3] info
-V[2] warn
-ERROR <nil> error
+V[4] ocm debug
+V[3] ocm info
+V[2] ocm warn
+ERROR <nil> ocm error
 `))
 		})
 
@@ -211,9 +212,9 @@ ERROR <nil> error
 			LogTest(ctx)
 
 			Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[3] info
-V[2] warn
-ERROR <nil> error
+V[3] ocm info
+V[2] ocm warn
+ERROR <nil> ocm error
 `))
 		})
 		It("re-applies config with extra id", func() {
@@ -227,10 +228,10 @@ ERROR <nil> error
 			LogTest(ctx)
 
 			Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[4] debug
-V[3] info
-V[2] warn
-ERROR <nil> error
+V[4] ocm debug
+V[3] ocm info
+V[2] ocm warn
+ERROR <nil> ocm error
 `))
 		})
 	})

--- a/pkg/contexts/oci/ociutils/handler.go
+++ b/pkg/contexts/oci/ociutils/handler.go
@@ -7,11 +7,12 @@ package ociutils
 import (
 	"sync"
 
+	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/cpi"
 )
 
 type InfoHandler interface {
-	Description(m cpi.ManifestAccess, config []byte) string
+	Description(pr common.Printer, m cpi.ManifestAccess, config []byte)
 	Info(m cpi.ManifestAccess, config []byte) interface{}
 }
 

--- a/pkg/contexts/oci/ociutils/info.go
+++ b/pkg/contexts/oci/ociutils/info.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/opencontainers/go-digest"
 	"sigs.k8s.io/yaml"
 
@@ -76,7 +77,9 @@ func GetManifestInfo(m cpi.ManifestAccess, layerFiles bool) *ArtefactInfo {
 	h := getHandler(man.Config.MediaType)
 
 	if h != nil {
-		cfg.Info = h.Description(m, config)
+		pr, buf := common.NewBufferedPrinter()
+		h.Description(pr, m, config)
+		cfg.Info = buf.String()
 	}
 	for _, l := range man.Layers {
 		blobinfo := &BlobInfo{

--- a/pkg/contexts/oci/ociutils/info.go
+++ b/pkg/contexts/oci/ociutils/info.go
@@ -11,10 +11,10 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/opencontainers/go-digest"
 	"sigs.k8s.io/yaml"
 
+	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/common/compression"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/artdesc"

--- a/pkg/contexts/oci/repositories/artefactset/utils_synthesis.go
+++ b/pkg/contexts/oci/repositories/artefactset/utils_synthesis.go
@@ -64,9 +64,11 @@ func SynthesizeArtefactBlob(ns cpi.NamespaceAccess, ref string) (ArtefactBlob, e
 	if err != nil {
 		return nil, GetArtifactError{Original: err, Ref: ref}
 	}
-
 	defer art.Close()
+	return SynthesizeArtefactBlobForArtefact(art, ref)
+}
 
+func SynthesizeArtefactBlobForArtefact(art cpi.ArtefactAccess, ref string) (ArtefactBlob, error) {
 	blob, err := art.Blob()
 	if err != nil {
 		return nil, err

--- a/pkg/contexts/oci/repositories/ctf/synthesis_test.go
+++ b/pkg/contexts/oci/repositories/ctf/synthesis_test.go
@@ -41,6 +41,10 @@ func (d *DummyMethod) GetKind() string {
 	return localblob.Type
 }
 
+func (d *DummyMethod) AccessSpec() cpi.AccessSpec {
+	return nil
+}
+
 func CheckBlob(blob accessio.BlobAccess) oci.NamespaceAccess {
 	set, err := artefactset.OpenFromBlob(accessobj.ACC_READONLY, blob)
 	Expect(err).To(Succeed())

--- a/pkg/contexts/oci/repositories/ocireg/namespace.go
+++ b/pkg/contexts/oci/repositories/ocireg/namespace.go
@@ -127,10 +127,13 @@ func (n *NamespaceContainer) GetBlobData(digest digest.Digest) (int64, cpi.DataA
 }
 
 func (n *NamespaceContainer) AddBlob(blob cpi.BlobAccess) error {
-	n.repo.ctx.Logger().Debug("adding blob", "digest", blob.Digest())
+	log := n.repo.ctx.Logger()
+	log.Debug("adding blob", "digest", blob.Digest())
 	if _, _, err := n.blobs.Get("").AddBlob(blob); err != nil {
+		log.Debug("adding blob failed", "digest", blob.Digest(), "error", err.Error())
 		return fmt.Errorf("unable to add blob: %w", err)
 	}
+	log.Debug("adding blob done", "digest", blob.Digest())
 	return nil
 }
 

--- a/pkg/contexts/oci/repositories/ocireg/namespace.go
+++ b/pkg/contexts/oci/repositories/ocireg/namespace.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 
 	"github.com/containerd/containerd/errdefs"
+	"github.com/opencontainers/go-digest"
+
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/common/accessobj"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/artdesc"
@@ -16,7 +18,6 @@ import (
 	"github.com/open-component-model/ocm/pkg/docker/resolve"
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/logging"
-	"github.com/opencontainers/go-digest"
 )
 
 type Namespace struct {
@@ -119,15 +120,14 @@ func (n *NamespaceContainer) GetBlobDescriptor(digest digest.Digest) *cpi.Descri
 }
 
 func (n *NamespaceContainer) GetBlobData(digest digest.Digest) (int64, cpi.DataAccess, error) {
-	n.repo.ctx.Logger().Info("getting blob", "digest", digest)
+	n.repo.ctx.Logger().Debug("getting blob", "digest", digest)
 	size, acc, err := n.blobs.Get("").GetBlobData(digest)
-	n.repo.ctx.Logger().Info("getting blob done", "digest", digest, "size", size, "error", logging.ErrorMessage(err))
+	n.repo.ctx.Logger().Debug("getting blob done", "digest", digest, "size", size, "error", logging.ErrorMessage(err))
 	return size, acc, err
-
 }
 
 func (n *NamespaceContainer) AddBlob(blob cpi.BlobAccess) error {
-	n.repo.ctx.Logger().Info("adding blob", "digest", blob.Digest())
+	n.repo.ctx.Logger().Debug("adding blob", "digest", blob.Digest())
 	if _, _, err := n.blobs.Get("").AddBlob(blob); err != nil {
 		return fmt.Errorf("unable to add blob: %w", err)
 	}
@@ -140,9 +140,9 @@ func (n *NamespaceContainer) ListTags() ([]string, error) {
 
 func (n *NamespaceContainer) GetArtefact(vers string) (cpi.ArtefactAccess, error) {
 	ref := n.repo.getRef(n.namespace, vers)
-	n.repo.ctx.Logger().Info("get artefact", "ref", ref)
+	n.repo.ctx.Logger().Debug("get artefact", "ref", ref)
 	_, desc, err := n.resolver.Resolve(context.Background(), ref)
-	n.repo.ctx.Logger().Info("done", "digest", desc.Digest, "size", desc.Size, "mimetype", desc.MediaType, "error", logging.ErrorMessage(err))
+	n.repo.ctx.Logger().Debug("done", "digest", desc.Digest, "size", desc.Size, "mimetype", desc.MediaType, "error", logging.ErrorMessage(err))
 	if err != nil {
 		if errdefs.IsNotFound(err) {
 			return nil, errors.ErrNotFound(cpi.KIND_OCIARTEFACT, ref, n.namespace)
@@ -164,7 +164,7 @@ func (n *NamespaceContainer) AddArtefact(artefact cpi.Artefact, tags ...string) 
 	if n.repo.info.Legacy {
 		blob = artdesc.MapArtefactBlobMimeType(blob, true)
 	}
-	n.repo.ctx.Logger().Info("adding artefact", "digest", blob.Digest(), "mimetype", blob.MimeType())
+	n.repo.ctx.Logger().Debug("adding artefact", "digest", blob.Digest(), "mimetype", blob.MimeType())
 	_, _, err = n.blobs.Get(blob.MimeType()).AddBlob(blob)
 	if err != nil {
 		return nil, err

--- a/pkg/contexts/oci/repositories/ocireg/repository.go
+++ b/pkg/contexts/oci/repositories/ocireg/repository.go
@@ -104,7 +104,6 @@ func (r *Repository) getCreds(comp string) (credentials.Credentials, error) {
 }
 
 func (r *Repository) getResolver(comp string) (resolve.Resolver, error) {
-	log := r.ctx.Logger()
 	creds, err := r.getCreds(comp)
 	if err != nil {
 		if !errors.IsErrUnknownKind(err, credentials.KIND_CONSUMER) {
@@ -116,14 +115,12 @@ func (r *Repository) getResolver(comp string) (resolve.Resolver, error) {
 		Hosts: docker.ConvertHosts(config.ConfigureHosts(context.Background(), config.HostOptions{
 			Credentials: func(host string) (string, string, error) {
 				if creds != nil {
-					log.Debug("************** creds **************", "host", host, "creds", creds)
 					p := creds.GetProperty(credentials.ATTR_IDENTITY_TOKEN)
 					if p == "" {
 						p = creds.GetProperty(credentials.ATTR_PASSWORD)
 					}
 					return creds.GetProperty(credentials.ATTR_USERNAME), p, err
 				}
-				log.Debug("************** no creds for host **************", "host", host)
 				return "", "", nil
 			},
 			DefaultScheme: r.info.Scheme,

--- a/pkg/contexts/oci/repositories/ocireg/utils.go
+++ b/pkg/contexts/oci/repositories/ocireg/utils.go
@@ -95,11 +95,11 @@ func pushData(ctx context.Context, p resolve.Pusher, desc artdesc.Descriptor, da
 		desc.Size = -1
 	}
 
-	logging.Logger().Info("*** push blob", "mediatype", desc.MediaType, "digest", desc.Digest, "key", key)
+	logging.Logger().Debug("*** push blob", "mediatype", desc.MediaType, "digest", desc.Digest, "key", key)
 	req, err := p.Push(ctx, desc, data)
 	if err != nil {
 		if errdefs.IsAlreadyExists(err) {
-			logging.Logger().Info("blob already exists", "mediatype", desc.MediaType, "digest", desc.Digest)
+			logging.Logger().Debug("blob already exists", "mediatype", desc.MediaType, "digest", desc.Digest)
 
 			return nil
 		}

--- a/pkg/contexts/oci/testhelper/manifests.go
+++ b/pkg/contexts/oci/testhelper/manifests.go
@@ -17,6 +17,7 @@ import (
 const (
 	OCINAMESPACE = "ocm/value"
 	OCIVERSION   = "v2.0"
+	OCILAYER     = "manifestlayer"
 )
 
 func OCIManifest1(env *builder.Builder) *artdesc.Descriptor {
@@ -28,7 +29,7 @@ func OCIManifest1(env *builder.Builder) *artdesc.Descriptor {
 				env.BlobStringData(mime.MIME_JSON, "{}")
 			})
 			ldesc = env.Layer(func() {
-				env.BlobStringData(mime.MIME_TEXT, "manifestlayer")
+				env.BlobStringData(mime.MIME_TEXT, OCILAYER)
 			})
 		})
 	})
@@ -48,7 +49,10 @@ func HashManifest1(fmt string) string {
 ////////////////////////////////////////////////////////////////////////////////
 // otherlayer
 
-const OCINAMESPACE2 = "ocm/ref"
+const (
+	OCINAMESPACE2 = "ocm/ref"
+	OCILAYER2     = "otherlayer"
+)
 
 func OCIManifest2(env *builder.Builder) *artdesc.Descriptor {
 	var ldesc *artdesc.Descriptor
@@ -59,7 +63,7 @@ func OCIManifest2(env *builder.Builder) *artdesc.Descriptor {
 				env.BlobStringData(mime.MIME_JSON, "{}")
 			})
 			ldesc = env.Layer(func() {
-				env.BlobStringData(mime.MIME_TEXT, "otherlayer")
+				env.BlobStringData(mime.MIME_TEXT, OCILAYER2)
 			})
 		})
 	})

--- a/pkg/contexts/oci/transfer/transfer.go
+++ b/pkg/contexts/oci/transfer/transfer.go
@@ -19,13 +19,13 @@ func TransferArtefact(art cpi.ArtefactAccess, set cpi.ArtefactSink, tags ...stri
 }
 
 func TransferIndex(art cpi.IndexAccess, set cpi.ArtefactSink, tags ...string) (err error) {
-	logging.Logger().Info("transfer OCI index", "digest", art.Digest())
+	logging.Logger().Debug("transfer OCI index", "digest", art.Digest())
 	defer func() {
-		logging.Logger().Info("transfer OCI index done", "error", logging.ErrorMessage(err))
+		logging.Logger().Debug("transfer OCI index done", "error", logging.ErrorMessage(err))
 	}()
 
 	for _, l := range art.GetDescriptor().Manifests {
-		logging.Logger().Info("indexed manifest", "digest", "digest", l.Digest, "size", l.Size)
+		logging.Logger().Debug("indexed manifest", "digest", "digest", l.Digest, "size", l.Size)
 		art, err := art.GetArtefact(l.Digest)
 		if err != nil {
 			return errors.Wrapf(err, "getting indexed artefact %s", l.Digest)
@@ -43,9 +43,9 @@ func TransferIndex(art cpi.IndexAccess, set cpi.ArtefactSink, tags ...string) (e
 }
 
 func TransferManifest(art cpi.ManifestAccess, set cpi.ArtefactSink, tags ...string) (err error) {
-	logging.Logger().Info("transfer OCI manifest", "digest", art.Digest())
+	logging.Logger().Debug("transfer OCI manifest", "digest", art.Digest())
 	defer func() {
-		logging.Logger().Info("transfer OCI manifest done", "error", logging.ErrorMessage(err))
+		logging.Logger().Debug("transfer OCI manifest done", "error", logging.ErrorMessage(err))
 	}()
 
 	blob, err := art.GetConfigBlob()
@@ -57,7 +57,7 @@ func TransferManifest(art cpi.ManifestAccess, set cpi.ArtefactSink, tags ...stri
 		return errors.Wrapf(err, "transferring config blob")
 	}
 	for i, l := range art.GetDescriptor().Layers {
-		logging.Logger().Info("layer", "digest", "digest", l.Digest, "size", l.Size, "index", i)
+		logging.Logger().Debug("layer", "digest", "digest", l.Digest, "size", l.Size, "index", i)
 		blob, err = art.GetBlob(l.Digest)
 		if err != nil {
 			return errors.Wrapf(err, "getting layer blob %s", l.Digest)

--- a/pkg/contexts/ocm/accessmethods/github/method.go
+++ b/pkg/contexts/ocm/accessmethods/github/method.go
@@ -254,6 +254,10 @@ func (m *accessMethod) MimeType() string {
 	return mime.MIME_TGZ
 }
 
+func (m *accessMethod) AccessSpec() cpi.AccessSpec {
+	return m.spec
+}
+
 func (m *accessMethod) Get() ([]byte, error) {
 	if err := m.setup(); err != nil {
 		return nil, err

--- a/pkg/contexts/ocm/accessmethods/none/method.go
+++ b/pkg/contexts/ocm/accessmethods/none/method.go
@@ -63,6 +63,10 @@ func (m *accessMethod) GetKind() string {
 	return Type
 }
 
+func (m *accessMethod) AccessSpec() cpi.AccessSpec {
+	return m.spec
+}
+
 func (m *accessMethod) Close() error {
 	return nil
 }

--- a/pkg/contexts/ocm/accessmethods/ociartefact/method.go
+++ b/pkg/contexts/ocm/accessmethods/ociartefact/method.go
@@ -21,6 +21,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/logging"
 	"github.com/open-component-model/ocm/pkg/runtime"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 // Type is the access type of a oci registry.
@@ -103,11 +104,18 @@ func (a *AccessSpec) AccessMethod(c cpi.ComponentVersionAccess) (cpi.AccessMetho
 
 ////////////////////////////////////////////////////////////////////////////////
 
+type AccessMethod = *accessMethod
+
 type accessMethod struct {
 	lock sync.Mutex
-	blob artefactset.ArtefactBlob
 	comp cpi.ComponentVersionAccess
 	spec *AccessSpec
+
+	finalizer utils.Finalizer
+	err       error
+	art       oci.ArtefactAccess
+	ref       *oci.RefSpec
+	blob      artefactset.ArtefactBlob
 }
 
 var (
@@ -126,15 +134,16 @@ func (m *accessMethod) GetKind() string {
 	return Type
 }
 
+func (m *accessMethod) AccessSpec() cpi.AccessSpec {
+	return m.spec
+}
+
 func (m *accessMethod) Close() error {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-	if m.blob != nil {
-		tmp := m.blob
-		m.blob = nil
-		return tmp.Close()
-	}
-	return nil
+
+	m.blob = nil
+	return m.finalizer.Finalize()
 }
 
 func (m *accessMethod) eval() (oci.Repository, *oci.RefSpec, error) {
@@ -151,21 +160,38 @@ func (m *accessMethod) eval() (oci.Repository, *oci.RefSpec, error) {
 	return repo, &ref, err
 }
 
-func (m *accessMethod) getArtefact() (oci.ArtefactAccess, error) {
+func (m *accessMethod) GetArtefact(finalizer *utils.Finalizer) (oci.ArtefactAccess, *oci.RefSpec, error) {
 	repo, ref, err := m.eval()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return repo.LookupArtefact(ref.Repository, ref.Version())
+	finalizer.Close(repo)
+	art, err := repo.LookupArtefact(ref.Repository, ref.Version())
+	return art, ref, err
+}
+
+func (m *accessMethod) getArtefact() (oci.ArtefactAccess, *oci.RefSpec, error) {
+	if m.art == nil && m.err == nil {
+		m.art, m.ref, m.err = m.GetArtefact(&m.finalizer)
+		if m.err == nil {
+			m.finalizer.Close(m.art)
+		}
+	}
+	return m.art, m.ref, m.err
 }
 
 func (m *accessMethod) Digest() digest.Digest {
-	art, err := m.getArtefact()
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	art, _, err := m.getArtefact()
 	if err == nil {
+		m.art = art
 		blob, err := art.Blob()
 		if err == nil {
 			return blob.Digest()
 		}
+		m.finalizer.Close(blob)
 	}
 	return ""
 }
@@ -192,7 +218,10 @@ func (m *accessMethod) Reader() (io.ReadCloser, error) {
 }
 
 func (m *accessMethod) MimeType() string {
-	art, err := m.getArtefact()
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	art, _, err := m.getArtefact()
 	if err != nil {
 		return ""
 	}
@@ -202,19 +231,17 @@ func (m *accessMethod) MimeType() string {
 func (m *accessMethod) getBlob() (artefactset.ArtefactBlob, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
+
 	if m.blob != nil {
 		return m.blob, nil
 	}
-	repo, ref, err := m.eval()
-	if err != nil {
-		return nil, err
-	}
-	ns, err := repo.LookupNamespace(ref.Repository)
+
+	art, ref, err := m.getArtefact()
 	if err != nil {
 		return nil, err
 	}
 	m.comp.GetContext().Logger().Info("synthesize artefact blob", "ref", m.spec.ImageReference)
-	m.blob, err = artefactset.SynthesizeArtefactBlob(ns, ref.Version())
+	m.blob, err = artefactset.SynthesizeArtefactBlobForArtefact(art, ref.Version())
 	m.comp.GetContext().Logger().Info("synthesize artefact blob done", "ref", m.spec.ImageReference, "error", logging.ErrorMessage(err))
 	if err != nil {
 		return nil, err

--- a/pkg/contexts/ocm/accessmethods/ociartefact/method.go
+++ b/pkg/contexts/ocm/accessmethods/ociartefact/method.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/open-component-model/ocm/pkg/logging"
 	"github.com/opencontainers/go-digest"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
@@ -20,6 +19,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/oci/repositories/artefactset"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/repositories/ocireg"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
+	"github.com/open-component-model/ocm/pkg/logging"
 	"github.com/open-component-model/ocm/pkg/runtime"
 )
 

--- a/pkg/contexts/ocm/accessmethods/ociartefact/method.go
+++ b/pkg/contexts/ocm/accessmethods/ociartefact/method.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/open-component-model/ocm/pkg/logging"
 	"github.com/opencontainers/go-digest"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
@@ -212,7 +213,9 @@ func (m *accessMethod) getBlob() (artefactset.ArtefactBlob, error) {
 	if err != nil {
 		return nil, err
 	}
+	m.comp.GetContext().Logger().Info("synthesize artefact blob", "ref", m.spec.ImageReference)
 	m.blob, err = artefactset.SynthesizeArtefactBlob(ns, ref.Version())
+	m.comp.GetContext().Logger().Info("synthesize artefact blob done", "ref", m.spec.ImageReference, "error", logging.ErrorMessage(err))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/contexts/ocm/accessmethods/ociblob/method.go
+++ b/pkg/contexts/ocm/accessmethods/ociblob/method.go
@@ -93,6 +93,10 @@ func (m *accessMethod) GetKind() string {
 	return Type
 }
 
+func (m *accessMethod) AccessSpec() cpi.AccessSpec {
+	return m.spec
+}
+
 func (m *accessMethod) Close() error {
 	m.lock.Lock()
 	defer m.lock.Unlock()

--- a/pkg/contexts/ocm/accessmethods/plugin/method.go
+++ b/pkg/contexts/ocm/accessmethods/plugin/method.go
@@ -82,6 +82,10 @@ func (m *accessMethod) GetKind() string {
 	return m.spec.GetKind()
 }
 
+func (m *accessMethod) AccessSpec() cpi.AccessSpec {
+	return m.spec
+}
+
 func (m *accessMethod) Close() error {
 	m.lock.Lock()
 	defer m.lock.Unlock()

--- a/pkg/contexts/ocm/accessmethods/s3/method.go
+++ b/pkg/contexts/ocm/accessmethods/s3/method.go
@@ -165,3 +165,7 @@ func getCreds(a *AccessSpec, cctx credentials.Context) (credentials.Credentials,
 func (m *accessMethod) GetKind() string {
 	return Type
 }
+
+func (m *accessMethod) AccessSpec() cpi.AccessSpec {
+	return m.spec
+}

--- a/pkg/contexts/ocm/blobhandler/generic/plugin/blobhandler.go
+++ b/pkg/contexts/ocm/blobhandler/generic/plugin/blobhandler.go
@@ -68,6 +68,15 @@ func (b *pluginHandler) StoreBlob(blob cpi.BlobAccess, artType, hint string, glo
 		}
 	}
 
+	cpi.BlobHandlerLogger(ctx.GetContext()).Debug("plugin blob handler",
+		"plugin", b.plugin.Name(),
+		"uploader", b.name,
+		"arttype", artType,
+		"mediatype", blob.MimeType(),
+		"hint", hint,
+		"target", string(target),
+	)
+
 	var creddata json.RawMessage
 	if creds != nil {
 		creddata, err = json.Marshal(creds.Properties())

--- a/pkg/contexts/ocm/blobhandler/oci/ocirepo/handler_test.go
+++ b/pkg/contexts/ocm/blobhandler/oci/ocirepo/handler_test.go
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ocirepo_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/open-component-model/ocm/pkg/contexts/oci/testhelper"
+	. "github.com/open-component-model/ocm/pkg/env"
+	. "github.com/open-component-model/ocm/pkg/env/builder"
+	. "github.com/open-component-model/ocm/pkg/testutils"
+
+	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/common/accessobj"
+	"github.com/open-component-model/ocm/pkg/contexts/oci"
+	"github.com/open-component-model/ocm/pkg/contexts/oci/artdesc"
+	ocictf "github.com/open-component-model/ocm/pkg/contexts/oci/repositories/ctf"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/ociartefact"
+	storagecontext "github.com/open-component-model/ocm/pkg/contexts/ocm/blobhandler/oci"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/blobhandler/oci/ocirepo"
+	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/ctf"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/genericocireg"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/resourcetypes"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/transfer"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/transfer/transferhandler/standard"
+	"github.com/open-component-model/ocm/pkg/mime"
+)
+
+const ARCH = "/tmp/ctf"
+const ARCH2 = "/tmp/ctf2"
+const PROVIDER = "mandelsoft"
+const VERSION = "v1"
+const COMPONENT = "github.com/mandelsoft/test"
+const COMPONENT2 = "github.com/mandelsoft/test2"
+const OUT = "/tmp/res"
+const OCIPATH = "/tmp/oci"
+const OCIHOST = "alias"
+
+func FakeOCIRegBaseFunction(ctx *storagecontext.StorageContext) string {
+	return "baseurl.io"
+}
+
+var _ = Describe("oci artefact transfer", func() {
+	var env *Builder
+	var ldesc *artdesc.Descriptor
+
+	BeforeEach(func() {
+		env = NewBuilder(NewEnvironment())
+
+		env.OCICommonTransport(OCIPATH, accessio.FormatDirectory, func() {
+			ldesc = OCIManifest1(env)
+		})
+
+		env.OCMCommonTransport(ARCH, accessio.FormatDirectory, func() {
+			env.Component(COMPONENT, func() {
+				env.Version(VERSION, func() {
+					env.Provider(PROVIDER)
+					env.Resource("testdata", "", "PlainText", metav1.LocalRelation, func() {
+						env.BlobStringData(mime.MIME_TEXT, "testdata")
+					})
+					env.Resource("artefact", "", resourcetypes.OCI_IMAGE, metav1.LocalRelation, func() {
+						env.Access(
+							ociartefact.New(oci.StandardOCIRef(OCIHOST+".alias", OCINAMESPACE, OCIVERSION)),
+						)
+					})
+				})
+			})
+		})
+
+		FakeOCIRepo(env, OCIPATH, OCIHOST)
+
+		_ = ldesc
+	})
+
+	AfterEach(func() {
+		env.Cleanup()
+	})
+
+	It("it should copy a resource by value to a ctf file", func() {
+
+		env.OCMContext().BlobHandlers().Register(ocirepo.NewArtefactHandler(FakeOCIRegBaseFunction),
+			cpi.ForRepo(oci.CONTEXT_TYPE, ocictf.Type), cpi.ForMimeType(artdesc.ToContentMediaType(artdesc.MediaTypeImageManifest)))
+
+		src := Must(ctf.Open(env.OCMContext(), accessobj.ACC_READONLY, ARCH, 0, env))
+		cv := Must(src.LookupComponentVersion(COMPONENT, VERSION))
+		tgt := Must(ctf.Create(env.OCMContext(), accessobj.ACC_WRITABLE|accessobj.ACC_CREATE, OUT, 0700, accessio.FormatDirectory, env))
+		defer tgt.Close()
+
+		opts := &standard.Options{}
+		opts.SetResourcesByValue(true)
+		handler := standard.NewDefaultHandler(opts)
+
+		MustBeSuccessful(transfer.TransferVersion(nil, nil, cv, tgt, handler))
+		Expect(env.DirExists(OUT)).To(BeTrue())
+
+		list := Must(tgt.ComponentLister().GetComponents("", true))
+		Expect(list).To(Equal([]string{COMPONENT}))
+		comp := Must(tgt.LookupComponentVersion(COMPONENT, VERSION))
+		Expect(len(comp.GetDescriptor().Resources)).To(Equal(2))
+		data := Must(json.Marshal(comp.GetDescriptor().Resources[1].Access))
+
+		fmt.Printf("%s\n", string(data))
+		Expect(string(data)).To(StringEqualWithContext("{\"imageReference\":\"baseurl.io/ocm/value:v2.0\",\"type\":\"ociArtefact\"}"))
+
+		ocirepo := tgt.(genericocireg.OCIBasedRepository).OCIRepository()
+
+		art := Must(ocirepo.LookupArtefact(OCINAMESPACE, OCIVERSION))
+		defer Close(art, "artefact")
+
+		man := MustBeNonNil(art.ManifestAccess())
+		Expect(len(man.GetDescriptor().Layers)).To(Equal(1))
+		Expect(man.GetDescriptor().Layers[0].Digest).To(Equal(ldesc.Digest))
+
+		blob := Must(man.GetBlob(ldesc.Digest))
+		data = Must(blob.Get())
+		Expect(string(data)).To(Equal(OCILAYER))
+	})
+})

--- a/pkg/contexts/ocm/blobhandler/oci/ocirepo/suite_test.go
+++ b/pkg/contexts/ocm/blobhandler/oci/ocirepo/suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ocirepo_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OCIRegistry Blob Handler Test Suite")
+}

--- a/pkg/contexts/ocm/blobhandler/ocm/comparch/blobhandler_test.go
+++ b/pkg/contexts/ocm/blobhandler/ocm/comparch/blobhandler_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/mandelsoft/logging"
 	"github.com/mandelsoft/vfs/pkg/vfs"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
@@ -29,8 +28,6 @@ import (
 const ARCHIVE = "archive"
 
 var _ = Describe("blobhandler", func() {
-	log := logging.DefaultContext().Logger()
-
 	Context("regular", func() {
 		var b *builder.Builder
 
@@ -56,7 +53,6 @@ var _ = Describe("blobhandler", func() {
 
 			data, err = json.Marshal(cd.Resources[0].Access)
 			Expect(err).To(Succeed())
-			log.Info("marshal result", "data", string(data))
 			found := &localblob.AccessSpec{}
 			Expect(json.Unmarshal(data, found)).To(Succeed())
 
@@ -91,7 +87,6 @@ var _ = Describe("blobhandler", func() {
 
 			data, err = json.Marshal(cd.Resources[0].Access)
 			Expect(err).To(Succeed())
-			log.Info("marshal result", "data", string(data))
 			found := &localfsblob.AccessSpec{}
 			Expect(json.Unmarshal(data, found)).To(Succeed())
 

--- a/pkg/contexts/ocm/cpi/interface.go
+++ b/pkg/contexts/ocm/cpi/interface.go
@@ -7,6 +7,8 @@ package cpi
 // This is the Context Provider Interface for credential providers
 
 import (
+	"github.com/mandelsoft/logging"
+
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/internal"
 	"github.com/open-component-model/ocm/pkg/runtime"
 )
@@ -14,6 +16,17 @@ import (
 const CONTEXT_TYPE = internal.CONTEXT_TYPE
 
 const CommonTransportFormat = internal.CommonTransportFormat
+
+var TAG_BLOBHANDLER = logging.NewTag("blobhandler")
+
+func BlobHandlerLogger(ctx Context, messageContext ...logging.MessageContext) logging.Logger {
+	if len(messageContext) > 0 {
+		messageContext = append(append(messageContext[:0:0], messageContext...), TAG_BLOBHANDLER)
+		return ctx.Logger(messageContext...)
+	} else {
+		return ctx.Logger(TAG_BLOBHANDLER)
+	}
+}
 
 type (
 	Context                          = internal.Context

--- a/pkg/contexts/ocm/cpi/support/compversaccess.go
+++ b/pkg/contexts/ocm/cpi/support/compversaccess.go
@@ -336,6 +336,7 @@ func (c *componentVersionAccessImpl) SetSource(meta *cpi.SourceMeta, acc compdes
 
 // AddResource adds a blob resource to the current archive.
 func (c *componentVersionAccessImpl) SetResourceBlob(meta *cpi.ResourceMeta, blob cpi.BlobAccess, refName string, global cpi.AccessSpec) error {
+	c.GetContext().Logger().Info("adding resource blob", "resource", meta.Name)
 	acc, err := c.AddBlob(blob, meta.Type, refName, global)
 	if err != nil {
 		return fmt.Errorf("unable to add blob: %w", err)
@@ -349,6 +350,7 @@ func (c *componentVersionAccessImpl) SetResourceBlob(meta *cpi.ResourceMeta, blo
 }
 
 func (c *componentVersionAccessImpl) SetSourceBlob(meta *cpi.SourceMeta, blob cpi.BlobAccess, refName string, global cpi.AccessSpec) error {
+	c.GetContext().Logger().Info("adding source blob", "source", meta.Name)
 	acc, err := c.AddBlob(blob, meta.Type, refName, global)
 	if err != nil {
 		return fmt.Errorf("unable to add blob: %w", err)

--- a/pkg/contexts/ocm/internal/accesstypes.go
+++ b/pkg/contexts/ocm/internal/accesstypes.go
@@ -51,15 +51,17 @@ type HintProvider interface {
 	GetReferenceHint(cv ComponentVersionAccess) string
 }
 
-// AccessMethod described the access to a dedicate resource
+// AccessMethod described the access to a dedicated resource
 // It can allocate external resources, which should be released
 // with the Close() call.
 // Resources SHOULD only be allocated, if the content is accessed
 // via the DataAccess interface to avoid unnecessary effort
 // if the method object is just used to access meta data.
 type AccessMethod interface {
-	GetKind() string
 	DataAccess
+
+	GetKind() string
+	AccessSpec() AccessSpec
 	MimeType
 	Close() error
 }

--- a/pkg/contexts/ocm/internal/digesthandler_test.go
+++ b/pkg/contexts/ocm/internal/digesthandler_test.go
@@ -104,6 +104,10 @@ func (a AccessMethod) GetKind() string {
 	return "demo"
 }
 
+func (a AccessMethod) AccessSpec() internal.AccessSpec {
+	return nil
+}
+
 func (a AccessMethod) Get() ([]byte, error) {
 	return nil, nil
 }

--- a/pkg/contexts/ocm/plugin/plugin.go
+++ b/pkg/contexts/ocm/plugin/plugin.go
@@ -189,5 +189,10 @@ func (p *pluginImpl) Download(name string, r io.Reader, artType, mimeType, targe
 }
 
 func (p *pluginImpl) Exec(r io.Reader, w io.Writer, args ...string) ([]byte, error) {
+	if len(p.config) == 0 {
+		p.ctx.Logger(TAG).Debug("execute plugin action", "path", p.Path(), "args", args)
+	} else {
+		p.ctx.Logger(TAG).Debug("execute plugin action", "path", p.Path(), "args", args, "config", p.config)
+	}
 	return cache.Exec(p.Path(), p.config, r, w, args...)
 }

--- a/pkg/contexts/ocm/plugin/plugins/plugins.go
+++ b/pkg/contexts/ocm/plugin/plugins/plugins.go
@@ -53,7 +53,7 @@ func New(ctx ocm.Context, path string) Set {
 func (pi *pluginsImpl) Update() {
 	err := pi.updater.Update()
 	if err != nil {
-		pi.ctx.Logger(internal.TAG).Error("config update failed", "error", err)
+		pi.ctx.Logger(internal.TAG).Error("config update failed", "error", err.Error())
 	}
 }
 

--- a/pkg/contexts/ocm/plugin/plugins/plugins.go
+++ b/pkg/contexts/ocm/plugin/plugins/plugins.go
@@ -104,7 +104,7 @@ func (pi *pluginsImpl) RegisterExtensions() error {
 			if m.Version != "" {
 				name = name + runtime.VersionSeparator + m.Version
 			}
-			pi.ctx.Logger(internal.TAG).Info("registering access method",
+			pi.ctx.Logger(internal.TAG).Debug("registering access method",
 				"plugin", p.Name(),
 				"type", name)
 			pi.ctx.AccessMethods().Register(name, access.NewType(name, p, &m))
@@ -117,7 +117,7 @@ func (pi *pluginsImpl) RegisterExtensions() error {
 					if err != nil {
 						pi.ctx.Logger(internal.TAG).Error("cannot create blob handler fpr plugin", "plugin", p.Name(), "handler", u.Name)
 					} else {
-						pi.ctx.Logger(internal.TAG).Info("registering repository blob handler",
+						pi.ctx.Logger(internal.TAG).Debug("registering repository blob handler",
 							"context", c.ContextType+":"+c.RepositoryType,
 							"plugin", p.Name(),
 							"handler", u.Name)

--- a/pkg/contexts/ocm/repositories/comparch/accessmethod_localfs.go
+++ b/pkg/contexts/ocm/repositories/comparch/accessmethod_localfs.go
@@ -30,6 +30,10 @@ func newLocalFilesystemBlobAccessMethod(a *localblob.AccessSpec, base support.Co
 	}, nil
 }
 
+func (m *localFilesystemBlobAccessMethod) AccessSpec() cpi.AccessSpec {
+	return m.spec
+}
+
 func (m *localFilesystemBlobAccessMethod) GetKind() string {
 	return localblob.Type
 }

--- a/pkg/contexts/ocm/repositories/genericocireg/accessmethod_localblob.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/accessmethod_localblob.go
@@ -40,6 +40,10 @@ func (m *localBlobAccessMethod) GetKind() string {
 	return localblob.Type
 }
 
+func (m *localBlobAccessMethod) AccessSpec() cpi.AccessSpec {
+	return m.spec
+}
+
 func (m *localBlobAccessMethod) Close() error {
 	m.lock.Lock()
 	defer m.lock.Unlock()

--- a/pkg/contexts/ocm/repositories/genericocireg/accessmethod_localoclblob.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/accessmethod_localoclblob.go
@@ -34,6 +34,10 @@ func (m *localOCIBlobAccessMethod) GetKind() string {
 	return localociblob.Type
 }
 
+func (m *localOCIBlobAccessMethod) AccessSpec() cpi.AccessSpec {
+	return m.spec
+}
+
 func (m *localOCIBlobAccessMethod) Close() error {
 	m.lock.Lock()
 	defer m.lock.Unlock()

--- a/pkg/contexts/ocm/repositories/genericocireg/info.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/info.go
@@ -7,6 +7,7 @@ package genericocireg
 import (
 	"encoding/json"
 
+	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/ociutils"
@@ -47,25 +48,28 @@ func (h handler) Info(m cpi.ManifestAccess, config []byte) interface{} {
 	return info
 }
 
-func (h handler) Description(m cpi.ManifestAccess, config []byte) string {
-	s := "component version:\n"
+func (h handler) Description(pr common.Printer, m cpi.ManifestAccess, config []byte) {
+	pr.Printf("component version:\n")
 	acc := NewStateAccess(m)
 	data, err := accessio.BlobData(acc.Get())
 	if err != nil {
-		return s + "  cannot read component descriptor: " + err.Error()
+		pr.Printf("  cannot read component descriptor: %s\n", err.Error())
+		return
 	}
-	s += "  descriptor:\n"
+	pr.Printf("  descriptor:\n")
 	var raw interface{}
 	err = runtime.DefaultYAMLEncoding.Unmarshal(data, &raw)
 	if err != nil {
-		s += "    " + string(data)
-		return s + "  cannot get unmarshal component descriptor: " + err.Error()
+		pr.Printf("    data: %s\n", string(data))
+		pr.Printf("  cannot get unmarshal component descriptor: %s\n", err.Error())
+		return
 	}
 
 	form, err := json.MarshalIndent(raw, "  ", "    ")
 	if err != nil {
-		s += "    " + string(data)
-		return s + "  cannot get marshal component descriptor: " + err.Error()
+		pr.Printf("    data: %s\n", string(data))
+		pr.Printf("  cannot get marshal component descriptor: %s\n", err.Error())
+		return
 	}
-	return s + string(form)
+	pr.Printf("%s\n", string(form))
 }

--- a/pkg/contexts/ocm/repositories/genericocireg/repository.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/repository.go
@@ -13,10 +13,16 @@ import (
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/contexts/oci"
+	ocicpi "github.com/open-component-model/ocm/pkg/contexts/oci/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/genericocireg/componentmapping"
 	"github.com/open-component-model/ocm/pkg/errors"
 )
+
+type OCIBasedRepository interface {
+	cpi.Repository
+	OCIRepository() ocicpi.Repository
+}
 
 type Repository struct {
 	view accessio.CloserView
@@ -39,7 +45,7 @@ type RepositoryImpl struct {
 	ocirepo oci.Repository
 }
 
-var _ cpi.Repository = (*Repository)(nil)
+var _ OCIBasedRepository = (*Repository)(nil)
 
 func NewRepository(ctx cpi.Context, meta *ComponentRepositoryMeta, ocirepo oci.Repository) (cpi.Repository, error) {
 	repo := &RepositoryImpl{
@@ -65,6 +71,10 @@ func (r *RepositoryImpl) Close() error {
 
 func (r *RepositoryImpl) GetContext() cpi.Context {
 	return r.ctx
+}
+
+func (r *RepositoryImpl) OCIRepository() ocicpi.Repository {
+	return r.ocirepo
 }
 
 func (r *RepositoryImpl) GetSpecification() cpi.RepositorySpec {

--- a/pkg/contexts/ocm/transfer/transfer.go
+++ b/pkg/contexts/ocm/transfer/transfer.go
@@ -5,6 +5,9 @@
 package transfer
 
 import (
+	"fmt"
+
+	"github.com/mandelsoft/logging"
 	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
@@ -26,15 +29,18 @@ func TransferVersion(printer common.Printer, closure TransportClosure, src ocmcp
 		printer = common.NewPrinter(nil)
 	}
 	state := common.WalkingState{Closure: closure}
-	return transferVersion(printer, state, src, tgt, handler)
+	return transferVersion(printer, Logger(src), state, src, tgt, handler)
 }
 
-func transferVersion(printer common.Printer, state common.WalkingState, src ocmcpi.ComponentVersionAccess, tgt ocmcpi.Repository, handler transferhandler.TransferHandler) error {
+func transferVersion(printer common.Printer, log logging.Logger, state common.WalkingState, src ocmcpi.ComponentVersionAccess, tgt ocmcpi.Repository, handler transferhandler.TransferHandler) error {
+	log = log.WithValues("history", state.History.String())
 	nv := common.VersionedElementKey(src)
 	if ok, err := state.Add(ocm.KIND_COMPONENTVERSION, nv); !ok {
 		return err
 	}
+	log = log.WithValues("version", nv)
 	printer.Printf("transferring version %q...\n", nv)
+	log.Info("transferring version", "version", nv)
 	if handler == nil {
 		var err error
 		handler, err = standard.New(standard.Overwrite())
@@ -70,19 +76,20 @@ func transferVersion(printer common.Printer, state common.WalkingState, src ocmc
 		return errors.Wrapf(err, "%s: creating target version", state.History)
 	}
 
-	err = CopyVersion(printer, state.History, src, t, handler)
+	err = CopyVersion(printer, log, state.History, src, t, handler)
 	if err != nil {
 		return err
 	}
 	subp := printer.AddGap("  ")
 	list := errors.ErrListf("component references for %s", nv)
+	log.Info("  transferring references", "version", nv)
 	for _, r := range d.References {
 		cv, shdlr, err := handler.TransferVersion(src.Repository(), src, &r)
 		if err != nil {
 			return errors.Wrapf(err, "%s: nested component %s[%s:%s]", state.History, r.GetName(), r.ComponentName, r.GetVersion())
 		}
 		if cv != nil {
-			list.Add(transferVersion(subp, state, cv, tgt, shdlr))
+			list.Add(transferVersion(subp, log.WithValues("ref", r.Name), state, cv, tgt, shdlr))
 			cv.Close()
 		}
 	}
@@ -100,10 +107,11 @@ func transferVersion(printer common.Printer, state common.WalkingState, src ocmc
 	}
 	cd.Signatures = src.GetDescriptor().Signatures.Copy()
 	printer.Printf("...adding component version...\n")
+	LogInfo(src, "  adding component version", "version", nv)
 	return list.Add(comp.AddVersion(t)).Result()
 }
 
-func CopyVersion(printer common.Printer, hist common.History, src ocm.ComponentVersionAccess, t ocm.ComponentVersionAccess, handler transferhandler.TransferHandler) error {
+func CopyVersion(printer common.Printer, log logging.Logger, hist common.History, src ocm.ComponentVersionAccess, t ocm.ComponentVersionAccess, handler transferhandler.TransferHandler) error {
 	if handler == nil {
 		handler = standard.NewDefaultHandler(nil)
 	}
@@ -124,7 +132,7 @@ func CopyVersion(printer common.Printer, hist common.History, src ocm.ComponentV
 				}
 				if ok {
 					hint := ocmcpi.ArtefactNameHint(a, src)
-					printArtefactInfo(printer, "resource", i, hint)
+					printArtefactInfo(printer, log, "resource", i, hint)
 					err = handler.HandleTransferResource(r, m, hint, t)
 				}
 			}
@@ -151,7 +159,7 @@ func CopyVersion(printer common.Printer, hist common.History, src ocm.ComponentV
 				}
 				if ok {
 					hint := ocmcpi.ArtefactNameHint(a, src)
-					printArtefactInfo(printer, "source", i, hint)
+					printArtefactInfo(printer, log, "source", i, hint)
 					err = handler.HandleTransferSource(r, m, hint, t)
 				}
 			}
@@ -166,12 +174,17 @@ func CopyVersion(printer common.Printer, hist common.History, src ocm.ComponentV
 	return nil
 }
 
-func printArtefactInfo(printer common.Printer, kind string, index int, hint string) {
+func printArtefactInfo(printer common.Printer, log logging.Logger, kind string, index int, hint string) {
 	if printer != nil {
 		if hint != "" {
-			printer.Printf("...resource %d(%s)...\n", index, hint)
+			printer.Printf("...%s %d(%s)...\n", kind, index, hint)
 		} else {
-			printer.Printf("...resource %d...\n", index)
+			printer.Printf("...%s %d...\n", kind, index)
 		}
+	}
+	if hint != "" {
+		log.Info(fmt.Sprintf("handle %s", kind), kind, fmt.Sprintf("%d(%s)", index, hint))
+	} else {
+		log.Info(fmt.Sprintf("handle %s", kind), kind, fmt.Sprintf("%d", index))
 	}
 }

--- a/pkg/contexts/ocm/transfer/utils.go
+++ b/pkg/contexts/ocm/transfer/utils.go
@@ -6,6 +6,7 @@ package transfer
 
 import (
 	"github.com/mandelsoft/logging"
+
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 )
 

--- a/pkg/contexts/ocm/transfer/utils.go
+++ b/pkg/contexts/ocm/transfer/utils.go
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package transfer
+
+import (
+	"github.com/mandelsoft/logging"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm"
+)
+
+var TAG = logging.NewTag("transfer")
+
+type ContextProvider interface {
+	GetContext() ocm.Context
+}
+
+func LogInfo(c ContextProvider, msg string, keyValuePairs ...interface{}) {
+	c.GetContext().Logger(TAG).Info(msg, keyValuePairs...)
+}
+
+func Logger(c ContextProvider, keyValuePairs ...interface{}) logging.Logger {
+	return c.GetContext().Logger(TAG).WithValues(keyValuePairs...)
+}

--- a/pkg/generics/conditional.go
+++ b/pkg/generics/conditional.go
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package generics
+
+func Conditional[T any](cond bool, a, b T) T {
+	if cond {
+		return a
+	}
+	return b
+}

--- a/pkg/logging/config_test.go
+++ b/pkg/logging/config_test.go
@@ -37,9 +37,9 @@ var _ = Describe("logging configuration", func() {
 	It("just logs with defaults", func() {
 		LogTest(ctx)
 		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[3] info
-V[2] warn
-ERROR <nil> error
+V[3] ocm info
+V[2] ocm warn
+ERROR <nil> ocm error
 `))
 	})
 	It("just logs with config", func() {
@@ -53,10 +53,10 @@ ERROR <nil> error
 		Expect(local.Configure(cfg)).To(Succeed())
 		LogTest(ctx)
 		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[4] debug
-V[3] info
-V[2] warn
-ERROR <nil> error
+V[4] ocm debug
+V[3] ocm info
+V[2] ocm warn
+ERROR <nil> ocm error
 `))
 	})
 

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -15,6 +15,11 @@ import (
 	"github.com/open-component-model/ocm/pkg/errors"
 )
 
+// REALM is used to tag all logging done by this library with the ocm tag.
+// This is also used as message context to configure settings for all
+// log output provided by this library.
+var REALM = logging.NewRealm("ocm")
+
 type StaticContext struct {
 	logging.Context
 	applied map[string]struct{}
@@ -26,7 +31,7 @@ func NewContext(ctx logging.Context) *StaticContext {
 		ctx = logging.DefaultContext()
 	}
 	return &StaticContext{
-		Context: ctx,
+		Context: ctx.WithContext(REALM),
 		applied: map[string]struct{}{},
 	}
 }

--- a/pkg/logging/utils.go
+++ b/pkg/logging/utils.go
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package logging
+
+func ErrorMessage(err error) *string {
+	if err == nil {
+		return nil
+	}
+	m := err.Error()
+	return &m
+}

--- a/pkg/runtime/unstructured_test.go
+++ b/pkg/runtime/unstructured_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mandelsoft/logging"
 
+	ocmlog "github.com/open-component-model/ocm/pkg/logging"
 	"github.com/open-component-model/ocm/pkg/runtime"
 )
 
@@ -46,7 +47,7 @@ func InOut(log logging.Logger, in runtime.TypedObject, encoding runtime.Encoding
 
 var _ = Describe("*** unstructured", func() {
 	result := "{\"type\":\"test\"}"
-	log := logging.DefaultContext().Logger()
+	log := ocmlog.Logger()
 
 	It("unmarshal simple unstructured", func() {
 		un := runtime.NewEmptyUnstructured("test")

--- a/pkg/testutils/utils.go
+++ b/pkg/testutils/utils.go
@@ -31,6 +31,11 @@ func Must[T any](o T, err error) T {
 	return o
 }
 
+func MustBeNonNil[T any](o T) T {
+	ExpectWithOffset(1, o).NotTo(BeNil())
+	return o
+}
+
 func MustBeSuccessful(err error) {
 	ExpectWithOffset(1, err).To(Succeed())
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -115,7 +115,7 @@ func RandomString(n int) string {
 			value = int(v.Int64())
 		} else {
 			// insecure fallback to provide a valid result
-			ocmlog.Logger().Error("failed to generate random number", "error", err)
+			ocmlog.Logger().Error("failed to generate random number", "error", err.Error())
 			value = rand.Intn(len(chars)) //nolint: gosec // only used as fallback
 		}
 		b[i] = chars[value]


### PR DESCRIPTION
**What this PR does / why we need it**:

If an oci artifact referenced from an OCI registry  is transported by-value it is always
converted into an artifact archive. If the artifact is a multi-arch artifact, this archive can 
be quite large.

For a copy into an OCI based OCM repository, it is possible to by-pass the archive
creation and to directly use the oci transfer to the target repository.

**Which issue(s) this PR fixes**:
Fixes #188

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
