### PR TITLE
support for download of executables with appropriate platform

### DIFF
--- a/cmds/ocm/commands/ocmcmds/common/cmds/signing/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/common/cmds/signing/cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/lookupoption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/repooption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/signoption"
+	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/versionconstraintsoption"
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/output"
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/utils"
 	"github.com/open-component-model/ocm/pkg/common"
@@ -49,7 +50,7 @@ func newOperation(op string, sign bool, terms []string, example string) *spec {
 // NewCommand creates a new ctf command.
 func NewCommand(ctx clictx.Context, op string, sign bool, terms []string, example string, names ...string) *cobra.Command {
 	spec := newOperation(op, sign, terms, example)
-	return utils.SetupCommand(&SignatureCommand{spec: spec, BaseCommand: utils.NewBaseCommand(ctx, repooption.New(), signoption.New(sign), lookupoption.New())}, names...)
+	return utils.SetupCommand(&SignatureCommand{spec: spec, BaseCommand: utils.NewBaseCommand(ctx, versionconstraintsoption.New(), repooption.New(), signoption.New(sign), lookupoption.New())}, names...)
 }
 
 func (o *SignatureCommand) ForName(name string) *cobra.Command {
@@ -82,7 +83,7 @@ func (o *SignatureCommand) Run() error {
 	sign := signoption.From(o)
 	repo := repooption.From(o).Repository
 	lookup := lookupoption.From(o)
-	handler := comphdlr.NewTypeHandler(o.Context.OCM(), session, repo)
+	handler := comphdlr.NewTypeHandler(o.Context.OCM(), session, repo, comphdlr.OptionsFor(o))
 	sopts := signing.NewOptions(sign, signing.Resolver(repo, lookup.Resolver))
 	err = sopts.Complete(signingattr.Get(o.Context.OCMContext()))
 	if err != nil {

--- a/cmds/ocm/commands/ocmcmds/common/handlers/comphdlr/options.go
+++ b/cmds/ocm/commands/ocmcmds/common/handlers/comphdlr/options.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package comphdlr
+
+import (
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/versionconstraintsoption"
+	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
+	"github.com/open-component-model/ocm/pkg/utils"
+)
+
+type Option interface {
+	ApplyToCompHandler(handler *TypeHandler)
+}
+
+type Options []Option
+
+func (o Options) ApplyToCompHandler(handler *TypeHandler) {
+	for _, e := range o {
+		e.ApplyToCompHandler(handler)
+	}
+}
+
+func OptionsFor(o options.OptionSetProvider) Options {
+	var hopts []Option
+	if constr := versionconstraintsoption.From(o); constr != nil {
+		if len(constr.Constraints) > 0 {
+			hopts = append(hopts, WithVersionConstraints(constr.Constraints))
+		}
+		if constr.Latest {
+			hopts = append(hopts, LatestOnly())
+		}
+	}
+	return hopts
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+type constraints struct {
+	constraints []*semver.Constraints
+}
+
+func (o constraints) ApplyToCompHandler(handler *TypeHandler) {
+	handler.constraints = o.constraints
+}
+
+func WithVersionConstraints(c []*semver.Constraints) Option {
+	return constraints{c}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+type latestonly struct {
+	flag bool
+}
+
+func (o latestonly) ApplyToCompHandler(handler *TypeHandler) {
+	handler.latest = o.flag
+}
+
+func LatestOnly(b ...bool) Option {
+	return latestonly{utils.OptionalDefaultedBool(true, b...)}
+}

--- a/cmds/ocm/commands/ocmcmds/common/handlers/elemhdlr/options.go
+++ b/cmds/ocm/commands/ocmcmds/common/handlers/elemhdlr/options.go
@@ -4,18 +4,81 @@
 
 package elemhdlr
 
+import (
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/handlers/comphdlr"
+	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/versionconstraintsoption"
+	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
+)
+
 type Option interface {
-	Apply(handler *TypeHandler)
+	ApplyToElemHandler(handler *TypeHandler)
 }
+
+type Options []Option
+
+func (o Options) ApplyToElemHandler(handler *TypeHandler) {
+	for _, e := range o {
+		e.ApplyToElemHandler(handler)
+	}
+}
+
+func OptionsFor(o options.OptionSetProvider) Options {
+	var hopts []Option
+	constr := versionconstraintsoption.From(o)
+	if len(constr.Constraints) > 0 {
+		hopts = append(hopts, WithVersionConstraints(constr.Constraints))
+	}
+	if constr.Latest {
+		hopts = append(hopts, LatestOnly())
+	}
+	return hopts
+}
+
+////////////////////////////////////////////////////////////////////////////////
 
 type forceEmpty struct {
 	flag bool
 }
 
-func (o forceEmpty) Apply(handler *TypeHandler) {
+func (o forceEmpty) ApplyToElemHandler(handler *TypeHandler) {
 	handler.forceEmpty = o.flag
 }
 
 func ForceEmpty(b bool) Option {
 	return forceEmpty{b}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+type filter struct {
+	filter ElementFilter
+}
+
+func (o filter) ApplyToElemHandler(handler *TypeHandler) {
+	handler.filter = o.filter
+}
+
+func WithFilter(fi ElementFilter) Option {
+	return filter{fi}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+type compoption = comphdlr.Option
+
+type compoptionwrapper struct {
+	compoption
+}
+
+func (o compoptionwrapper) ApplyToElemHandler(handler *TypeHandler) {
+}
+
+func WithVersionConstraints(c []*semver.Constraints) Option {
+	return compoptionwrapper{comphdlr.WithVersionConstraints(c)}
+}
+
+func LatestOnly(b ...bool) Option {
+	return compoptionwrapper{comphdlr.LatestOnly(b...)}
 }

--- a/cmds/ocm/commands/ocmcmds/common/options/schemaoption/option.go
+++ b/cmds/ocm/commands/ocmcmds/common/options/schemaoption/option.go
@@ -56,11 +56,11 @@ func (o *Option) Usage() string {
 	s := ""
 	if o.Defaulted != "" {
 		s = `
-It the option <code>--scheme</code> is given, the given component descriptor format is used/generated.
+If the option <code>--scheme</code> is given, the specified component descriptor format is used/generated.
 `
 	} else {
 		s = `
-It the option <code>--scheme</code> is given, the given component descriptor is converted to given format for output.
+If the option <code>--scheme</code> is given, the component descriptor is converted to specified format for output.
 `
 	}
 	s += `The following schema versions are supported:

--- a/cmds/ocm/commands/ocmcmds/common/options/versionconstraintsoption/option.go
+++ b/cmds/ocm/commands/ocmcmds/common/options/versionconstraintsoption/option.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package versionconstraintsoption
+
+import (
+	"github.com/Masterminds/semver/v3"
+	"github.com/spf13/pflag"
+
+	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
+	"github.com/open-component-model/ocm/pkg/cobrautils/flag"
+)
+
+func From(o options.OptionSetProvider) *Option {
+	var opt *Option
+	o.AsOptionSet().Get(&opt)
+	return opt
+}
+
+func New() *Option {
+	return &Option{}
+}
+
+type Option struct {
+	Latest      bool
+	Constraints []*semver.Constraints
+}
+
+func (o *Option) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVarP(&o.Latest, "latest", "", false, "restrict component versions to latest")
+	flag.SemverConstraintsVarP(fs, &o.Constraints, "constraints", "c", nil, "version constraint")
+}
+
+func (o *Option) Usage() string {
+
+	s := `
+If the option <code>--constraints</code> is given, and no version is specified for a component, only versions matching
+the given version constraints (semver https://github.com/Masterminds/semver) are selected. With <code>--latest</code> only
+the latest matching versions will be selected.
+`
+	return s
+}

--- a/cmds/ocm/commands/ocmcmds/components/get/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/components/get/cmd.go
@@ -15,6 +15,7 @@ import (
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/lookupoption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/repooption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/schemaoption"
+	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/versionconstraintsoption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/names"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/verbs"
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
@@ -39,9 +40,14 @@ type Command struct {
 
 // NewCommand creates a new ctf command.
 func NewCommand(ctx clictx.Context, names ...string) *cobra.Command {
-	return utils.SetupCommand(&Command{BaseCommand: utils.NewBaseCommand(ctx, repooption.New(), output.OutputOptions(outputs, closureoption.New(
-		"component reference", output.Fields("IDENTITY"), options.Not(output.Selected("tree")), addIdentityField), lookupoption.New(), schemaoption.New(""),
-	))}, utils.Names(Names, names...)...)
+	return utils.SetupCommand(
+		&Command{BaseCommand: utils.NewBaseCommand(ctx,
+			versionconstraintsoption.New(), repooption.New(),
+			output.OutputOptions(outputs, closureoption.New(
+				"component reference", output.Fields("IDENTITY"), options.Not(output.Selected("tree")), addIdentityField), lookupoption.New(), schemaoption.New(""),
+			))},
+		utils.Names(Names, names...)...,
+	)
 }
 
 func (o *Command) ForName(name string) *cobra.Command {
@@ -75,7 +81,7 @@ func (o *Command) Run() error {
 	if err != nil {
 		return err
 	}
-	handler := comphdlr.NewTypeHandler(o.Context.OCM(), session, repooption.From(o).Repository)
+	handler := comphdlr.NewTypeHandler(o.Context.OCM(), session, repooption.From(o).Repository, comphdlr.OptionsFor(o))
 	return utils.HandleArgs(output.From(o), handler, o.Refs...)
 }
 

--- a/cmds/ocm/commands/ocmcmds/components/transfer/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/components/transfer/cmd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/rscbyvalueoption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/scriptoption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/uploaderoption"
+	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/versionconstraintsoption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/names"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/verbs"
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/output"
@@ -47,6 +48,7 @@ type Command struct {
 // NewCommand creates a new ctf command.
 func NewCommand(ctx clictx.Context, names ...string) *cobra.Command {
 	return utils.SetupCommand(&Command{BaseCommand: utils.NewBaseCommand(ctx,
+		versionconstraintsoption.New(),
 		repooption.New(),
 		formatoption.New(),
 		closureoption.New("component reference"),
@@ -114,7 +116,7 @@ func (o *Command) Run() error {
 	if err != nil {
 		return err
 	}
-	hdlr := comphdlr.NewTypeHandler(o.Context.OCM(), session, repooption.From(o).Repository)
+	hdlr := comphdlr.NewTypeHandler(o.Context.OCM(), session, repooption.From(o).Repository, comphdlr.OptionsFor(o))
 	err = utils.HandleOutput(&action{
 		cmd:     o,
 		printer: common.NewPrinter(o.Context.StdOut()),

--- a/cmds/ocm/commands/ocmcmds/references/common/typehandler.go
+++ b/cmds/ocm/commands/ocmcmds/references/common/typehandler.go
@@ -17,6 +17,8 @@ func Elem(e interface{}) *compdesc.ComponentReference {
 	return e.(*elemhdlr.Object).Element.(*compdesc.ComponentReference)
 }
 
+var OptionsFor = elemhdlr.OptionsFor
+
 ////////////////////////////////////////////////////////////////////////////////
 
 type TypeHandler struct {

--- a/cmds/ocm/commands/ocmcmds/references/get/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/references/get/cmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/handlers/elemhdlr"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/lookupoption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/repooption"
+	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/versionconstraintsoption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/names"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/references/common"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/verbs"
@@ -39,7 +40,7 @@ type Command struct {
 
 // NewCommand creates a new ctf command.
 func NewCommand(ctx clictx.Context, names ...string) *cobra.Command {
-	return utils.SetupCommand(&Command{BaseCommand: utils.NewBaseCommand(ctx, repooption.New(), output.OutputOptions(outputs, closureoption.New("component reference"), lookupoption.New()))}, utils.Names(Names, names...)...)
+	return utils.SetupCommand(&Command{BaseCommand: utils.NewBaseCommand(ctx, versionconstraintsoption.New(), repooption.New(), output.OutputOptions(outputs, closureoption.New("component reference"), lookupoption.New()))}, utils.Names(Names, names...)...)
 }
 
 func (o *Command) ForName(name string) *cobra.Command {
@@ -73,7 +74,7 @@ func (o *Command) Run() error {
 	}
 
 	opts := output.From(o)
-	hdlr, err := common.NewTypeHandler(o.Context.OCM(), opts, repooption.From(o).Repository, session, []string{o.Comp})
+	hdlr, err := common.NewTypeHandler(o.Context.OCM(), opts, repooption.From(o).Repository, session, []string{o.Comp}, common.OptionsFor(o))
 	if err != nil {
 		return err
 	}

--- a/cmds/ocm/commands/ocmcmds/resources/common/typehandler.go
+++ b/cmds/ocm/commands/ocmcmds/resources/common/typehandler.go
@@ -17,6 +17,37 @@ func Elem(e interface{}) *compdesc.Resource {
 	return e.(*elemhdlr.Object).Element.(*compdesc.Resource)
 }
 
+var WithVersionConstraints = elemhdlr.WithVersionConstraints
+var LatestOnly = elemhdlr.LatestOnly
+var OptionsFor = elemhdlr.OptionsFor
+
+type typeFilter struct {
+	types []string
+}
+
+func (t typeFilter) ApplyToElemHandler(handler *elemhdlr.TypeHandler) {
+	if len(t.types) > 0 {
+		handler.SetFilter(t)
+	}
+}
+
+func (t typeFilter) Accept(e compdesc.ElementMetaAccessor) bool {
+	if len(t.types) == 0 {
+		return true
+	}
+	typ := e.(*compdesc.Resource).GetType()
+	for _, a := range t.types {
+		if a == typ {
+			return true
+		}
+	}
+	return false
+}
+
+func WithTypes(types []string) elemhdlr.Option {
+	return typeFilter{types}
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 type TypeHandler struct {

--- a/cmds/ocm/commands/ocmcmds/resources/download/options.go
+++ b/cmds/ocm/commands/ocmcmds/resources/download/options.go
@@ -21,7 +21,9 @@ func NewOptions() *Option {
 }
 
 type Option struct {
-	UseHandlers bool
+	UseHandlers   bool
+	Executable    bool
+	ResourceTypes []string
 }
 
 func (o *Option) AddFlags(fs *pflag.FlagSet) {

--- a/cmds/ocm/commands/ocmcmds/resources/get/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/resources/get/cmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/handlers/elemhdlr"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/lookupoption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/repooption"
+	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/versionconstraintsoption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/names"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/resources/common"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/verbs"
@@ -37,7 +38,7 @@ type Command struct {
 
 // NewCommand creates a new ctf command.
 func NewCommand(ctx clictx.Context, names ...string) *cobra.Command {
-	return utils.SetupCommand(&Command{BaseCommand: utils.NewBaseCommand(ctx, repooption.New(), output.OutputOptions(outputs, closureoption.New("component reference"), lookupoption.New()))}, utils.Names(Names, names...)...)
+	return utils.SetupCommand(&Command{BaseCommand: utils.NewBaseCommand(ctx, versionconstraintsoption.New(), repooption.New(), output.OutputOptions(outputs, closureoption.New("component reference"), lookupoption.New()))}, utils.Names(Names, names...)...)
 }
 
 func (o *Command) ForName(name string) *cobra.Command {
@@ -71,7 +72,7 @@ func (o *Command) Run() error {
 	}
 
 	opts := output.From(o)
-	hdlr, err := common.NewTypeHandler(o.Context.OCM(), opts, repooption.From(o).Repository, session, []string{o.Comp}, elemhdlr.ForceEmpty(output.Selected("tree")(opts)))
+	hdlr, err := common.NewTypeHandler(o.Context.OCM(), opts, repooption.From(o).Repository, session, []string{o.Comp}, elemhdlr.ForceEmpty(output.Selected("tree")(opts)), common.OptionsFor(o))
 	if err != nil {
 		return err
 	}

--- a/cmds/ocm/commands/ocmcmds/sources/common/typehandler.go
+++ b/cmds/ocm/commands/ocmcmds/sources/common/typehandler.go
@@ -17,6 +17,8 @@ func Elem(e interface{}) *compdesc.Source {
 	return e.(*elemhdlr.Object).Element.(*compdesc.Source)
 }
 
+var OptionsFor = elemhdlr.OptionsFor
+
 ////////////////////////////////////////////////////////////////////////////////
 
 type TypeHandler struct {

--- a/cmds/ocm/commands/ocmcmds/sources/get/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/sources/get/cmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/handlers/elemhdlr"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/lookupoption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/repooption"
+	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/versionconstraintsoption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/names"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/sources/common"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/verbs"
@@ -37,7 +38,7 @@ type Command struct {
 
 // NewCommand creates a new ctf command.
 func NewCommand(ctx clictx.Context, names ...string) *cobra.Command {
-	return utils.SetupCommand(&Command{BaseCommand: utils.NewBaseCommand(ctx, &repooption.Option{}, output.OutputOptions(outputs, closureoption.New("component reference"), lookupoption.New()))}, utils.Names(Names, names...)...)
+	return utils.SetupCommand(&Command{BaseCommand: utils.NewBaseCommand(ctx, versionconstraintsoption.New(), repooption.New(), output.OutputOptions(outputs, closureoption.New("component reference"), lookupoption.New()))}, utils.Names(Names, names...)...)
 }
 
 func (o *Command) ForName(name string) *cobra.Command {
@@ -71,7 +72,7 @@ func (o *Command) Run() error {
 	}
 
 	opts := output.From(o)
-	hdlr, err := common.NewTypeHandler(o.Context.OCM(), opts, repooption.From(o).Repository, session, []string{o.Comp})
+	hdlr, err := common.NewTypeHandler(o.Context.OCM(), opts, repooption.From(o).Repository, session, []string{o.Comp}, common.OptionsFor(o))
 	if err != nil {
 		return err
 	}

--- a/components/ocmcli/Makefile
+++ b/components/ocmcli/Makefile
@@ -1,15 +1,17 @@
-NAME      = ocm
-PROVIDER  ?= mandelsoft
-COMPONENT = github.com/$(PROVIDER)/$(NAME)
-OCMREPO   ?= ghcr.io/$(PROVIDER)/cnudie
-PLATFORMS = linux/amd64 linux/arm64
+NAME      = ocmcli
+CMD       = ocm
+PROVIDER  ?= ocm.software
+GITHUBORG  ?= open-component-model
+COMPONENT = $(PROVIDER)/$(NAME)
+OCMREPO   ?= ghcr.io/$(GITHUBORG)/ocm
+PLATFORMS = linux/amd64 linux/arm64 darwin/arm64 darwin/amd64
 
 REPO_ROOT                                      := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/../..
-VERSION                                        = $(shell git describe --tags --exact-match 2>/dev/null|| echo "$$(cat $(REPO_ROOT)/VERSION)-dev")
+VERSION                                        = $(shell git describe --tags --exact-match 2>/dev/null|| echo "$$(cat $(REPO_ROOT)/VERSION)")
 COMMIT                                         = $(shell git rev-parse HEAD)
 EFFECTIVE_VERSION                              = $(VERSION)-$(COMMIT)
 
-CMDSRCS=$(shell find $(REPO_ROOT)/cmds/$(NAME) -type f)
+CMDSRCS=$(shell find $(REPO_ROOT)/cmds/$(CMD) -type f)
 OCMSRCS=$(shell find $(REPO_ROOT)/pkg -type f) $(REPO_ROOT)/go.*
 
 GEN = $(REPO_ROOT)/gen/$(shell basename $(realpath .))
@@ -29,8 +31,8 @@ build: $(GEN)/build
 $(GEN)/build: $(CMDSRCS) $(OCMSRCS)
 	@for i in $(PLATFORMS); do \
     tag=$$(echo $$i | sed -e s:/:-:g); \
-    echo GOARCH=$$(basename $$i) GOOS=$$(dirname $$i) go build -ldflags $(BUILD_FLAGS) -o $(GEN)/$(NAME).$$tag ../../cmds/$(NAME); \
-    GOARCH=$$(basename $$i) GOOS=$$(dirname $$i) go build -ldflags $(BUILD_FLAGS) -o $(GEN)/$(NAME).$$tag ../../cmds/$(NAME); \
+    echo GOARCH=$$(basename $$i) GOOS=$$(dirname $$i) go build -ldflags $(BUILD_FLAGS) -o $(GEN)/$(NAME).$$tag ../../cmds/$(CMD); \
+    GOARCH=$$(basename $$i) GOOS=$$(dirname $$i) go build -ldflags $(BUILD_FLAGS) -o $(GEN)/$(NAME).$$tag ../../cmds/$(CMD); \
     done
 	@touch $(GEN)/build
 

--- a/components/ocmcli/resources.yaml
+++ b/components/ocmcli/resources.yaml
@@ -6,6 +6,9 @@ helper:
     name: ocmcli
     type: executable
     version: (( values.VERSION ))
+    labels:
+      - name: "downloadName"
+        value: "ocm"
     extraIdentity:
       os: ((dirname(p) ))
       architecture: (( basename(p) ))

--- a/docs/reference/ocm_create_componentarchive.md
+++ b/docs/reference/ocm_create_componentarchive.md
@@ -32,7 +32,7 @@ target archive to use. The following formats are supported:
 - tgz
 The default format is <code>directory</code>.
 
-It the option <code>--scheme</code> is given, the given component descriptor format is used/generated.
+If the option <code>--scheme</code> is given, the specified component descriptor format is used/generated.
 The following schema versions are supported:
 
   - <code>ocm.software/v3alpha1</code>: 

--- a/docs/reference/ocm_download_resources.md
+++ b/docs/reference/ocm_download_resources.md
@@ -9,12 +9,16 @@ ocm download resources [<options>]  <component> {<name> { <key>=<value> }}
 ### Options
 
 ```
-  -d, --download-handlers    use download handler if possible
-  -h, --help                 help for resources
-      --lookup stringArray   repository name or spec for closure lookup fallback
-  -O, --outfile string       output file or directory
-  -r, --recursive            follow component reference nesting
-      --repo string          repository name or spec
+  -c, --constraints constraints   version constraint
+  -d, --download-handlers         use download handler if possible
+  -x, --executable                download executable for local platform
+  -h, --help                      help for resources
+      --latest                    restrict component versions to latest
+      --lookup stringArray        repository name or spec for closure lookup fallback
+  -O, --outfile string            output file or directory
+  -r, --recursive                 follow component reference nesting
+      --repo string               repository name or spec
+  -t, --type stringArray          resource type filter
 ```
 
 ### Description
@@ -46,6 +50,10 @@ order:
     <pre>&lt;resource name>[-[&lt;name>=&lt>value>]{,&lt;name>=&lt>value>}]</pre>
 </center>
 
+
+If the option <code>--constraints</code> is given, and no version is specified for a component, only versions matching
+the given version constraints (semver https://github.com/Masterminds/semver) are selected. With <code>--latest</code> only
+the latest matching versions will be selected.
 
 If the <code>--repo</code> option is specified, the given names are interpreted
 relative to the specified repository using the syntax

--- a/docs/reference/ocm_get_componentversions.md
+++ b/docs/reference/ocm_get_componentversions.md
@@ -9,13 +9,15 @@ ocm get componentversions [<options>] {<component-reference>}
 ### Options
 
 ```
-  -h, --help                 help for componentversions
-      --lookup stringArray   repository name or spec for closure lookup fallback
-  -o, --output string        output mode (JSON, json, tree, wide, yaml)
-  -r, --recursive            follow component reference nesting
-      --repo string          repository name or spec
-  -S, --scheme string        schema version
-  -s, --sort stringArray     sort fields
+  -c, --constraints constraints   version constraint
+  -h, --help                      help for componentversions
+      --latest                    restrict component versions to latest
+      --lookup stringArray        repository name or spec for closure lookup fallback
+  -o, --output string             output mode (JSON, json, tree, wide, yaml)
+  -r, --recursive                 follow component reference nesting
+      --repo string               repository name or spec
+  -S, --scheme string             schema version
+  -s, --sort stringArray          sort fields
 ```
 
 ### Description
@@ -23,6 +25,10 @@ ocm get componentversions [<options>] {<component-reference>}
 
 Get lists all component versions specified, if only a component is specified
 all versions are listed.
+
+If the option <code>--constraints</code> is given, and no version is specified for a component, only versions matching
+the given version constraints (semver https://github.com/Masterminds/semver) are selected. With <code>--latest</code> only
+the latest matching versions will be selected.
 
 If the <code>--repo</code> option is specified, the given names are interpreted
 relative to the specified repository using the syntax
@@ -81,7 +87,7 @@ contains a single component version. Therefore, in this scenario
 this option must always be specified to be able to follow component
 references.
 
-It the option <code>--scheme</code> is given, the given component descriptor is converted to given format for output.
+If the option <code>--scheme</code> is given, the component descriptor is converted to specified format for output.
 The following schema versions are supported:
 
   - <code>ocm.software/v3alpha1</code>: 

--- a/docs/reference/ocm_get_references.md
+++ b/docs/reference/ocm_get_references.md
@@ -9,12 +9,14 @@ ocm get references [<options>]  <component> {<name> { <key>=<value> }}
 ### Options
 
 ```
-  -h, --help                 help for references
-      --lookup stringArray   repository name or spec for closure lookup fallback
-  -o, --output string        output mode (JSON, json, tree, wide, yaml)
-  -r, --recursive            follow component reference nesting
-      --repo string          repository name or spec
-  -s, --sort stringArray     sort fields
+  -c, --constraints constraints   version constraint
+  -h, --help                      help for references
+      --latest                    restrict component versions to latest
+      --lookup stringArray        repository name or spec for closure lookup fallback
+  -o, --output string             output mode (JSON, json, tree, wide, yaml)
+  -r, --recursive                 follow component reference nesting
+      --repo string               repository name or spec
+  -s, --sort stringArray          sort fields
 ```
 
 ### Description
@@ -24,6 +26,10 @@ Get references of a component version. References are specified
 by identities. An identity consists of 
 a name argument followed by optional <code>&lt;key>=&lt;value></code>
 arguments.
+
+If the option <code>--constraints</code> is given, and no version is specified for a component, only versions matching
+the given version constraints (semver https://github.com/Masterminds/semver) are selected. With <code>--latest</code> only
+the latest matching versions will be selected.
 
 If the <code>--repo</code> option is specified, the given names are interpreted
 relative to the specified repository using the syntax

--- a/docs/reference/ocm_get_resources.md
+++ b/docs/reference/ocm_get_resources.md
@@ -9,12 +9,14 @@ ocm get resources [<options>]  <component> {<name> { <key>=<value> }}
 ### Options
 
 ```
-  -h, --help                 help for resources
-      --lookup stringArray   repository name or spec for closure lookup fallback
-  -o, --output string        output mode (JSON, json, tree, treewide, wide, yaml)
-  -r, --recursive            follow component reference nesting
-      --repo string          repository name or spec
-  -s, --sort stringArray     sort fields
+  -c, --constraints constraints   version constraint
+  -h, --help                      help for resources
+      --latest                    restrict component versions to latest
+      --lookup stringArray        repository name or spec for closure lookup fallback
+  -o, --output string             output mode (JSON, json, tree, treewide, wide, yaml)
+  -r, --recursive                 follow component reference nesting
+      --repo string               repository name or spec
+  -s, --sort stringArray          sort fields
 ```
 
 ### Description
@@ -24,6 +26,10 @@ Get resources of a component version. Resources are specified
 by identities. An identity consists of 
 a name argument followed by optional <code>&lt;key>=&lt;value></code>
 arguments.
+
+If the option <code>--constraints</code> is given, and no version is specified for a component, only versions matching
+the given version constraints (semver https://github.com/Masterminds/semver) are selected. With <code>--latest</code> only
+the latest matching versions will be selected.
 
 If the <code>--repo</code> option is specified, the given names are interpreted
 relative to the specified repository using the syntax

--- a/docs/reference/ocm_get_sources.md
+++ b/docs/reference/ocm_get_sources.md
@@ -9,12 +9,14 @@ ocm get sources [<options>]  <component> {<name> { <key>=<value> }}
 ### Options
 
 ```
-  -h, --help                 help for sources
-      --lookup stringArray   repository name or spec for closure lookup fallback
-  -o, --output string        output mode (JSON, json, tree, wide, yaml)
-  -r, --recursive            follow component reference nesting
-      --repo string          repository name or spec
-  -s, --sort stringArray     sort fields
+  -c, --constraints constraints   version constraint
+  -h, --help                      help for sources
+      --latest                    restrict component versions to latest
+      --lookup stringArray        repository name or spec for closure lookup fallback
+  -o, --output string             output mode (JSON, json, tree, wide, yaml)
+  -r, --recursive                 follow component reference nesting
+      --repo string               repository name or spec
+  -s, --sort stringArray          sort fields
 ```
 
 ### Description
@@ -24,6 +26,10 @@ Get sources of a component version. Sources are specified
 by identities. An identity consists of 
 a name argument followed by optional <code>&lt;key>=&lt;value></code>
 arguments.
+
+If the option <code>--constraints</code> is given, and no version is specified for a component, only versions matching
+the given version constraints (semver https://github.com/Masterminds/semver) are selected. With <code>--latest</code> only
+the latest matching versions will be selected.
 
 If the <code>--repo</code> option is specified, the given names are interpreted
 relative to the specified repository using the syntax

--- a/docs/reference/ocm_sign_componentversions.md
+++ b/docs/reference/ocm_sign_componentversions.md
@@ -11,9 +11,11 @@ ocm sign componentversions [<options>] {<component-reference>}
 ```
   -S, --algorithm string          signature handler (default "RSASSA-PKCS1-V1_5")
       --ca-cert stringArray       Additional root certificates
+  -c, --constraints constraints   version constraint
   -H, --hash string               hash algorithm (default "sha256")
   -h, --help                      help for componentversions
   -I, --issuer string             issuer name
+      --latest                    restrict component versions to latest
       --lookup stringArray        repository name or spec for closure lookup fallback
   -N, --normalization string      normalization algorithm (default "jsonNormalisation/v1")
   -K, --private-key stringArray   private key setting
@@ -29,6 +31,10 @@ ocm sign componentversions [<options>] {<component-reference>}
 
 
 Sign specified component versions. 
+
+If the option <code>--constraints</code> is given, and no version is specified for a component, only versions matching
+the given version constraints (semver https://github.com/Masterminds/semver) are selected. With <code>--latest</code> only
+the latest matching versions will be selected.
 
 If the <code>--repo</code> option is specified, the given names are interpreted
 relative to the specified repository using the syntax

--- a/docs/reference/ocm_transfer_componentversions.md
+++ b/docs/reference/ocm_transfer_componentversions.md
@@ -9,8 +9,10 @@ ocm transfer componentversions [<options>] {<component-reference>} <target>
 ### Options
 
 ```
+  -c, --constraints constraints   version constraint
   -V, --copy-resources            transfer referenced resources by-value
   -h, --help                      help for componentversions
+      --latest                    restrict component versions to latest
       --lookup stringArray        repository name or spec for closure lookup fallback
   -f, --overwrite                 overwrite existing component versions
   -r, --recursive                 follow component reference nesting
@@ -27,6 +29,10 @@ ocm transfer componentversions [<options>] {<component-reference>} <target>
 Transfer all component versions specified to the given target repository.
 If only a component (instead of a component version) is specified all versions
 are transferred.
+
+If the option <code>--constraints</code> is given, and no version is specified for a component, only versions matching
+the given version constraints (semver https://github.com/Masterminds/semver) are selected. With <code>--latest</code> only
+the latest matching versions will be selected.
 
 If the <code>--repo</code> option is specified, the given names are interpreted
 relative to the specified repository using the syntax

--- a/docs/reference/ocm_verify_componentversions.md
+++ b/docs/reference/ocm_verify_componentversions.md
@@ -9,20 +9,26 @@ ocm verify componentversions [<options>] {<component-reference>}
 ### Options
 
 ```
-      --ca-cert stringArray      Additional root certificates
-  -h, --help                     help for componentversions
-  -L, --local                    verification based on information found in component versions, only
-      --lookup stringArray       repository name or spec for closure lookup fallback
-  -k, --public-key stringArray   public key setting
-      --repo string              repository name or spec
-  -s, --signature stringArray    signature name
-  -V, --verify                   verify existing digests
+      --ca-cert stringArray       Additional root certificates
+  -c, --constraints constraints   version constraint
+  -h, --help                      help for componentversions
+      --latest                    restrict component versions to latest
+  -L, --local                     verification based on information found in component versions, only
+      --lookup stringArray        repository name or spec for closure lookup fallback
+  -k, --public-key stringArray    public key setting
+      --repo string               repository name or spec
+  -s, --signature stringArray     signature name
+  -V, --verify                    verify existing digests
 ```
 
 ### Description
 
 
 Verify signature of specified component versions. 
+
+If the option <code>--constraints</code> is given, and no version is specified for a component, only versions matching
+the given version constraints (semver https://github.com/Masterminds/semver) are selected. With <code>--latest</code> only
+the latest matching versions will be selected.
 
 If the <code>--repo</code> option is specified, the given names are interpreted
 relative to the specified repository using the syntax

--- a/pkg/contexts/ocm/compdesc/meta/v1/labels.go
+++ b/pkg/contexts/ocm/compdesc/meta/v1/labels.go
@@ -67,7 +67,7 @@ func NewLabel(name string, value interface{}, opts ...LabelOption) (*Label, erro
 // +k8s:openapi-gen=true
 type Labels []Label
 
-// Get returns the label with the given name.
+// Get returns the label value with the given name as json string.
 func (l Labels) Get(name string) ([]byte, bool) {
 	for _, label := range l {
 		if label.Name == name {
@@ -75,6 +75,16 @@ func (l Labels) Get(name string) ([]byte, bool) {
 		}
 	}
 	return nil, false
+}
+
+// GetValue returns the label value with the given name as parsed object.
+func (l Labels) GetValue(name string, dest interface{}) (bool, error) {
+	for _, label := range l {
+		if label.Name == name {
+			return true, json.Unmarshal(label.Value, dest)
+		}
+	}
+	return false, nil
 }
 
 func (l *Labels) Set(name string, value interface{}, opts ...LabelOption) error {

--- a/pkg/contexts/ocm/consts/extra_identities.go
+++ b/pkg/contexts/ocm/consts/extra_identities.go
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package consts
+
+const (
+	ExecutableOperatingSystem = "os"
+	ExecutableArchitecture    = "architecture"
+)

--- a/pkg/contexts/ocm/plugin/cache/updater.go
+++ b/pkg/contexts/ocm/plugin/cache/updater.go
@@ -20,6 +20,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/attrs/plugindirattr"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/consts"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/download"
 	"github.com/open-component-model/ocm/pkg/errors"
@@ -191,8 +192,8 @@ func (o *PluginUpdater) download(session ocm.Session, cv ocm.ComponentVersionAcc
 			continue
 		}
 		if r.Meta().Type == "ocmPlugin" {
-			if r.Meta().ExtraIdentity.Get("os") == runtime.GOOS &&
-				r.Meta().ExtraIdentity.Get("architecture") == runtime.GOARCH {
+			if r.Meta().ExtraIdentity.Get(consts.ExecutableOperatingSystem) == runtime.GOOS &&
+				r.Meta().ExtraIdentity.Get(consts.ExecutableArchitecture) == runtime.GOARCH {
 				found = r
 				break
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

The ocm CLI is available as resource of a component and there is a download handler for executables.

But there was no option to download an executable of the appropriate platform. This will be added by this
PR.

The download command now has the option `-x` to indicate, that an executable should be downloaded.
Then a filter for the resource type (`executable`) and the appropriate platform specific extra-identities (`os`and `architecture`) used to mark platforms is implicitly added.

The type filter is also new and can explicitly be used with the `--type` option.

Additionally it makes sense to be able to specify version constraints. This is now a general option for the component version type handler also used for command like `get components`  or `get resources`.  Constraints according to semver ([mastermind](https://github.com/Masterminds/semver)) can be specified with the `--constraints` options, similar to the plugin installation command. If given together with a version-less component specification, only the matching versions will be selected, instead of all available versions. This can be combined with the `--latest` option to filter the latest version of the selected version set.

With this the ocm tool can now be downloaded with the command

```
$ ocm download resource -x  --latest ghcr.io/open-component-model/ocm//ocm.software/ocmcli
```

It is not required anymore to specify a resource identity or concrete version (this still works if dedicated resources or versions should be used). The already existing download handler will automatically add the x-bit.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
