### PR TITLE
check type assertions where it makes sense to avoid runtime panics

### DIFF
--- a/cmds/ocm/commands/ocicmds/artifacts/transfer/cmd.go
+++ b/cmds/ocm/commands/ocicmds/artifacts/transfer/cmd.go
@@ -152,7 +152,10 @@ func NewAction(ctx clictx.Context, session oci.Session, target string, transferR
 }
 
 func (a *action) Add(e interface{}) error {
-	src := e.(*artifacthdlr.Object)
+	src, ok := e.(*artifacthdlr.Object)
+	if !ok {
+		return fmt.Errorf("failed type assertion for type %T to artifacthtlr.Object", e)
+	}
 
 	ns := src.Namespace.GetNamespace()
 	if ns == "" && a.Ref.IsRegistry() {

--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/comp/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/comp/elements.go
@@ -67,7 +67,7 @@ func (*ResourceSpecHandler) Add(ctx clictx.Context, ictx inputs.Context, elem ad
 
 	r, ok := elem.Spec().(*ResourceSpec)
 	if !ok {
-		return fmt.Errorf("element spec is not a valid resource spec")
+		return fmt.Errorf("element spec is not a valid resource spec, failed to assert type %T to ResourceSpec", elem.Spec())
 	}
 	comp, err := repo.LookupComponent(r.Name)
 	if err != nil {

--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/comp/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/comp/elements.go
@@ -65,7 +65,10 @@ func (*ResourceSpecHandler) Add(ctx clictx.Context, ictx inputs.Context, elem ad
 	var final utils.Finalizer
 	defer final.FinalizeWithErrorPropagation(&err)
 
-	r := elem.Spec().(*ResourceSpec)
+	r, ok := elem.Spec().(*ResourceSpec)
+	if !ok {
+		return fmt.Errorf("element spec is not a valid resource spec")
+	}
 	comp, err := repo.LookupComponent(r.Name)
 	if err != nil {
 		return errors.ErrNotFound(errors.KIND_COMPONENT, r.Name)

--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/refs/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/refs/elements.go
@@ -40,7 +40,10 @@ func (ResourceSpecHandler) Decode(data []byte) (addhdlrs.ElementSpec, error) {
 }
 
 func (ResourceSpecHandler) Set(v ocm.ComponentVersionAccess, r addhdlrs.Element, acc compdesc.AccessSpec) error {
-	spec := r.Spec().(*ResourceSpec)
+	spec, ok := r.Spec().(*ResourceSpec)
+	if !ok {
+		return fmt.Errorf("element spec is not a valid resource spec")
+	}
 	vers := spec.Version
 	if vers == "" {
 		vers = v.GetVersion()

--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/refs/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/refs/elements.go
@@ -42,7 +42,7 @@ func (ResourceSpecHandler) Decode(data []byte) (addhdlrs.ElementSpec, error) {
 func (ResourceSpecHandler) Set(v ocm.ComponentVersionAccess, r addhdlrs.Element, acc compdesc.AccessSpec) error {
 	spec, ok := r.Spec().(*ResourceSpec)
 	if !ok {
-		return fmt.Errorf("element spec is not a valid resource spec")
+		return fmt.Errorf("element spec is not a valid resource spec, failed to assert type %T to ResourceSpec", r.Spec())
 	}
 	vers := spec.Version
 	if vers == "" {

--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/rscs/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/rscs/elements.go
@@ -46,7 +46,10 @@ func (ResourceSpecHandler) Decode(data []byte) (addhdlrs.ElementSpec, error) {
 }
 
 func (ResourceSpecHandler) Set(v ocm.ComponentVersionAccess, r addhdlrs.Element, acc compdesc.AccessSpec) error {
-	spec := r.Spec().(*ResourceSpec)
+	spec, ok := r.Spec().(*ResourceSpec)
+	if !ok {
+		return fmt.Errorf("element spec is not a valid resource spec")
+	}
 	vers := spec.Version
 	if spec.Relation == metav1.LocalRelation {
 		if vers == "" || vers == ComponentVersionTag {

--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/rscs/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/rscs/elements.go
@@ -48,7 +48,7 @@ func (ResourceSpecHandler) Decode(data []byte) (addhdlrs.ElementSpec, error) {
 func (ResourceSpecHandler) Set(v ocm.ComponentVersionAccess, r addhdlrs.Element, acc compdesc.AccessSpec) error {
 	spec, ok := r.Spec().(*ResourceSpec)
 	if !ok {
-		return fmt.Errorf("element spec is not a valid resource spec")
+		return fmt.Errorf("element spec is not a valid resource spec, failed to assert type %T to ResourceSpec", r.Spec())
 	}
 	vers := spec.Version
 	if spec.Relation == metav1.LocalRelation {

--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/srcs/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/srcs/elements.go
@@ -40,7 +40,10 @@ func (ResourceSpecHandler) Decode(data []byte) (addhdlrs.ElementSpec, error) {
 }
 
 func (ResourceSpecHandler) Set(v ocm.ComponentVersionAccess, r addhdlrs.Element, acc compdesc.AccessSpec) error {
-	spec := r.Spec().(*ResourceSpec)
+	spec, ok := r.Spec().(*ResourceSpec)
+	if !ok {
+		return fmt.Errorf("element spec is not a valid resource spec")
+	}
 	vers := spec.Version
 	if vers == "" {
 		vers = v.GetVersion()

--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/srcs/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/srcs/elements.go
@@ -42,7 +42,7 @@ func (ResourceSpecHandler) Decode(data []byte) (addhdlrs.ElementSpec, error) {
 func (ResourceSpecHandler) Set(v ocm.ComponentVersionAccess, r addhdlrs.Element, acc compdesc.AccessSpec) error {
 	spec, ok := r.Spec().(*ResourceSpec)
 	if !ok {
-		return fmt.Errorf("element spec is not a valid resource spec")
+		return fmt.Errorf("element spec is not a valid resource spec, failed to assert type %T to ResourceSpec", r.Spec())
 	}
 	vers := spec.Version
 	if vers == "" {

--- a/cmds/ocm/commands/ocmcmds/common/cmds/signing/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/common/cmds/signing/cmd.go
@@ -60,7 +60,7 @@ func (o *SignatureCommand) ForName(name string) *cobra.Command {
 		Use:   "[<options>] {<component-reference>}",
 		Short: o.spec.op + " component version",
 		Long: `
-` + o.spec.op + ` specified component versions. 
+` + o.spec.op + ` specified component versions.
 `,
 		Example: o.spec.example,
 	}
@@ -136,7 +136,10 @@ func (a *action) Digest(o *comphdlr.Object) (*metav1.DigestSpec, *compdesc.Compo
 }
 
 func (a *action) Add(e interface{}) error {
-	o := e.(*comphdlr.Object)
+	o, ok := e.(*comphdlr.Object)
+	if !ok {
+		return fmt.Errorf("failed to assert %T to *comphdlr.Object", e)
+	}
 	cv := o.ComponentVersion
 	d, _, err := a.Digest(o)
 	a.errlist.Add(err)

--- a/cmds/ocm/commands/ocmcmds/common/handlers/elemhdlr/typehandler.go
+++ b/cmds/ocm/commands/ocmcmds/common/handlers/elemhdlr/typehandler.go
@@ -5,6 +5,7 @@
 package elemhdlr
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/common/options/closureoption"
@@ -200,7 +201,10 @@ func (h *TypeHandler) Get(elemspec utils.ElemSpec) ([]output.Object, error) {
 func (h *TypeHandler) get(c *comphdlr.Object, elemspec utils.ElemSpec) ([]output.Object, error) {
 	var result []output.Object
 
-	selector := elemspec.(metav1.Identity)
+	selector, ok := elemspec.(metav1.Identity)
+	if !ok {
+		return nil, fmt.Errorf("element spec is not a valid identity")
+	}
 	elemaccess := h.elemaccess(c.ComponentVersion)
 	l := elemaccess.Len()
 	for i := 0; i < l; i++ {

--- a/cmds/ocm/commands/ocmcmds/common/handlers/elemhdlr/typehandler.go
+++ b/cmds/ocm/commands/ocmcmds/common/handlers/elemhdlr/typehandler.go
@@ -203,7 +203,7 @@ func (h *TypeHandler) get(c *comphdlr.Object, elemspec utils.ElemSpec) ([]output
 
 	selector, ok := elemspec.(metav1.Identity)
 	if !ok {
-		return nil, fmt.Errorf("element spec is not a valid identity")
+		return nil, fmt.Errorf("element spec is not a valid identity, failed to assert type %T to metav1.Identity", elemspec)
 	}
 	elemaccess := h.elemaccess(c.ComponentVersion)
 	l := elemaccess.Len()

--- a/cmds/ocm/commands/ocmcmds/components/transfer/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/components/transfer/cmd.go
@@ -90,7 +90,7 @@ func (o *Command) Run() error {
 	session := ocm.NewSession(nil)
 	defer session.Close()
 	session.Finalize(o.OCMContext())
-	
+
 	err := o.ProcessOnOptions(ocmcommon.CompleteOptionsWithSession(o, session))
 	if err != nil {
 		return err
@@ -146,7 +146,10 @@ type action struct {
 var _ output.Output = (*action)(nil)
 
 func (a *action) Add(e interface{}) error {
-	o := e.(*comphdlr.Object)
+	o, ok := e.(*comphdlr.Object)
+	if !ok {
+		return fmt.Errorf("object of type %T is not a valid comphdlr.Object", e)
+	}
 	err := transfer.TransferVersion(a.printer, a.closure, o.ComponentVersion, a.target, a.handler)
 	a.errors.Add(err)
 	if err != nil {

--- a/cmds/ocm/commands/toicmds/components/bootstrap/cmd.go
+++ b/cmds/ocm/commands/toicmds/components/bootstrap/cmd.go
@@ -5,6 +5,8 @@
 package bootstrap
 
 import (
+	"fmt"
+
 	"github.com/mandelsoft/vfs/pkg/vfs"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -88,7 +90,7 @@ printed to standard out. If the output file is a directory, for every output a
 dedicated file is created, otherwise the yaml representation is stored to the
 file.
 
-If no credentials file name is provided (option -c) the file 
+If no credentials file name is provided (option -c) the file
 <code>` + DEFAULT_CREDENTIALS_FILE + `</code> is used, if present. If no parameter file name is
 provided (option -p) the file <code>` + DEFAULT_PARAMETER_FILE + `</code> is used, if present.
 `,
@@ -166,7 +168,10 @@ func (a *action) Add(e interface{}) error {
 	if len(a.data) > 0 {
 		return errors.New("found multiple component versions")
 	}
-	o := e.(*comphdlr.Object)
+	o, ok := e.(*comphdlr.Object)
+	if !ok {
+		return fmt.Errorf("object of type %T is not a valid comphdlr.Object", e)
+	}
 	if o.ComponentVersion != nil && !ocireg.IsKind(o.Repository.GetSpecification().GetKind()) {
 		out.Outf(a.cmd, "Warning: repository is no OCI registry, consider importing it or use upload repository with option ' -X ociuploadrepo=...'")
 	}

--- a/pkg/cobrautils/flagsets/provider.go
+++ b/pkg/cobrautils/flagsets/provider.go
@@ -83,9 +83,16 @@ func (p *typedConfigProvider) GetConfigFor(opts ConfigOptions) (Config, error) {
 
 	var data Config
 	if cfgv != nil {
-		data = cfgv.(Config)
+		var ok bool
+		data, ok = cfgv.(Config)
+		if !ok {
+			return nil, fmt.Errorf("failed to assert type %T as Config", cfgv)
+		}
 	}
-	typ := typv.(string)
+	typ, ok := typv.(string)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type %T as string", typv)
+	}
 
 	opts = opts.FilterBy(p.HasOptionType)
 	if typ == "" && data != nil && data["type"] != nil {

--- a/pkg/contexts/credentials/internal/credentialsspec.go
+++ b/pkg/contexts/credentials/internal/credentialsspec.go
@@ -75,7 +75,11 @@ func (s *DefaultCredentialsSpec) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("failed ot unmarshal spec data: %w", err)
 	}
 
-	s.RepositorySpec = repo.(RepositorySpec)
+	var ok bool
+	s.RepositorySpec, ok = repo.(RepositorySpec)
+	if !ok {
+		return fmt.Errorf("invalid repository spec type: %T", repo)
+	}
 	s.CredentialsName = specdata.Name
 	return nil
 }

--- a/pkg/contexts/credentials/repositories/aliases/type.go
+++ b/pkg/contexts/credentials/repositories/aliases/type.go
@@ -5,6 +5,8 @@
 package aliases
 
 import (
+	"fmt"
+
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/cpi"
 	"github.com/open-component-model/ocm/pkg/runtime"
 )
@@ -20,7 +22,11 @@ func init() {
 }
 
 func setAlias(ctx cpi.Context, name string, spec cpi.RepositorySpec, creds cpi.CredentialsSource) error {
-	repos := ctx.GetAttributes().GetOrCreateAttribute(ATTR_REPOS, newRepositories).(*Repositories)
+	r := ctx.GetAttributes().GetOrCreateAttribute(ATTR_REPOS, newRepositories)
+	repos, ok := r.(*Repositories)
+	if !ok {
+		return fmt.Errorf("failed to assert type %T to Repositories", r)
+	}
 	repos.Set(name, spec, creds)
 	return nil
 }
@@ -44,7 +50,11 @@ func (a *RepositorySpec) GetType() string {
 }
 
 func (a *RepositorySpec) Repository(ctx cpi.Context, creds cpi.Credentials) (cpi.Repository, error) {
-	repos := ctx.GetAttributes().GetOrCreateAttribute(ATTR_REPOS, newRepositories).(*Repositories)
+	r := ctx.GetAttributes().GetOrCreateAttribute(ATTR_REPOS, newRepositories)
+	repos, ok := r.(*Repositories)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type %T to Repositories", r)
+	}
 	alias := repos.GetRepository(a.Alias)
 	if alias == nil {
 		return nil, cpi.ErrUnknownRepository(Type, a.Alias)

--- a/pkg/contexts/credentials/repositories/dockerconfig/type.go
+++ b/pkg/contexts/credentials/repositories/dockerconfig/type.go
@@ -5,6 +5,8 @@
 package dockerconfig
 
 import (
+	"fmt"
+
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/cpi"
 	"github.com/open-component-model/ocm/pkg/runtime"
 )
@@ -49,6 +51,10 @@ func (a *RepositorySpec) GetType() string {
 }
 
 func (a *RepositorySpec) Repository(ctx cpi.Context, creds cpi.Credentials) (cpi.Repository, error) {
-	repos := ctx.GetAttributes().GetOrCreateAttribute(ATTR_REPOS, newRepositories).(*Repositories)
+	r := ctx.GetAttributes().GetOrCreateAttribute(ATTR_REPOS, newRepositories)
+	repos, ok := r.(*Repositories)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type %T to Repositories", r)
+	}
 	return repos.GetRepository(ctx, a.DockerConfigFile, a.PropgateConsumerIdentity)
 }

--- a/pkg/contexts/credentials/repositories/gardenerconfig/type.go
+++ b/pkg/contexts/credentials/repositories/gardenerconfig/type.go
@@ -34,7 +34,7 @@ func init() {
 
 	cpi.RegisterStandardIdentityMatcher(CONSUMER_TYPE, IdentityMatcher, `Gardener config credential matcher
 
-It matches the <code>`+CONSUMER_TYPE+`</code> consumer type and additionally acts like 
+It matches the <code>`+CONSUMER_TYPE+`</code> consumer type and additionally acts like
 the <code>`+hostpath.IDENTITY_TYPE+`</code> type.`)
 }
 
@@ -63,7 +63,11 @@ func (a *RepositorySpec) GetType() string {
 }
 
 func (a *RepositorySpec) Repository(ctx cpi.Context, creds cpi.Credentials) (cpi.Repository, error) {
-	repos := ctx.GetAttributes().GetOrCreateAttribute(ATTR_REPOS, newRepositories).(*Repositories)
+	r := ctx.GetAttributes().GetOrCreateAttribute(ATTR_REPOS, newRepositories)
+	repos, ok := r.(*Repositories)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type %T to Responsitories", r)
+	}
 
 	key, err := getKey(ctx, a.URL)
 	if err != nil {

--- a/pkg/contexts/credentials/repositories/memory/config/type.go
+++ b/pkg/contexts/credentials/repositories/memory/config/type.go
@@ -83,7 +83,10 @@ func (a *Config) ApplyTo(ctx cfgcpi.Context, target interface{}) error {
 		return fmt.Errorf("unable to get repository for spec: %w", err)
 	}
 
-	mem := repo.(*memory.Repository)
+	mem, ok := repo.(*memory.Repository)
+	if !ok {
+		return fmt.Errorf("invalid type assertion of type %T to memory.Repository", repo)
+	}
 
 	for i, e := range a.Credentials {
 		var creds cpi.Credentials

--- a/pkg/contexts/credentials/repositories/memory/type.go
+++ b/pkg/contexts/credentials/repositories/memory/type.go
@@ -5,6 +5,8 @@
 package memory
 
 import (
+	"fmt"
+
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/cpi"
 	"github.com/open-component-model/ocm/pkg/runtime"
 )
@@ -38,6 +40,10 @@ func (a *RepositorySpec) GetType() string {
 }
 
 func (a *RepositorySpec) Repository(ctx cpi.Context, creds cpi.Credentials) (cpi.Repository, error) {
-	repos := ctx.GetAttributes().GetOrCreateAttribute(ATTR_REPOS, newRepositories).(*Repositories)
+	r := ctx.GetAttributes().GetOrCreateAttribute(ATTR_REPOS, newRepositories)
+	repos, ok := r.(*Repositories)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type %T to Repositories", r)
+	}
 	return repos.GetRepository(a.RepositoryName), nil
 }

--- a/pkg/contexts/oci/cpi/base.go
+++ b/pkg/contexts/oci/cpi/base.go
@@ -5,6 +5,7 @@
 package cpi
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/opencontainers/go-digest"
@@ -67,7 +68,10 @@ func (a *artifactBase) newArtifact(art ...*artdesc.Artifact) (ArtifactAccess, er
 }
 
 func (a *artifactBase) Blob() (accessio.BlobAccess, error) {
-	d := a.state.GetState().(artdesc.BlobDescriptorSource)
+	d, ok := a.state.GetState().(artdesc.BlobDescriptorSource)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type %T to artdesc.BlobDescriptorSource", a.state.GetState())
+	}
 	if !d.IsValid() {
 		return nil, errors.ErrUnknown("artifact type")
 	}

--- a/pkg/contexts/oci/cpi/flavor_artifact.go
+++ b/pkg/contexts/oci/cpi/flavor_artifact.go
@@ -5,6 +5,8 @@
 package cpi
 
 import (
+	"fmt"
+
 	"github.com/opencontainers/go-digest"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
@@ -135,7 +137,10 @@ func (a *ArtifactImpl) GetBlobDescriptor(digest digest.Digest) *Descriptor {
 func (a *ArtifactImpl) Index() (*artdesc.Index, error) {
 	a.lock.Lock()
 	defer a.lock.Unlock()
-	d := a.state.GetState().(*artdesc.Artifact)
+	d, ok := a.state.GetState().(*artdesc.Artifact)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type %T to *artdesc.Artifact", a.state.GetState())
+	}
 	idx := d.Index()
 	if idx == nil {
 		idx = artdesc.NewIndex()
@@ -149,7 +154,10 @@ func (a *ArtifactImpl) Index() (*artdesc.Index, error) {
 func (a *ArtifactImpl) Manifest() (*artdesc.Manifest, error) {
 	a.lock.Lock()
 	defer a.lock.Unlock()
-	d := a.state.GetState().(*artdesc.Artifact)
+	d, ok := a.state.GetState().(*artdesc.Artifact)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type %T to *artdesc.Artifact", a.state.GetState())
+	}
 	m := d.Manifest()
 	if m == nil {
 		m = artdesc.NewManifest()

--- a/pkg/contexts/oci/cpi/support/base.go
+++ b/pkg/contexts/oci/cpi/support/base.go
@@ -5,6 +5,7 @@
 package support
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/opencontainers/go-digest"
@@ -68,7 +69,10 @@ func (a *artifactBase) newArtifact(art ...*artdesc.Artifact) (cpi.ArtifactAccess
 }
 
 func (a *artifactBase) Blob() (accessio.BlobAccess, error) {
-	d := a.state.GetState().(artdesc.BlobDescriptorSource)
+	d, ok := a.state.GetState().(artdesc.BlobDescriptorSource)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type %T to artdesc.BlobDescriptorSource", a.state.GetState())
+	}
 	if !d.IsValid() {
 		return nil, errors.ErrUnknown("artifact type")
 	}

--- a/pkg/contexts/oci/cpi/support/flavor_artifact.go
+++ b/pkg/contexts/oci/cpi/support/flavor_artifact.go
@@ -5,6 +5,8 @@
 package support
 
 import (
+	"fmt"
+
 	"github.com/opencontainers/go-digest"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
@@ -109,7 +111,10 @@ func (a *ArtifactImpl) GetBlobDescriptor(digest digest.Digest) *cpi.Descriptor {
 func (a *ArtifactImpl) Index() (*artdesc.Index, error) {
 	a.lock.Lock()
 	defer a.lock.Unlock()
-	d := a.state.GetState().(*artdesc.Artifact)
+	d, ok := a.state.GetState().(*artdesc.Artifact)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type %T to *artdesc.Artifact", a.state.GetState())
+	}
 	idx := d.Index()
 	if idx == nil {
 		idx = artdesc.NewIndex()

--- a/pkg/contexts/ocm/accessmethods/localblob/method.go
+++ b/pkg/contexts/ocm/accessmethods/localblob/method.go
@@ -121,7 +121,10 @@ type converterV1 struct{}
 var LocalBlobV1 = cpi.NewAccessSpecVersion(&AccessSpecV1{}, converterV1{})
 
 func (_ converterV1) ConvertFrom(object cpi.AccessSpec) (runtime.TypedObject, error) {
-	in := object.(*AccessSpec)
+	in, ok := object.(*AccessSpec)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type %T to AccessSpec", object)
+	}
 	return &AccessSpecV1{
 		ObjectVersionedType: runtime.NewVersionedObjectType(in.Type),
 		LocalReference:      in.LocalReference,
@@ -132,7 +135,10 @@ func (_ converterV1) ConvertFrom(object cpi.AccessSpec) (runtime.TypedObject, er
 }
 
 func (_ converterV1) ConvertTo(object interface{}) (cpi.AccessSpec, error) {
-	in := object.(*AccessSpecV1)
+	in, ok := object.(*AccessSpecV1)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type %T to AccessSpecV1", object)
+	}
 	return &AccessSpec{
 		ObjectVersionedType: runtime.NewVersionedObjectType(in.Type),
 		LocalReference:      in.LocalReference,

--- a/pkg/contexts/ocm/accessmethods/localfsblob/method.go
+++ b/pkg/contexts/ocm/accessmethods/localfsblob/method.go
@@ -5,6 +5,8 @@
 package localfsblob
 
 import (
+	"fmt"
+
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/runtime"
@@ -49,7 +51,10 @@ type localfsblobConverterV1 struct{}
 var LocalFilesystemBlobV1 = cpi.NewAccessSpecVersion(&AccessSpec{}, localfsblobConverterV1{})
 
 func (_ localfsblobConverterV1) ConvertFrom(object cpi.AccessSpec) (runtime.TypedObject, error) {
-	in := object.(*localblob.AccessSpec)
+	in, ok := object.(*localblob.AccessSpec)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type %T to localblob.AccessSpec", object)
+	}
 	return &AccessSpec{
 		ObjectVersionedType: runtime.NewVersionedObjectType(in.Type),
 		Filename:            in.LocalReference,
@@ -58,7 +63,10 @@ func (_ localfsblobConverterV1) ConvertFrom(object cpi.AccessSpec) (runtime.Type
 }
 
 func (_ localfsblobConverterV1) ConvertTo(object interface{}) (cpi.AccessSpec, error) {
-	in := object.(*AccessSpec)
+	in, ok := object.(*AccessSpec)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type %T to localfsblob.AccessSpec", object)
+	}
 	return &localblob.AccessSpec{
 		ObjectVersionedType: runtime.NewVersionedObjectType(in.Type),
 		LocalReference:      in.Filename,

--- a/pkg/contexts/ocm/blobhandler/generic/ocirepo/registration.go
+++ b/pkg/contexts/ocm/blobhandler/generic/ocirepo/registration.go
@@ -33,6 +33,7 @@ func (r *RegistrationHandler) RegisterByName(handler string, ctx cpi.Context, co
 		return true, fmt.Errorf("oci target specification required")
 	}
 	var attr *Config
+	var ok bool
 	switch a := config.(type) {
 	case *ociuploadattr.Attribute:
 		attr = a
@@ -41,13 +42,19 @@ func (r *RegistrationHandler) RegisterByName(handler string, ctx cpi.Context, co
 		if err != nil {
 			return true, errors.Wrapf(err, "cannot unmarshal blob handler target configuration")
 		}
-		attr = r.(*ociuploadattr.Attribute)
+		attr, ok = r.(*ociuploadattr.Attribute)
+		if !ok {
+			return true, fmt.Errorf("failed to assert type %T to ociuploadattr.Attribute", r)
+		}
 	case []byte:
 		r, err := ociuploadattr.AttributeType{}.Decode(a, runtime.DefaultYAMLEncoding)
 		if err != nil {
 			return true, errors.Wrapf(err, "cannot unmarshal blob handler target configuration")
 		}
-		attr = r.(*ociuploadattr.Attribute)
+		attr, ok = r.(*ociuploadattr.Attribute)
+		if !ok {
+			return true, fmt.Errorf("failed to assert type %T to ociuploadattr.Attribute", r)
+		}
 	default:
 		return true, fmt.Errorf("unexpected type %T for oci blob handler target", a)
 	}

--- a/pkg/contexts/ocm/blobhandler/oci/ocirepo/blobhandler.go
+++ b/pkg/contexts/ocm/blobhandler/oci/ocirepo/blobhandler.go
@@ -70,7 +70,10 @@ func NewBlobHandler(base BaseFunction) cpi.BlobHandler {
 }
 
 func (b *blobHandler) StoreBlob(blob cpi.BlobAccess, artType, hint string, global cpi.AccessSpec, ctx cpi.StorageContext) (cpi.AccessSpec, error) {
-	ocictx := ctx.(*storagecontext.StorageContext)
+	ocictx, ok := ctx.(*storagecontext.StorageContext)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type %T to storagecontext.StorageContext", ctx)
+	}
 
 	values := []interface{}{
 		"arttype", artType,
@@ -162,7 +165,10 @@ func (b *artifactHandler) StoreBlob(blob cpi.BlobAccess, artType, hint string, g
 	var tag string
 	var digest digest.Digest
 
-	ocictx := ctx.(*storagecontext.StorageContext)
+	ocictx, ok := ctx.(*storagecontext.StorageContext)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type %T to storagecontext.StorageContext", ctx)
+	}
 	base := b.GetBaseURL(ocictx)
 	if hint == "" {
 		namespace = ocictx.Namespace

--- a/pkg/contexts/ocm/blobhandler/ocm/comparch/blobhandler.go
+++ b/pkg/contexts/ocm/blobhandler/ocm/comparch/blobhandler.go
@@ -5,6 +5,8 @@
 package comparch
 
 import (
+	"fmt"
+
 	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localfsblob"
@@ -29,7 +31,10 @@ func NewBlobHandler() cpi.BlobHandler {
 }
 
 func (b *blobHandler) StoreBlob(blob cpi.BlobAccess, artType, hint string, global cpi.AccessSpec, ctx cpi.StorageContext) (cpi.AccessSpec, error) {
-	ocmctx := ctx.(storagecontext.StorageContext)
+	ocmctx, ok := ctx.(storagecontext.StorageContext)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type %T to storagecontext.StorageContext", ctx)
+	}
 
 	if blob == nil {
 		return nil, errors.New("a resource has to be defined")

--- a/pkg/contexts/ocm/repositories/genericocireg/state.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/state.go
@@ -230,7 +230,10 @@ func (i StateHandler) Initial() interface{} {
 
 // Encode always provides a yaml representation.
 func (i StateHandler) Encode(d interface{}) ([]byte, error) {
-	desc := d.(*compdesc.ComponentDescriptor)
+	desc, ok := d.(*compdesc.ComponentDescriptor)
+	if !ok {
+		return nil, fmt.Errorf("failed to assert type %t to *compdesc.ComponentDescriptor", d)
+	}
 	desc.Name = i.name
 	desc.Version = i.version
 	return compdesc.Encode(desc)


### PR DESCRIPTION
**What this PR does / why we need it**:

#22 - This PR adds type assertion checks where it feel sensible in order to avoid `nil` pointer referencing that causes runtime panics. 

There are still a lot of type assertions occurring in the code, but adding checks for many of these either didn't make sense in the context, or would require code refactoring beyond the scope of the ticket.

**Which issue(s) this PR fixes**:
Fixes #22


