### PR TITLE
Add release notes for `v0.3.0`

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,10 +1,10 @@
-name-template: '$NEXT_MINOR_VERSION'
-tag-template: '$NEXT_MINOR_VERSION'
+name-template: 'v$NEXT_MINOR_VERSION'
+tag-template: 'v$NEXT_MINOR_VERSION'
 version-template: '$COMPLETE'
 change-template: '- $TITLE (#$NUMBER)'
 change-title-escapes: '\<*_&#@`'
 template: |
-  # Release $NEXT_MINOR_VERSION
+  # Release v$NEXT_MINOR_VERSION
 
   $CHANGES
 exclude-labels:

--- a/docs/releasenotes/v0.3.0.md
+++ b/docs/releasenotes/v0.3.0.md
@@ -1,0 +1,10 @@
+# Release v0.3.0
+
+- update generated files (#293)
+- Update release process (#291)
+- remove ocm-controller dependency (#290)
+- gomega string comparison with substitution (#282)
+- Fix missing command, change componentReferences field & improve err message (#288)
+- support NPM registry access (#283)
+- feat: add installing ocm-controller with ocm cli (#271)
+- add kubebuilder annotation to \`Label.Values\` (#281)

--- a/pkg/version/release.go
+++ b/pkg/version/release.go
@@ -5,7 +5,7 @@
 package version
 
 // ReleaseVersion is the version number in semver format "vX.Y.Z", prefixed with "v".
-var ReleaseVersion = "v0.2.0"
+var ReleaseVersion = "v0.3.0"
 
 // ReleaseCandidate is the release candidate ID in format "rc.X", which will be appended to the release version.
 var ReleaseCandidate = "rc.1"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the release notes for `v0.3.0`.
It also appends `v` since the release-drafter cuts this for some reason.