### PR TITLE
update date command in Makefile to work crossplatform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ COMPONENT_CLI_IMAGE_REPOSITORY                 := $(REGISTRY)/cli
 SOURCES := $(shell go list -f '{{$$I:=.Dir}}{{range .GoFiles }}{{$$I}}/{{.}} {{end}}' ./... )
 GOPATH                                         := $(shell go env GOPATH)
 
-NOW         := $(shell date -u +%FT%TZ)
+NOW         := $(shell date -u +%FT%T%:z)
 BUILD_FLAGS := "-s -w \
  -X github.com/open-component-model/ocm/pkg/version.gitVersion=$(EFFECTIVE_VERSION) \
  -X github.com/open-component-model/ocm/pkg/version.gitTreeState=$(GIT_TREE_STATE) \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ COMPONENT_CLI_IMAGE_REPOSITORY                 := $(REGISTRY)/cli
 SOURCES := $(shell go list -f '{{$$I:=.Dir}}{{range .GoFiles }}{{$$I}}/{{.}} {{end}}' ./... )
 GOPATH                                         := $(shell go env GOPATH)
 
-NOW         := $(shell date -u +%FT%T%:z)
+NOW         := $(shell date -u +%FT%T%z)
 BUILD_FLAGS := "-s -w \
  -X github.com/open-component-model/ocm/pkg/version.gitVersion=$(EFFECTIVE_VERSION) \
  -X github.com/open-component-model/ocm/pkg/version.gitTreeState=$(GIT_TREE_STATE) \

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ COMPONENT_CLI_IMAGE_REPOSITORY                 := $(REGISTRY)/cli
 SOURCES := $(shell go list -f '{{$$I:=.Dir}}{{range .GoFiles }}{{$$I}}/{{.}} {{end}}' ./... )
 GOPATH                                         := $(shell go env GOPATH)
 
-NOW         := $(shell date --rfc-3339=seconds | sed 's/ /T/')
+NOW         := $(shell date -u +%FT%TZ)
 BUILD_FLAGS := "-s -w \
  -X github.com/open-component-model/ocm/pkg/version.gitVersion=$(EFFECTIVE_VERSION) \
  -X github.com/open-component-model/ocm/pkg/version.gitTreeState=$(GIT_TREE_STATE) \

--- a/components/demoplugin/Makefile
+++ b/components/demoplugin/Makefile
@@ -17,7 +17,7 @@ OCMSRCS=$(shell find $(REPO_ROOT)/pkg -type f) $(REPO_ROOT)/go.*
 GEN = $(REPO_ROOT)/gen/$(NAME)
 OCM = go run $(REPO_ROOT)/cmds/ocm
 
-NOW         := $(shell date -u +%FT%T%:z)
+NOW         := $(shell date -u +%FT%T%z)
 BUILD_FLAGS := "-s -w \
  -X github.com/open-component-model/ocm/pkg/version.gitVersion=$(EFFECTIVE_VERSION) \
  -X github.com/open-component-model/ocm/pkg/version.gitTreeState=$(GIT_TREE_STATE) \

--- a/components/demoplugin/Makefile
+++ b/components/demoplugin/Makefile
@@ -17,7 +17,7 @@ OCMSRCS=$(shell find $(REPO_ROOT)/pkg -type f) $(REPO_ROOT)/go.*
 GEN = $(REPO_ROOT)/gen/$(NAME)
 OCM = go run $(REPO_ROOT)/cmds/ocm
 
-NOW         := $(shell date --rfc-3339=seconds | sed 's/ /T/')
+NOW         := $(shell date -u +%FT%T%:z)
 BUILD_FLAGS := "-s -w \
  -X github.com/open-component-model/ocm/pkg/version.gitVersion=$(EFFECTIVE_VERSION) \
  -X github.com/open-component-model/ocm/pkg/version.gitTreeState=$(GIT_TREE_STATE) \

--- a/components/helminstaller/Dockerfile
+++ b/components/helminstaller/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=$BUILDPLATFORM golang:1.19 AS builder
 ARG COMMIT EFFECTIVE_VERSION GIT_TREE_STATE
-ARG TARGETOS TARGETARCH 
+ARG TARGETOS TARGETARCH
 
 WORKDIR /go/src/github.com/open-component-model/ocm/
 COPY go.* ./
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=$TARGETOS
 	-X github.com/open-component-model/ocm/pkg/version.gitVersion=$EFFECTIVE_VERSION \
 	-X github.com/open-component-model/ocm/pkg/version.gitTreeState=$GIT_TREE_STATE \
 	-X github.com/open-component-model/ocm/pkg/version.gitCommit=$COMMIT \
-	-X github.com/open-component-model/ocm/pkg/version.buildDate=$(date --rfc-3339=seconds | sed 's/ /T/')" \
+	-X github.com/open-component-model/ocm/pkg/version.buildDate=$(date -u +%FT%T%:z)" \
 	./cmds/helminstaller
 
 ###################################################################################

--- a/components/helminstaller/Dockerfile
+++ b/components/helminstaller/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 GOOS=$TARGETOS
 	-X github.com/open-component-model/ocm/pkg/version.gitVersion=$EFFECTIVE_VERSION \
 	-X github.com/open-component-model/ocm/pkg/version.gitTreeState=$GIT_TREE_STATE \
 	-X github.com/open-component-model/ocm/pkg/version.gitCommit=$COMMIT \
-	-X github.com/open-component-model/ocm/pkg/version.buildDate=$(date -u +%FT%T%:z)" \
+	-X github.com/open-component-model/ocm/pkg/version.buildDate=$(date -u +%FT%T%z)" \
 	./cmds/helminstaller
 
 ###################################################################################

--- a/components/ocmcli/Makefile
+++ b/components/ocmcli/Makefile
@@ -18,7 +18,7 @@ OCMSRCS=$(shell find $(REPO_ROOT)/pkg -type f) $(REPO_ROOT)/go.*
 GEN = $(REPO_ROOT)/gen/$(shell basename $(realpath .))
 OCM = go run $(REPO_ROOT)/cmds/ocm
 
-NOW         := $(shell date -u +%FT%T%:z)
+NOW         := $(shell date -u +%FT%T%z)
 BUILD_FLAGS := "-s -w \
  -X github.com/open-component-model/ocm/pkg/version.gitVersion=$(EFFECTIVE_VERSION) \
  -X github.com/open-component-model/ocm/pkg/version.gitTreeState=$(GIT_TREE_STATE) \

--- a/components/ocmcli/Makefile
+++ b/components/ocmcli/Makefile
@@ -18,7 +18,7 @@ OCMSRCS=$(shell find $(REPO_ROOT)/pkg -type f) $(REPO_ROOT)/go.*
 GEN = $(REPO_ROOT)/gen/$(shell basename $(realpath .))
 OCM = go run $(REPO_ROOT)/cmds/ocm
 
-NOW         := $(shell date --rfc-3339=seconds | sed 's/ /T/')
+NOW         := $(shell date -u +%FT%T%:z)
 BUILD_FLAGS := "-s -w \
  -X github.com/open-component-model/ocm/pkg/version.gitVersion=$(EFFECTIVE_VERSION) \
  -X github.com/open-component-model/ocm/pkg/version.gitTreeState=$(GIT_TREE_STATE) \

--- a/hack/cross-build.sh
+++ b/hack/cross-build.sh
@@ -29,7 +29,7 @@ for i in "${build_matrix[@]}"; do
             -X github.com/open-component-model/ocm/pkg/version.gitVersion=$EFFECTIVE_VERSION \
             -X github.com/open-component-model/ocm/pkg/version.gitTreeState=$([ -z "$(git status --porcelain 2>/dev/null)" ] && echo clean || echo dirty) \
             -X github.com/open-component-model/ocm/pkg/version.gitCommit=$(git rev-parse --verify HEAD) \
-            -X github.com/open-component-model/ocm/pkg/version.buildDate=$(date --rfc-3339=seconds | sed 's/ /T/')" \
+            -X github.com/open-component-model/ocm/pkg/version.buildDate=$(date -u +%FT%T%:z)" \
   ${PROJECT_ROOT}/cmds/ocm
 
   # create zipped file

--- a/hack/cross-build.sh
+++ b/hack/cross-build.sh
@@ -29,7 +29,7 @@ for i in "${build_matrix[@]}"; do
             -X github.com/open-component-model/ocm/pkg/version.gitVersion=$EFFECTIVE_VERSION \
             -X github.com/open-component-model/ocm/pkg/version.gitTreeState=$([ -z "$(git status --porcelain 2>/dev/null)" ] && echo clean || echo dirty) \
             -X github.com/open-component-model/ocm/pkg/version.gitCommit=$(git rev-parse --verify HEAD) \
-            -X github.com/open-component-model/ocm/pkg/version.buildDate=$(date -u +%FT%T%:z)" \
+            -X github.com/open-component-model/ocm/pkg/version.buildDate=$(date -u +%FT%T%z)" \
   ${PROJECT_ROOT}/cmds/ocm
 
   # create zipped file

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -19,5 +19,5 @@ CGO_ENABLED=0 GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) GO111MODULE=on \
             -X github.com/open-component-model/ocm/pkg/version.gitVersion=$EFFECTIVE_VERSION \
             -X github.com/open-component-model/ocm/pkg/version.gitTreeState=$([ -z git status --porcelain 2>/dev/null ] && echo clean || echo dirty) \
             -X github.com/open-component-model/ocm/pkg/version.gitCommit=$(git rev-parse --verify HEAD) \
-            -X github.com/open-component-model/ocm/pkg/version.buildDate=$(date -u +%FT%T%:z)" \
+            -X github.com/open-component-model/ocm/pkg/version.buildDate=$(date -u +%FT%T%z)" \
   ${PROJECT_ROOT}/cmds/ocm

--- a/hack/install.sh
+++ b/hack/install.sh
@@ -19,5 +19,5 @@ CGO_ENABLED=0 GOOS=$(go env GOOS) GOARCH=$(go env GOARCH) GO111MODULE=on \
             -X github.com/open-component-model/ocm/pkg/version.gitVersion=$EFFECTIVE_VERSION \
             -X github.com/open-component-model/ocm/pkg/version.gitTreeState=$([ -z git status --porcelain 2>/dev/null ] && echo clean || echo dirty) \
             -X github.com/open-component-model/ocm/pkg/version.gitCommit=$(git rev-parse --verify HEAD) \
-            -X github.com/open-component-model/ocm/pkg/version.buildDate=$(date --rfc-3339=seconds | sed 's/ /T/')" \
+            -X github.com/open-component-model/ocm/pkg/version.buildDate=$(date -u +%FT%T%:z)" \
   ${PROJECT_ROOT}/cmds/ocm


### PR DESCRIPTION
**What this PR does / why we need it**:

#226 - Not all `date` commands are made equal. To resolve the issue we can specify the exact format of the date we want rather than use the `--rfc-3339` flag. There is a minor, but inconsequential difference in the output.

See below output:

GNU Date:

```
❯ gdate --rfc-3339=seconds | sed 's/ /T/'
2023-02-16T11:50:12+00:00
```

With explicit formatting:

```
❯ date -u +%FT%TZ
2023-02-16T11:51:20Z
```

Alternatively, we can remove the `Z` with:

```
❯ date -u +%FT%T%z
2023-02-16T11:52:38+0000
```

If the above is preferred I am happy to change it.

**Which issue(s) this PR fixes**:
Fixes #226
