### PR TITLE
filter digests from OCI tag list

### DIFF
--- a/pkg/contexts/ocm/repositories/genericocireg/component.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/component.go
@@ -6,11 +6,11 @@ package genericocireg
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/common/accessobj"
 	"github.com/open-component-model/ocm/pkg/contexts/oci"
+	"github.com/open-component-model/ocm/pkg/contexts/oci/artdesc"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/utils"
@@ -112,7 +112,7 @@ func (c *componentAccessImpl) ListVersions() ([]string, error) {
 	result := make([]string, 0, len(tags))
 	for _, t := range tags {
 		// omit reported digests (typically for ctf)
-		if !strings.HasPrefix(t, "@") {
+		if ok, _ := artdesc.IsDigest(t); !ok {
 			result = append(result, t)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

JFrog Artifactory reports digests on tag list call. Now we filter out those digests from the 
list in the components version list interface method.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
