### PR TITLE
Set Go version in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,10 +27,13 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - name: Setup Go
+      uses: actions/setup-go@v3
+      with:
+        go-version-file: $GITHUB_WORKSPACE/go.mod
     - name: Cache go-build and mod
       uses: actions/cache@v3
       with:
-        go-version-file: go.mod
         path: |
           ~/.cache/go-build/
           ~/go/pkg/mod/


### PR DESCRIPTION
**What this PR does / why we need it**:

Using `actions/setup-go@v3` to set the Go version correctly in the release worfklow to match the Go version in `go.mod`.