### PR TITLE
add gofmt to make format and run

### DIFF
--- a/cmds/ocm/commands/ocmcmds/common/options/uploaderoption/uploader_test.go
+++ b/cmds/ocm/commands/ocmcmds/common/options/uploaderoption/uploader_test.go
@@ -32,7 +32,7 @@ var _ = Describe("uploader option", func() {
 		MustBeSuccessful(flags.Parse([]string{`--uploader`, `plugin/name:art:media={"name":"Name"}`}))
 		MustBeSuccessful(opt.Complete(ctx))
 
-		Expect(opt.Registrations).To(Equal([]*Registration{&Registration{
+		Expect(opt.Registrations).To(Equal([]*Registration{{
 			Name:         "plugin/name",
 			ArtifactType: "art",
 			MediaType:    "media",
@@ -44,7 +44,7 @@ var _ = Describe("uploader option", func() {
 		MustBeSuccessful(flags.Parse([]string{`--uploader`, `plugin/name:art={"name":"Name"}`}))
 		MustBeSuccessful(opt.Complete(ctx))
 
-		Expect(opt.Registrations).To(Equal([]*Registration{&Registration{
+		Expect(opt.Registrations).To(Equal([]*Registration{{
 			Name:         "plugin/name",
 			ArtifactType: "art",
 			MediaType:    "",
@@ -56,7 +56,7 @@ var _ = Describe("uploader option", func() {
 		MustBeSuccessful(flags.Parse([]string{`--uploader`, `plugin/name={"name":"Name"}`}))
 		MustBeSuccessful(opt.Complete(ctx))
 
-		Expect(opt.Registrations).To(Equal([]*Registration{&Registration{
+		Expect(opt.Registrations).To(Equal([]*Registration{{
 			Name:         "plugin/name",
 			ArtifactType: "",
 			MediaType:    "",
@@ -68,7 +68,7 @@ var _ = Describe("uploader option", func() {
 		MustBeSuccessful(flags.Parse([]string{`--uploader`, `plugin/name::={"name":"Name"}`}))
 		MustBeSuccessful(opt.Complete(ctx))
 
-		Expect(opt.Registrations).To(Equal([]*Registration{&Registration{
+		Expect(opt.Registrations).To(Equal([]*Registration{{
 			Name:         "plugin/name",
 			ArtifactType: "",
 			MediaType:    "",
@@ -80,7 +80,7 @@ var _ = Describe("uploader option", func() {
 		MustBeSuccessful(flags.Parse([]string{`--uploader`, `plugin/name=Name`}))
 		MustBeSuccessful(opt.Complete(ctx))
 
-		Expect(opt.Registrations).To(Equal([]*Registration{&Registration{
+		Expect(opt.Registrations).To(Equal([]*Registration{{
 			Name:         "plugin/name",
 			ArtifactType: "",
 			MediaType:    "",

--- a/cmds/ocm/commands/ocmcmds/common/resources.go
+++ b/cmds/ocm/commands/ocmcmds/common/resources.go
@@ -8,12 +8,12 @@ import (
 	"encoding/json"
 	"fmt"
 
+	_ "github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs/types"
+
 	"github.com/mandelsoft/vfs/pkg/vfs"
 	"github.com/spf13/pflag"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
-
-	_ "github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs/types"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/addhdlrs"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs"

--- a/cmds/ocm/commands/ocmcmds/components/transfer/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/components/transfer/cmd.go
@@ -90,7 +90,7 @@ func (o *Command) Run() error {
 	session := ocm.NewSession(nil)
 	defer session.Close()
 	session.Finalize(o.OCMContext())
-	
+
 	err := o.ProcessOnOptions(ocmcommon.CompleteOptionsWithSession(o, session))
 	if err != nil {
 		return err

--- a/cmds/ocm/commands/ocmcmds/resources/download/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/resources/download/cmd.go
@@ -113,7 +113,7 @@ func (o *Command) Complete(args []string) error {
 		}
 		if len(o.Ids) == 0 {
 			o.Ids = []v1.Identity{
-				v1.Identity{},
+				{},
 			}
 		}
 		for _, id := range o.Ids {

--- a/hack/format.sh
+++ b/hack/format.sh
@@ -21,3 +21,7 @@ gci diff --skip-generated "${GCIFMT[@]}"  $@ </dev/null \
   | xargs -I "{}" \
     gci write --skip-generated  "${GCIFMT[@]}" "{}"
 log "Format done"
+
+log "Format with gofmt"
+gofmt -s -w $@
+log "Format done"

--- a/pkg/contexts/credentials/config/config_test.go
+++ b/pkg/contexts/credentials/config/config_test.go
@@ -68,7 +68,7 @@ var _ = Describe("generic credentials", func() {
 			Expect(err).To(Succeed())
 			s := &S{
 				Repositories: map[string]localconfig.RepositorySpec{
-					"repo": localconfig.RepositorySpec{Repository: *rspec},
+					"repo": {Repository: *rspec},
 				},
 			}
 			data, err := json.Marshal(s)

--- a/pkg/contexts/ocm/compdesc/versions/ocm.gardener.cloud/v3alpha1/jsonscheme/bindata.go
+++ b/pkg/contexts/ocm/compdesc/versions/ocm.gardener.cloud/v3alpha1/jsonscheme/bindata.go
@@ -162,11 +162,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("nonexistent") would return an error
@@ -199,16 +201,16 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"..": &bintree{nil, map[string]*bintree{
-		"..": &bintree{nil, map[string]*bintree{
-			"..": &bintree{nil, map[string]*bintree{
-				"..": &bintree{nil, map[string]*bintree{
-					"..": &bintree{nil, map[string]*bintree{
-						"..": &bintree{nil, map[string]*bintree{
-							"..": &bintree{nil, map[string]*bintree{
-								"..": &bintree{nil, map[string]*bintree{
-									"resources": &bintree{nil, map[string]*bintree{
-										"component-descriptor-ocm-v3-schema.yaml": &bintree{ResourcesComponentDescriptorOcmV3SchemaYaml, map[string]*bintree{}},
+	"..": {nil, map[string]*bintree{
+		"..": {nil, map[string]*bintree{
+			"..": {nil, map[string]*bintree{
+				"..": {nil, map[string]*bintree{
+					"..": {nil, map[string]*bintree{
+						"..": {nil, map[string]*bintree{
+							"..": {nil, map[string]*bintree{
+								"..": {nil, map[string]*bintree{
+									"resources": {nil, map[string]*bintree{
+										"component-descriptor-ocm-v3-schema.yaml": {ResourcesComponentDescriptorOcmV3SchemaYaml, map[string]*bintree{}},
 									}},
 								}},
 							}},

--- a/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1/jsonscheme/bindata.go
+++ b/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1/jsonscheme/bindata.go
@@ -158,11 +158,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("nonexistent") would return an error
@@ -195,16 +197,16 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"..": &bintree{nil, map[string]*bintree{
-		"..": &bintree{nil, map[string]*bintree{
-			"..": &bintree{nil, map[string]*bintree{
-				"..": &bintree{nil, map[string]*bintree{
-					"..": &bintree{nil, map[string]*bintree{
-						"..": &bintree{nil, map[string]*bintree{
-							"..": &bintree{nil, map[string]*bintree{
-								"..": &bintree{nil, map[string]*bintree{
-									"resources": &bintree{nil, map[string]*bintree{
-										"component-descriptor-ocm-v3-schema.yaml": &bintree{ResourcesComponentDescriptorOcmV3SchemaYaml, map[string]*bintree{}},
+	"..": {nil, map[string]*bintree{
+		"..": {nil, map[string]*bintree{
+			"..": {nil, map[string]*bintree{
+				"..": {nil, map[string]*bintree{
+					"..": {nil, map[string]*bintree{
+						"..": {nil, map[string]*bintree{
+							"..": {nil, map[string]*bintree{
+								"..": {nil, map[string]*bintree{
+									"resources": {nil, map[string]*bintree{
+										"component-descriptor-ocm-v3-schema.yaml": {ResourcesComponentDescriptorOcmV3SchemaYaml, map[string]*bintree{}},
 									}},
 								}},
 							}},

--- a/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1/jsonscheme/jsonscheme.go
+++ b/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1/jsonscheme/jsonscheme.go
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:generate go-bindata -pkg jsonscheme ../../../../../../../../resources/component-descriptor-ocm-v3-schema.yaml
+//go:generate gofmt -s -w bindata.go
 
 package jsonscheme
 

--- a/pkg/contexts/ocm/compdesc/versions/v2/jsonscheme/bindata.go
+++ b/pkg/contexts/ocm/compdesc/versions/v2/jsonscheme/bindata.go
@@ -158,11 +158,13 @@ var _bindata = map[string]func() (*asset, error){
 // directory embedded in the file by go-bindata.
 // For example if you run go-bindata on data/... and data contains the
 // following hierarchy:
-//     data/
-//       foo.txt
-//       img/
-//         a.png
-//         b.png
+//
+//	data/
+//	  foo.txt
+//	  img/
+//	    a.png
+//	    b.png
+//
 // then AssetDir("data") would return []string{"foo.txt", "img"}
 // AssetDir("data/img") would return []string{"a.png", "b.png"}
 // AssetDir("foo.txt") and AssetDir("nonexistent") would return an error
@@ -195,15 +197,15 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"..": &bintree{nil, map[string]*bintree{
-		"..": &bintree{nil, map[string]*bintree{
-			"..": &bintree{nil, map[string]*bintree{
-				"..": &bintree{nil, map[string]*bintree{
-					"..": &bintree{nil, map[string]*bintree{
-						"..": &bintree{nil, map[string]*bintree{
-							"..": &bintree{nil, map[string]*bintree{
-								"resources": &bintree{nil, map[string]*bintree{
-									"component-descriptor-v2-schema.yaml": &bintree{ResourcesComponentDescriptorV2SchemaYaml, map[string]*bintree{}},
+	"..": {nil, map[string]*bintree{
+		"..": {nil, map[string]*bintree{
+			"..": {nil, map[string]*bintree{
+				"..": {nil, map[string]*bintree{
+					"..": {nil, map[string]*bintree{
+						"..": {nil, map[string]*bintree{
+							"..": {nil, map[string]*bintree{
+								"resources": {nil, map[string]*bintree{
+									"component-descriptor-v2-schema.yaml": {ResourcesComponentDescriptorV2SchemaYaml, map[string]*bintree{}},
 								}},
 							}},
 						}},

--- a/pkg/contexts/ocm/compdesc/versions/v2/jsonscheme/jsonscheme.go
+++ b/pkg/contexts/ocm/compdesc/versions/v2/jsonscheme/jsonscheme.go
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:generate go-bindata -pkg jsonscheme ../../../../../../../resources/component-descriptor-v2-schema.yaml
+//go:generate gofmt -s -w bindata.go
 
 package jsonscheme
 

--- a/pkg/contexts/ocm/utils/localize/config_test.go
+++ b/pkg/contexts/ocm/utils/localize/config_test.go
@@ -174,7 +174,7 @@ utilities:
 `)
 
 			libs := []v1.ResourceReference{
-				v1.ResourceReference{
+				{
 					Resource: v1.NewIdentity(LIB),
 				},
 			}
@@ -211,7 +211,7 @@ configRules:
 `
 
 			libs := []v1.ResourceReference{
-				v1.ResourceReference{
+				{
 					Resource: v1.NewIdentity(LIB),
 				},
 			}

--- a/pkg/signing/normalization_test.go
+++ b/pkg/signing/normalization_test.go
@@ -556,10 +556,10 @@ var _ = Describe("normalization", func() {
 	It("list of complex values", func() {
 		v := map[string]interface{}{
 			"list": []map[string]interface{}{
-				map[string]interface{}{
+				{
 					"alice": 25,
 				},
-				map[string]interface{}{
+				{
 					"bob": 26,
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `gofmt` to the `make format` command. The PR also includes the changes introduced by `gofmt`.

**Which issue(s) this PR fixes**:
Fixes #29

