### PR TITLE
Fixes for release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
       contents: read
       pull-requests: read
   release:
+    needs: lint-and-test
     name: Trigger release build
     runs-on: ubuntu-latest
     permissions:
@@ -29,6 +30,7 @@ jobs:
     - name: Cache go-build and mod
       uses: actions/cache@v3
       with:
+        go-version-file: go.mod
         path: |
           ~/.cache/go-build/
           ~/go/pkg/mod/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,5 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
-before:
-  hooks:
-    - go mod tidy
 builds:
   - main: ./cmds/ocm/main.go
     env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,8 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+before:
+  hooks:
+    - go mod tidy
 builds:
   - main: ./cmds/ocm/main.go
     env:
@@ -9,12 +12,12 @@ builds:
       - windows
       - darwin
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
**What this PR does / why we need it**:

- Fixing the following Goreleaser errors: https://github.com/open-component-model/ocm/actions/runs/4007881021/jobs/6881323108 by ensuring that the Go versions in `go-cache` step matches the one in `go.mod`.
- Replacing the deprecated `archives` config for goreleaser from the warning, see: https://goreleaser.com/deprecations/#archivesreplacements
- Adding a `needs` to the release job to ensure that there is a successful run of lint-and-tester beforehand.