### PR TITLE
Add release-drafter GitHub Action workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,15 +5,10 @@ Fixes #
 
 **Special notes for your reviewer**:
 
-**Release note**:
-<!--  Write your release note:
-1. Enter your release note in the below block.
-2. If no release note is required, just write "NONE" within the block.
-
-Format of block header: <category> <target_group>
-Possible values:
-- category:       breaking|feature|bugfix|doc|other
-- target_group:   user|operator|developer|dependency
+**Release Notes**:
+<!--
+Please ensure that the title of this PR is good so that it can be added to the release notes.
+To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
 -->
 ```feature user
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,11 @@
+name-template: '$NEXT_MINOR_VERSION'
+tag-template: '$NEXT_MINOR_VERSION'
+version-template: '$COMPLETE'
+change-template: '- $TITLE (#$NUMBER)'
+change-title-escapes: '\<*_&#@`'
+template: |
+  # Release $NEXT_MINOR_VERSION
+
+  $CHANGES
+exclude-labels:
+  - 'kind/skip-release-notes'

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,19 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a workflow to automatically generate a draft with release notes for the next minor version (based on latest tag), using `release-drafter`. When new PRs are pushed to `main`, their title will be added to the release notes.

**Which issue(s) this PR fixes**:
Completes first step in https://github.com/open-component-model/ocm/issues/101