### PR TITLE
builtin support for GitHub token

### DIFF
--- a/pkg/contexts/credentials/builtin/github/ghcr.go
+++ b/pkg/contexts/credentials/builtin/github/ghcr.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"os"
+
+	"github.com/open-component-model/ocm/pkg/common"
+	"github.com/open-component-model/ocm/pkg/contexts/credentials/cpi"
+	"github.com/open-component-model/ocm/pkg/contexts/oci/identity"
+)
+
+const HOST = "ghcr.io"
+
+func init() {
+	t := os.Getenv("GITHUB_TOKEN")
+	if t != "" {
+		host := os.Getenv("GITHUB_HOST")
+		if host == "" {
+			host = HOST
+		}
+		id := cpi.ConsumerIdentity{
+			identity.ID_TYPE:     identity.CONSUMER_TYPE,
+			identity.ID_HOSTNAME: host,
+		}
+		if src, err := cpi.DefaultContext.GetCredentialsForConsumer(id); err != nil || src == nil {
+			creds := cpi.NewCredentials(common.Properties{cpi.ATTR_IDENTITY_TOKEN: t})
+			cpi.DefaultContext.SetCredentialsForConsumer(id, creds)
+		}
+	}
+}

--- a/pkg/contexts/credentials/builtin/init.go
+++ b/pkg/contexts/credentials/builtin/init.go
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package builtin
+
+import _ "github.com/open-component-model/ocm/pkg/contexts/credentials/builtin/github"

--- a/pkg/contexts/credentials/init.go
+++ b/pkg/contexts/credentials/init.go
@@ -5,6 +5,7 @@
 package credentials
 
 import (
+	_ "github.com/open-component-model/ocm/pkg/contexts/credentials/builtin"
 	_ "github.com/open-component-model/ocm/pkg/contexts/credentials/config"
 	_ "github.com/open-component-model/ocm/pkg/contexts/credentials/repositories"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

If a `GITHUB_TOKEN` is found in the environment appropriate credentials are set for the actual `GITHUB_HOST`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
