### PR TITLE
get rid of pflag replacement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ local
 /gen
 bin/
 *.go.grc.bk
+go.mod.bak

--- a/cmds/ocm/commands/ocmcmds/common/options/fileoption/option.go
+++ b/cmds/ocm/commands/ocmcmds/common/options/fileoption/option.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
+	"github.com/open-component-model/ocm/pkg/cobrautils/flag"
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/common/compression"
 )
@@ -42,7 +43,7 @@ type Option struct {
 }
 
 func (o *Option) AddFlags(fs *pflag.FlagSet) {
-	o.flag = fs.StringVarPF(&o.Path, "file", "F", o.def, o.usage)
+	o.flag = flag.StringVarPF(fs, &o.Path, "file", "F", o.def, o.usage)
 }
 
 func (o *Option) IsSet() bool {

--- a/docs/pluginreference/plugin_accessmethod_get.md
+++ b/docs/pluginreference/plugin_accessmethod_get.md
@@ -9,7 +9,7 @@ plugin accessmethod get [<flags>] <access spec> [<options>]
 ### Options
 
 ```
-  -C, --credential <name>=<value>   dedicated credential value
+  -C, --credential <name>=<value>   dedicated credential value (default [])
   -c, --credentials YAML            credentials
   -h, --help                        help for get
 ```

--- a/docs/pluginreference/plugin_upload_put.md
+++ b/docs/pluginreference/plugin_upload_put.md
@@ -10,7 +10,7 @@ plugin upload put [<flags>] <name> <repository specification> [<options>]
 
 ```
   -a, --artifactType string         artifact type of input blob
-  -C, --credential <name>=<value>   dedicated credential value
+  -C, --credential <name>=<value>   dedicated credential value (default [])
   -c, --credentials YAML            credentials
   -h, --help                        help for put
   -H, --hint string                 reference hint for storing blob

--- a/docs/reference/ocm_add_references.md
+++ b/docs/reference/ocm_add_references.md
@@ -23,7 +23,7 @@ ocm add references [<options>] [<target>] {<referencefile> | <var>=<value>}
 
 ```
       --component string       component name
-      --extra <name>=<value>   reference extra identity
+      --extra <name>=<value>   reference extra identity (default [])
       --label <name>=<YAML>    reference label (leading * indicates signature relevant, optional version separated by @)
       --name string            reference name
       --reference YAML         reference meta data (yaml)

--- a/docs/reference/ocm_add_resource-configuration.md
+++ b/docs/reference/ocm_add_resource-configuration.md
@@ -60,7 +60,7 @@ ocm add resource-configuration [<options>] <target> {<configfile> | <var>=<value
 
 ```
       --external                     flag non-local resource
-      --extra <name>=<value>         resource extra identity
+      --extra <name>=<value>         resource extra identity (default [])
       --label <name>=<YAML>          resource label (leading * indicates signature relevant, optional version separated by @)
       --name string                  resource name
       --resource YAML                resource meta data (yaml)

--- a/docs/reference/ocm_add_resources.md
+++ b/docs/reference/ocm_add_resources.md
@@ -63,7 +63,7 @@ ocm add resources [<options>] [<target>] {<resourcefile> | <var>=<value>}
 
 ```
       --external                     flag non-local resource
-      --extra <name>=<value>         resource extra identity
+      --extra <name>=<value>         resource extra identity (default [])
       --label <name>=<YAML>          resource label (leading * indicates signature relevant, optional version separated by @)
       --name string                  resource name
       --resource YAML                resource meta data (yaml)

--- a/docs/reference/ocm_add_source-configuration.md
+++ b/docs/reference/ocm_add_source-configuration.md
@@ -59,7 +59,7 @@ ocm add source-configuration [<options>] <target> {<configfile> | <var>=<value>}
 #### Source Meta Data Options
 
 ```
-      --extra <name>=<value>         source extra identity
+      --extra <name>=<value>         source extra identity (default [])
       --label <name>=<YAML>          source label (leading * indicates signature relevant, optional version separated by @)
       --name string                  source name
       --source YAML                  source meta data (yaml)

--- a/docs/reference/ocm_add_sources.md
+++ b/docs/reference/ocm_add_sources.md
@@ -62,7 +62,7 @@ ocm add sources [<options>] [<target>] {<resourcefile> | <var>=<value>}
 #### Source Meta Data Options
 
 ```
-      --extra <name>=<value>         source extra identity
+      --extra <name>=<value>         source extra identity (default [])
       --label <name>=<YAML>          source label (leading * indicates signature relevant, optional version separated by @)
       --name string                  source name
       --source YAML                  source meta data (yaml)

--- a/docs/reference/ocm_transfer_commontransportarchive.md
+++ b/docs/reference/ocm_transfer_commontransportarchive.md
@@ -15,7 +15,7 @@ ocm transfer commontransportarchive [<options>] <ctf> <target>
       --script string             config name of transfer handler script
   -s, --scriptFile string         filename of transfer handler script
   -t, --type string               archive format (directory, tar, tgz) (default "directory")
-      --uploader <name>=<value>   repository uploader (<name>:<artifact type>:<media type>=<JSON target config)
+      --uploader <name>=<value>   repository uploader (<name>:<artifact type>:<media type>=<JSON target config) (default [])
 ```
 
 ### Description

--- a/docs/reference/ocm_transfer_componentversions.md
+++ b/docs/reference/ocm_transfer_componentversions.md
@@ -20,7 +20,7 @@ ocm transfer componentversions [<options>] {<component-reference>} <target>
       --script string             config name of transfer handler script
   -s, --scriptFile string         filename of transfer handler script
   -t, --type string               archive format (directory, tar, tgz) (default "directory")
-      --uploader <name>=<value>   repository uploader (<name>:<artifact type>:<media type>=<JSON target config)
+      --uploader <name>=<value>   repository uploader (<name>:<artifact type>:<media type>=<JSON target config) (default [])
 ```
 
 ### Description

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,7 @@ module github.com/open-component-model/ocm
 
 go 1.19
 
-replace (
-	github.com/spf13/cobra => github.com/mandelsoft/cobra v1.5.1-0.20221030110806-c236cde1e2bd
-	github.com/spf13/pflag => github.com/mandelsoft/pflag v0.0.0-20221103113840-a15b5f7fa89e
-)
+replace github.com/spf13/cobra => github.com/mandelsoft/cobra v1.5.1-0.20221030110806-c236cde1e2bd
 
 require (
 	github.com/docker/cli v20.10.17+incompatible
@@ -41,6 +38,7 @@ require (
 	github.com/docker/distribution v2.8.1+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/drone/envsubst v1.0.3
+	github.com/gertd/go-pluralize v0.2.1
 	github.com/goccy/go-yaml v1.9.5
 	github.com/golang/mock v1.6.0
 	github.com/google/go-github/v45 v45.2.0
@@ -57,6 +55,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	github.com/tonglil/buflogr v1.0.1
 	github.com/ulikunitz/xz v0.5.10
+	golang.org/x/exp v0.0.0-20221212164502-fae10dda9338
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/text v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -464,6 +464,8 @@ github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXt
 github.com/fvbommel/sortorder v1.0.1 h1:dSnXLt4mJYH25uDDGa3biZNQsozaUWDSWeKJ0qqFfzE=
 github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
+github.com/gertd/go-pluralize v0.2.1 h1:M3uASbVjMnTsPb0PNqg+E/24Vwigyo/tvyMTtAlLgiA=
+github.com/gertd/go-pluralize v0.2.1/go.mod h1:rbYaKDbsXxmRfr8uygAEKhOWsjyrrqrkHVpZvoOp8zk=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -820,8 +822,6 @@ github.com/mandelsoft/filepath v0.0.0-20220503095057-4432a2285b68 h1:99GWPlKVS11
 github.com/mandelsoft/filepath v0.0.0-20220503095057-4432a2285b68/go.mod h1:n4xEiUD2HNHnn2w5ZKF0qgjDecHVCWAl5DxZ7+pcFU8=
 github.com/mandelsoft/logging v0.0.0-20221114215048-ab754b164dd6 h1:xlUJPmMJo1IVQVn42ELLDUNY3sfwzKVp4kyuy7Q2QwI=
 github.com/mandelsoft/logging v0.0.0-20221114215048-ab754b164dd6/go.mod h1:vxGpzOesdqLGRSWb4fz5DaH0ekJvkISst4qq6UZ2xFA=
-github.com/mandelsoft/pflag v0.0.0-20221103113840-a15b5f7fa89e h1:XW05FCl7x4ZLYL109cCqZbyF7vq5ihmOWIleT+luIr4=
-github.com/mandelsoft/pflag v0.0.0-20221103113840-a15b5f7fa89e/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/mandelsoft/spiff v1.7.0-beta-3 h1:AvZldpnctpyfQqtAA5uxokD5rlCK52mGAXxg7tnW5Ag=
 github.com/mandelsoft/spiff v1.7.0-beta-3/go.mod h1:3Kg6qrggWO4oc1k++acd6xhcWisJ2YkzxpVZpuYONGg=
 github.com/mandelsoft/vfs v0.0.0-20201002080026-d03d33d5889a/go.mod h1:74aV7kulg9C434HiI3zNALN79QHc9IZMN+SI4UdLn14=
@@ -1119,6 +1119,13 @@ github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431/go.mod h1:
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
+github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.0/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.1-0.20171106142849-4c012f6dcd95/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v0.0.0-20150530192845-be5ff3e4840c/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
 github.com/spf13/viper v1.7.1 h1:pM5oEahlgWv/WnHXpgbKz7iLIxRf65tye2Ci+XFK5sk=
 github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
@@ -1287,6 +1294,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20221212164502-fae10dda9338 h1:OvjRkcNHnf6/W5FZXSxODbxwD+X7fspczG7Jn/xQVD4=
+golang.org/x/exp v0.0.0-20221212164502-fae10dda9338/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/cobrautils/flag/replace.go
+++ b/pkg/cobrautils/flag/replace.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package flag
+
+import (
+	"github.com/spf13/pflag"
+)
+
+// StringVarPF is like StringVarP, but returns the created flag.
+func StringVarPF(f *pflag.FlagSet, p *string, name, shorthand string, value string, usage string) *pflag.Flag {
+	f.StringVarP(p, name, shorthand, value, usage)
+	return f.Lookup(name)
+}
+
+// StringArrayVarPF is like StringArrayVarP, but returns the created flag.
+func StringArrayVarPF(f *pflag.FlagSet, p *[]string, name, shorthand string, value []string, usage string) *pflag.Flag {
+	f.StringArrayVarP(p, name, shorthand, value, usage)
+	return f.Lookup(name)
+}
+
+// BoolVarPF is like BoolVarP, but returns the created flag.
+func BoolVarPF(f *pflag.FlagSet, p *bool, name, shorthand string, value bool, usage string) *pflag.Flag {
+	f.BoolVarP(p, name, shorthand, value, usage)
+	return f.Lookup(name)
+}
+
+// IntVarPF is like IntVarP, but returns the created flag.
+func IntVarPF(f *pflag.FlagSet, p *int, name, shorthand string, value int, usage string) *pflag.Flag {
+	f.IntVarP(p, name, shorthand, value, usage)
+	return f.Lookup(name)
+}

--- a/pkg/cobrautils/flagsets/types.go
+++ b/pkg/cobrautils/flagsets/types.go
@@ -105,7 +105,7 @@ type StringOption struct {
 var _ Option = (*StringOption)(nil)
 
 func (o *StringOption) AddFlags(fs *pflag.FlagSet) {
-	o.TweakFlag(fs.StringVarPF(&o.value, o.otyp.GetName(), "", "", o.otyp.GetDescription()))
+	o.TweakFlag(flag.StringVarPF(fs, &o.value, o.otyp.GetName(), "", "", o.otyp.GetDescription()))
 }
 
 func (o *StringOption) Value() interface{} {
@@ -142,7 +142,7 @@ type StringArrayOption struct {
 var _ Option = (*StringArrayOption)(nil)
 
 func (o *StringArrayOption) AddFlags(fs *pflag.FlagSet) {
-	o.TweakFlag(fs.StringArrayVarPF(&o.value, o.otyp.GetName(), "", nil, o.otyp.GetDescription()))
+	o.TweakFlag(flag.StringArrayVarPF(fs, &o.value, o.otyp.GetName(), "", nil, o.otyp.GetDescription()))
 }
 
 func (o *StringArrayOption) Value() interface{} {
@@ -179,7 +179,7 @@ type BoolOption struct {
 var _ Option = (*BoolOption)(nil)
 
 func (o *BoolOption) AddFlags(fs *pflag.FlagSet) {
-	o.TweakFlag(fs.BoolVarPF(&o.value, o.otyp.GetName(), "", false, o.otyp.GetDescription()))
+	o.TweakFlag(flag.BoolVarPF(fs, &o.value, o.otyp.GetName(), "", false, o.otyp.GetDescription()))
 }
 
 func (o *BoolOption) Value() interface{} {
@@ -216,7 +216,7 @@ type IntOption struct {
 var _ Option = (*IntOption)(nil)
 
 func (o *IntOption) AddFlags(fs *pflag.FlagSet) {
-	o.TweakFlag(fs.IntVarPF(&o.value, o.otyp.GetName(), "", 0, o.otyp.GetDescription()))
+	o.TweakFlag(flag.IntVarPF(fs, &o.value, o.otyp.GetName(), "", 0, o.otyp.GetDescription()))
 }
 
 func (o *IntOption) Value() interface{} {

--- a/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1/jsonscheme/bindata.go
+++ b/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1/jsonscheme/bindata.go
@@ -94,7 +94,7 @@ func ResourcesComponentDescriptorOcmV3SchemaYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../../../../../../../../resources/component-descriptor-ocm-v3-schema.yaml", size: 10607, mode: os.FileMode(436), modTime: time.Unix(1668066250, 0)}
+	info := bindataFileInfo{name: "../../../../../../../../resources/component-descriptor-ocm-v3-schema.yaml", size: 10607, mode: os.FileMode(436), modTime: time.Unix(1670858152, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/contexts/ocm/compdesc/versions/v2/jsonscheme/bindata.go
+++ b/pkg/contexts/ocm/compdesc/versions/v2/jsonscheme/bindata.go
@@ -94,7 +94,7 @@ func ResourcesComponentDescriptorV2SchemaYaml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../../../../../../../resources/component-descriptor-v2-schema.yaml", size: 10392, mode: os.FileMode(436), modTime: time.Unix(1668066250, 0)}
+	info := bindataFileInfo{name: "../../../../../../../resources/component-descriptor-v2-schema.yaml", size: 10392, mode: os.FileMode(436), modTime: time.Unix(1670858152, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }


### PR DESCRIPTION
the required new improved API is now replaced by a wrapper method in flag/replace.go, which provides the same behaviour with a more complex implementation, but which is based on the officital API.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
