### PR TITLE
option to write normalized cd into file(s)

### DIFF
--- a/cmds/ocm/commands/ocmcmds/components/hash/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/components/hash/cmd.go
@@ -6,7 +6,10 @@ package hash
 
 import (
 	"fmt"
+	"strings"
 
+	"github.com/mandelsoft/filepath/pkg/filepath"
+	"github.com/mandelsoft/vfs/pkg/vfs"
 	"github.com/spf13/cobra"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/common/options/closureoption"
@@ -130,6 +133,7 @@ type Manifest struct {
 
 var outputs = output.NewOutputs(getRegular, output.Outputs{
 	"wide": getWide,
+	"norm": getNorm,
 }).AddChainedManifestOutputs(output.ComposeChain(closureoption.OutputChainFunction(comphdlr.ClosureExplode, comphdlr.Sort), mapManifest))
 
 func mapManifest(opts *output.Options) processing.ProcessChain {
@@ -147,21 +151,90 @@ func getWide(opts *output.Options) output.Output {
 	return TableOutput(opts, h, h.mapGetWideOutput, "NORMALIZED FORM").New()
 }
 
+func getNorm(opts *output.Options) output.Output {
+	h := newHandler(opts)
+	return h
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 type handler struct {
+	ctx  clictx.Context
 	opts *hashoption.Option
 	mode *Option
+
+	norms map[common.NameVersion]string
 }
 
+//////////
+// handler as output.Output
+
+func (h *handler) Add(e interface{}) error {
+	m := h._manifester(h.digester(e))
+	if m.Error != "" {
+		return fmt.Errorf("cannot handle %s: %s\n", m.History, m.Error)
+	}
+	h.norms[common.NewNameVersion(m.Component, m.Version)] = m.Normalized
+	return nil
+}
+
+func (h *handler) Close() error {
+	return nil
+}
+
+func (h *handler) Out() error {
+	if len(h.norms) > 1 {
+		dir := h.mode.outfile
+		if strings.HasSuffix(dir, ".ncd") {
+			dir = dir[:len(dir)-4]
+		}
+		err := h.ctx.FileSystem().Mkdir(dir, 0o755)
+		if err != nil {
+			return fmt.Errorf("cannot create output dir %s", dir)
+		}
+		for k, n := range h.norms {
+			p := filepath.Join(dir, k.String())
+			err := h.write(p+".ncd", n)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		for _, n := range h.norms {
+			return h.write(h.mode.outfile, n)
+		}
+	}
+	return nil
+}
+
+func (h *handler) write(p, n string) error {
+	dir := filepath.Dir(p)
+	err := h.ctx.FileSystem().MkdirAll(dir, 0o755)
+	if err != nil {
+		return fmt.Errorf("cannot create dir %s", dir)
+	}
+	return vfs.WriteFile(h.ctx.FileSystem(), p, []byte(n), 0o644)
+}
+
+/////////
+
 func newHandler(opts *output.Options) *handler {
-	return &handler{
+	h := &handler{
+		ctx:  opts.Context,
 		opts: hashoption.From(opts),
 		mode: From(opts),
 	}
+	if opts.OutputMode == "norm" {
+		h.norms = map[common.NameVersion]string{}
+	}
+	return h
 }
 
 func (h *handler) manifester(e interface{}) interface{} {
+	return h._manifester(e)
+}
+
+func (h *handler) _manifester(e interface{}) *Manifest {
 	p := e.(*Object)
 
 	tag := "-"

--- a/cmds/ocm/commands/ocmcmds/components/hash/options.go
+++ b/cmds/ocm/commands/ocmcmds/components/hash/options.go
@@ -28,11 +28,13 @@ var _ options.Options = (*Option)(nil)
 type Option struct {
 	Actual bool
 
-	action signingcmd.Action
+	action  signingcmd.Action
+	outfile string
 }
 
 func (o *Option) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVarP(&o.Actual, "actual", "", false, "use actual component descriptor")
+	fs.StringVarP(&o.outfile, "outfile", "O", "norm.ncd", "Output file for normalized component descriptor")
 }
 
 func (o *Option) Complete(cmd *Command) error {

--- a/docs/reference/ocm_hash_componentversions.md
+++ b/docs/reference/ocm_hash_componentversions.md
@@ -16,7 +16,8 @@ ocm hash componentversions [<options>] {<component-reference>}
       --latest                    restrict component versions to latest
       --lookup stringArray        repository name or spec for closure lookup fallback
   -N, --normalization string      normalization algorithm (default "jsonNormalisation/v1")
-  -o, --output string             output mode (JSON, json, wide, yaml)
+  -O, --outfile string            Output file for normalized component descriptor (default "norm.ncd")
+  -o, --output string             output mode (JSON, json, norm, wide, yaml)
   -r, --recursive                 follow component reference nesting
       --repo string               repository name or spec
   -s, --sort stringArray          sort fields
@@ -108,6 +109,7 @@ With the option <code>--output</code> the output mode can be selected.
 The following modes are supported:
  - JSON
  - json
+ - norm
  - wide
  - yaml
 

--- a/pkg/contexts/oci/repositories/ocireg/type.go
+++ b/pkg/contexts/oci/repositories/ocireg/type.go
@@ -60,6 +60,13 @@ func NewRepositorySpec(baseURL string) *RepositorySpec {
 	}
 }
 
+func NewLegacyRepositorySpec(baseURL string) *RepositorySpec {
+	return &RepositorySpec{
+		ObjectVersionedType: runtime.NewVersionedObjectType(LegacyType),
+		BaseURL:             baseURL,
+	}
+}
+
 func (a *RepositorySpec) GetType() string {
 	return Type
 }

--- a/pkg/contexts/ocm/repositories/genericocireg/uniform.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/uniform.go
@@ -6,6 +6,7 @@ package genericocireg
 
 import (
 	"github.com/open-component-model/ocm/pkg/contexts/oci/repositories/ocireg"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/attrs/compatattr"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 )
 
@@ -22,6 +23,9 @@ func (h *repospechandler) MapReference(ctx cpi.Context, u *cpi.UniformRepository
 	var meta *ComponentRepositoryMeta
 	if u.SubPath != "" {
 		meta = NewComponentRepositoryMeta(u.SubPath, "")
+	}
+	if compatattr.Get(ctx) {
+		return NewRepositorySpec(ocireg.NewLegacyRepositorySpec(u.Host), meta), nil
 	}
 	return NewRepositorySpec(ocireg.NewRepositorySpec(u.Host), meta), nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

It extends the hash command to write normalized component descriptors into files.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
