### PR TITLE
Update release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,10 +27,23 @@ jobs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+
     - name: Setup Go
       uses: actions/setup-go@v3
       with:
         go-version-file: '${{ github.workspace }}/go.mod'
+
+    - name: Setup Syft
+      uses: anchore/sbom-action/download-syft@07978da4bdb4faa726e52dfc6b1bed63d4b56479 # v0.13.3
+
+    - name: Setup Cosign
+      uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # v2.8.1
+
+    - name: Setup git config
+      run: |
+        git config user.name "GitHub Actions Bot"
+        git config user.email "<41898282+github-actions[bot]@users.noreply.github.com>"
+
     - name: Cache go-build and mod
       uses: actions/cache@v3
       with:
@@ -40,23 +53,32 @@ jobs:
         key: go-${{ hashFiles('go.sum') }}
         restore-keys: |
           go-
-    - name: Set release version
+
+    - name: Set Pre-Release Version
+      if: inputs.release_candidate == true
       run: |
-        if ${{ inputs.release_candidate }}; then
-          echo "RELEASE_VERSION=$(go run $GITHUB_WORKSPACE/pkg/version/generate/release_generate.go print-rc-version)" >> $GITHUB_ENV
-        else
-          echo "RELEASE_VERSION=$(go run $GITHUB_WORKSPACE/pkg/version/generate/release_generate.go print-version)" >> $GITHUB_ENV
-        fi
+        RELEASE_VERSION=$(go run $GITHUB_WORKSPACE/pkg/version/generate print-rc-version)
+        echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+
+    - name: Set Version
+      if: inputs.release_candidate == false
+      run: |
+        RELEASE_VERSION=$(go run $GITHUB_WORKSPACE/pkg/version/generate print-version)
+        echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_ENV
+
     - name: Set release notes file
       run: |
-        echo "RELEASE_NOTES_FILE=docs/releasenotes/$(go run $GITHUB_WORKSPACE/pkg/version/generate/release_generate.go print-version).md" >> $GITHUB_ENV
+        RELEASE_NOTES_FILE=docs/releasenotes/$(go run $GITHUB_WORKSPACE/pkg/version/generate print-version).md
+        echo "RELEASE_NOTES_FILE=$RELEASE_NOTES_FILE" >> $GITHUB_ENV
+
     - name: Validate release notes
       run: |
         if [[ ! -f ${{ env.RELEASE_NOTES_FILE }} ]]; then
           >&2 echo "Must have release notes ${{ env.RELEASE_NOTES_FILE }}"
           exit 6
         fi
-    - name: Create and push branch
+
+    - name: Create or Push Release Branch
       env:
         RELEASE_BRANCH: release-${{ env.RELEASE_VERSION }}
       run: |
@@ -68,16 +90,14 @@ jobs:
             git checkout ${RELEASE_BRANCH}
             git pull --ff-only origin ${RELEASE_BRANCH}
         fi
-    - name: Setup git config
-      run: |
-        git config user.name "GitHub Actions Bot"
-        git config user.email "<41898282+github-actions[bot]@users.noreply.github.com>"
-    - name: Create and push tag
+
+    - name: Push Tag
       run: |
         msg="Release ${{ env.RELEASE_VERSION }}"
         git tag --annotate --message "${msg}" ${{ env.RELEASE_VERSION }}
         git push origin ${{ env.RELEASE_VERSION }}
-    - name: Run goreleaser
+
+    - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v4
       with:
         distribution: goreleaser
@@ -87,7 +107,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.EVENT_API }}
         GORELEASER_CURRENT_TAG: ${{ env.RELEASE_VERSION }}
-    - name: Repository Dispatch
+
+    - name: Publish Release Event
       if: inputs.release_candidate == false
       uses: peter-evans/repository-dispatch@v2
       with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -30,13 +30,13 @@ builds:
     goos:
       - windows
 archives:
-  - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - name_template: "{{ .Binary }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     id: nix
     builds: [linux, darwin]
     format: tar.gz
     files:
       - none*
-  - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  - name_template: "{{ .Binary }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     id: windows
     builds: [windows]
     format: zip
@@ -44,12 +44,12 @@ archives:
       - none*
 source:
   enabled: true
-  name_template: '{{ .ProjectName }}_{{ .Version }}_source_code'
+  name_template: '{{ .ProjectName }}-{{ .Version }}-source_code'
 sboms:
   - id: source
     artifacts: source
     documents:
-      - "{{ .ProjectName }}_{{ .Version }}_sbom.spdx.json"
+      - "{{ .ProjectName }}-{{ .Version }}-sbom.spdx.json"
 signs:
   - cmd: cosign
     env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,27 +1,67 @@
-# This is an example .goreleaser.yml file with some sensible defaults.
-# Make sure to check the documentation at https://goreleaser.com
 before:
   hooks:
     - go mod tidy
 builds:
-  - main: ./cmds/ocm/main.go
-    env:
-      - CGO_ENABLED=0
+  - <<: &build_defaults
+      binary: ocm
+      main: ./cmds/ocm/main.go
+      ldflags:
+        - -s -w -X github.com/open-component-model/ocm/pkg/version.gitVersion={{.Version}} -X github.com/open-component-model/ocm/pkg/version.gitCommit={{.Commit}} -X github.com/open-component-model/ocm/pkg/version.buildDate={{.CommitDate}}
+      env:
+        - CGO_ENABLED=0
+    id: linux
     goos:
       - linux
-      - windows
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - 7
+  - <<: *build_defaults
+    id: darwin
+    goos:
       - darwin
+    goarch:
+      - amd64
+      - arm64
+  - <<: *build_defaults
+    id: windows
+    goos:
+      - windows
 archives:
-  - name_template: >-
-      {{ .ProjectName }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-checksum:
-  name_template: 'checksums.txt'
-snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    id: nix
+    builds: [linux, darwin]
+    format: tar.gz
+    files:
+      - none*
+  - name_template: "{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    id: windows
+    builds: [windows]
+    format: zip
+    files:
+      - none*
+source:
+  enabled: true
+  name_template: '{{ .ProjectName }}_{{ .Version }}_source_code'
+sboms:
+  - id: source
+    artifacts: source
+    documents:
+      - "{{ .ProjectName }}_{{ .Version }}_sbom.spdx.json"
+signs:
+  - cmd: cosign
+    env:
+      - COSIGN_EXPERIMENTAL=1
+    certificate: '${artifact}.pem'
+    args:
+      - sign-blob
+      - '--output-certificate=${certificate}'
+      - '--output-signature=${signature}'
+      - '${artifact}'
+    artifacts: checksum
+    output: true
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
**What this PR does / why we need it**:
This change updates the release process to produce build artifacts inline with standard practices.

We update the goreleaser config with the following changes:
- ensure the `version.gitVersion`, `version.gitCommit`, `version.buildDate` package variables are set when building the ocm binary
- change the template format for archives to `{{ .Binary }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
- add SBOM
- add checksum signing

The following is the output produced:
![image](https://user-images.githubusercontent.com/4415593/223827183-1a6d7743-ea23-4b8f-9020-1f674e9ae705.png)
**Please note**
Sigstore will require authentication to sign the release, the link is generated and printed to the log output. So please monitor the log for this link when executing release following this change.
 
**Which issue(s) this PR fixes**:
Fixes #286 

@mandelsoft please kindly confirm that this addresses your concerns from #286.