### PR TITLE
some fixes

### DIFF
--- a/cmds/ocm/commands/ocmcmds/components/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/components/cmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/components/get"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/components/hash"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/components/sign"
+	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/components/transfer"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/components/verify"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/names"
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/utils"
@@ -34,6 +35,7 @@ func AddCommands(ctx clictx.Context, cmd *cobra.Command) {
 	cmd.AddCommand(get.NewCommand(ctx, get.Verb))
 	cmd.AddCommand(hash.NewCommand(ctx, hash.Verb))
 	cmd.AddCommand(sign.NewCommand(ctx, sign.Verb))
+	cmd.AddCommand(transfer.NewCommand(ctx, transfer.Verb))
 	cmd.AddCommand(verify.NewCommand(ctx, verify.Verb))
 	cmd.AddCommand(download.NewCommand(ctx, download.Verb))
 }

--- a/cmds/ocm/commands/ocmcmds/ctf/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/ctf/cmd.go
@@ -7,8 +7,7 @@ package ctf
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/componentarchive/create"
-	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/componentarchive/transfer"
+	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/ctf/transfer"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/names"
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/utils"
 	"github.com/open-component-model/ocm/pkg/contexts/clictx"
@@ -22,6 +21,5 @@ func NewCommand(ctx clictx.Context) *cobra.Command {
 		Short: "Commands acting on common transport archives",
 	}, Names...)
 	cmd.AddCommand(transfer.NewCommand(ctx, transfer.Verb))
-	cmd.AddCommand(create.NewCommand(ctx, create.Verb))
 	return cmd
 }

--- a/pkg/contexts/ocm/compdesc/versions/v2/signing.go
+++ b/pkg/contexts/ocm/compdesc/versions/v2/signing.go
@@ -35,7 +35,7 @@ var CDExcludes = signing.MapExcludes{
 			},
 		},
 		"sources": nil,
-		"references": signing.ArrayExcludes{
+		"componentReferences": signing.ArrayExcludes{
 			signing.MapExcludes{
 				"labels": signing.ExcludeEmpty{signing.DynamicArrayExcludes{
 					ValueChecker: signing.IgnoreLabelsWithoutSignature,

--- a/pkg/runtime/unstructured.go
+++ b/pkg/runtime/unstructured.go
@@ -193,7 +193,7 @@ func (u *UnstructuredTypedObject) Evaluate(types Scheme) (TypedObject, error) {
 		decoder = types.GetDecoder(u.GetType())
 	}
 	if decoder == nil {
-		return nil, errors.ErrUnknown(errors.KIND_OBJECTTYPE)
+		return nil, errors.ErrUnknown(errors.KIND_OBJECTTYPE, u.GetType())
 	}
 
 	if obj, err := decoder.Decode(data, DefaultJSONEncoding); err != nil {


### PR DESCRIPTION
- error message for non-exsisting access method type for CV composition.
- fix CV normalization field for componentReferences.
- fix missing command verb combinations.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
