### PR TITLE
Add permissions to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,9 @@ on:
 jobs:
   lint-and-test:
     uses: ./.github/workflows/lint_and_test.yaml
+    permissions:
+      contents: read
+      pull-requests: read
   release:
     name: Trigger release build
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What this PR does / why we need it**:
Error: https://github.com/open-component-model/ocm/actions/runs/4005777395 

Add permissions for the lint/test job to use it in the release workflow.