### PR TITLE
Add Homebrew to Release Process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,6 +85,7 @@ jobs:
         args: release --rm-dist --timeout 60m --skip-validate --config=./.goreleaser.yaml --release-notes=${{ env.RELEASE_NOTES_FILE }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.EVENT_API }}
         GORELEASER_CURRENT_TAG: ${{ env.RELEASE_VERSION }}
     - name: Repository Dispatch
       if: inputs.release_candidate == false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -28,3 +28,14 @@ changelog:
     exclude:
       - '^docs:'
       - '^test:'
+brews:
+  - name: ocm
+    tap:
+      owner: open-component-model
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    folder: Formula
+    homepage: "https://ocm.software/"
+    description: "The OCM CLI makes it easy to create component versions and embed them in build processes."
+    test: |
+      system "#{bin}/ocm --version"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the release workflow to publish a homebrew forumla for the OCM CLI to the 'open-component-model/homebrew-tap' repository.


**Which issue(s) this PR fixes**:
Fixes #239

Should also address #227 

Signed-off-by: Piaras Hoban <phoban01@gmail.com>
