### PR TITLE
Add `workflow_call` to lint workflow

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read


### PR DESCRIPTION
**What this PR does / why we need it**:

We need to add a `workflow_call` to the lint/test workflow so that it can be used from the release workflow, which failed here due to this: https://github.com/open-component-model/ocm/actions/runs/4005104187