### PR TITLE
Add event to update version on website

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,3 +86,11 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GORELEASER_CURRENT_TAG: ${{ env.RELEASE_VERSION }}
+    - name: Repository Dispatch
+      if: inputs.release_candidate == false
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        token: ${{ secrets.EVENT_API }}
+        repository: open-component-model/ocm-website
+        event-type: ocm-cli-release
+        client-payload: '{"tag": "${{ env.RELEASE_VERSION }}"}'


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR triggers an event to update the release version for the `ocm` CLI in the ocm website.

**Which issue(s) this PR fixes**:
Addresses https://github.com/open-component-model/ocm/issues/238 for the `ocm` CLI
