### PR TITLE
gomega string comparison with substitution

### DIFF
--- a/pkg/testutils/signing_test.go
+++ b/pkg/testutils/signing_test.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package testutils_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/open-component-model/ocm/pkg/common"
+	"github.com/open-component-model/ocm/pkg/testutils"
+)
+
+var _ = Describe("normalization", func() {
+
+	It("compares with substitution variables", func() {
+		exp := "A ${TEST}."
+		res := "A testcase."
+		vars := common.Properties{
+			"TEST": "testcase",
+		}
+		Expect(res).To(testutils.StringEqualTrimmedWithContext(exp, common.Properties{}, vars))
+		Expect(res).To(testutils.StringEqualTrimmedWithContext(exp, vars, common.Properties{}))
+	})
+})

--- a/pkg/testutils/suite_test.go
+++ b/pkg/testutils/suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package testutils_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Testutils")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Extend the context based string comparison matcher for gomega by the possibility to specify substitution
variables

This will later be used for the signature tests to provide a single source of truth for the expected hashes
in command outputs and manifests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
