### PR TITLE
docs: change language to liberate ocm from oci specific statements

### DIFF
--- a/cmds/ocm/commands/ocicmds/artifacts/download/cmd.go
+++ b/cmds/ocm/commands/ocicmds/artifacts/download/cmd.go
@@ -50,7 +50,7 @@ func (o *Command) ForName(name string) *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 		Short: "download oci artifacts",
 		Long: `
-Download artifacts from an OCI registry. The result is stored in
+Download artifacts. The result is stored in
 artifact set format, without the repository part
 
 The files are named according to the artifact repository name.

--- a/docs/reference/ocm_download_artifacts.md
+++ b/docs/reference/ocm_download_artifacts.md
@@ -18,7 +18,7 @@ ocm download artifacts [<options>]  {<artifact>}
 ### Description
 
 
-Download artifacts from an OCI registry. The result is stored in
+Download artifacts. The result is stored in
 artifact set format, without the repository part
 
 The files are named according to the artifact repository name.


### PR DESCRIPTION
I read through all OCI / Docker references, and found only this one. I can't say I 'm 100% sure I found all of them, but the best I can do. All other references contain some degree of separation using words like "for example", or the section is already scoped to `contexts/oci` or `repositories/ocireg`.


Related to: https://github.com/open-component-model/ocm/issues/183