### PR TITLE
hint for helm input + arbitrary resource version

### DIFF
--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/rscs/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/rscs/elements.go
@@ -54,12 +54,13 @@ func (ResourceSpecHandler) Set(v ocm.ComponentVersionAccess, r addhdlrs.Element,
 	if spec.Relation == metav1.LocalRelation {
 		if vers == "" || vers == ComponentVersionTag {
 			vers = v.GetVersion()
-		} else if vers != v.GetVersion() {
-			return errors.Newf("local resource %q (%s) has non-matching version %q", spec.Name, r.Source(), vers)
 		}
 	}
 	if vers == ComponentVersionTag {
 		vers = v.GetVersion()
+	}
+	if vers == "" {
+		return errors.Newf("resource %q (%s): missing version", spec.Name, r.Source())
 	}
 
 	meta := &compdesc.ResourceMeta{

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/docker/spec.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/docker/spec.go
@@ -14,6 +14,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/repositories/artifactset"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/repositories/docker"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/ociartifact"
 )
 
 type Spec struct {
@@ -68,5 +69,5 @@ func (s *Spec) GetBlob(ctx inputs.Context, nv common.NameVersion, inputFilePath 
 	if err != nil {
 		return nil, "", err
 	}
-	return blob, ociimage.Hint(nv, locator, s.Repository, version), nil
+	return blob, ociartifact.Hint(nv, locator, s.Repository, version), nil
 }

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/dockermulti/spec.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/dockermulti/spec.go
@@ -20,6 +20,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/oci/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/repositories/artifactset"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/repositories/docker"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/ociartifact"
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/runtime"
 	"github.com/open-component-model/ocm/pkg/utils"
@@ -167,5 +168,5 @@ func (s *Spec) GetBlob(ctx inputs.Context, nv common.NameVersion, inputFilePath 
 	if err != nil {
 		return nil, "", err
 	}
-	return blob, ociimage.Hint(nv, nv.GetName(), s.Repository, nv.GetVersion()), nil
+	return blob, ociartifact.Hint(nv, nv.GetName(), s.Repository, nv.GetVersion()), nil
 }

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/helm/cli.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/helm/cli.go
@@ -12,7 +12,7 @@ import (
 
 func ConfigHandler() flagsets.ConfigOptionTypeSetHandler {
 	return cpi.NewMediaFileSpecOptionType(TYPE, AddConfig,
-		options.PathOption, options.VersionOption)
+		options.PathOption, options.VersionOption, options.HintOption)
 }
 
 func AddConfig(opts flagsets.ConfigOptions, config flagsets.Config) error {
@@ -20,5 +20,6 @@ func AddConfig(opts flagsets.ConfigOptions, config flagsets.Config) error {
 		return err
 	}
 	flagsets.AddFieldByOptionP(opts, options.VersionOption, config, "version")
+	flagsets.AddFieldByOptionP(opts, options.HintOption, config, "repository")
 	return nil
 }

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/helm/spec.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/helm/spec.go
@@ -5,8 +5,6 @@
 package helm
 
 import (
-	"fmt"
-
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs"
@@ -15,12 +13,14 @@ import (
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/ociutils/helm"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/ociutils/helm/loader"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/ociartifact"
 )
 
 type Spec struct {
 	// PathSpec hold the path that points to the helm chart file
 	cpi.PathSpec `json:",inline"`
 	Version      string `json:"version,omitempty"`
+	Repository   string `json:"repository,omitempty"`
 }
 
 var _ inputs.InputSpec = (*Spec)(nil)
@@ -65,10 +65,6 @@ func (s *Spec) GetBlob(ctx inputs.Context, nv common.NameVersion, inputFilePath 
 	if err != nil {
 		return nil, "", err
 	}
-	name := chart.Name()
-	hint := fmt.Sprintf("%s/%s:%s", nv.GetName(), name, vers)
-	if name == "" {
-		hint = fmt.Sprintf("%s:%s", nv.GetName(), vers)
-	}
-	return blob, hint, err
+
+	return blob, ociartifact.Hint(nv, chart.Name(), s.Repository, vers), err
 }

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/helm/type.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/helm/type.go
@@ -33,7 +33,13 @@ This blob type specification supports the following fields:
 - **<code>version</code>** *string*
 
   This OPTIONAL property can be set to configure an explicit version hint.
-  If not specified the versio from the chart will be used.
+  If not specified the version from the chart will be used.
   Basically, it is a good practice to use the component version for local resources
   This can be achieved by using templating for this attribute in the resource file.
+
+- **<code>repository</code>** *string*
+
+  This OPTIONAL property can be used to specify the repository hint for the
+  generated local artifact access. It is prefixed by the component name if
+  it does not start with slash "/".
 `

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/ociimage/spec.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/ociimage/spec.go
@@ -5,7 +5,6 @@
 package ociimage
 
 import (
-	"fmt"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -18,6 +17,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/oci/grammar"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/repositories/artifactset"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/repositories/docker"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/ociartifact"
 )
 
 type Spec struct {
@@ -77,20 +77,7 @@ func (s *Spec) GetBlob(ctx inputs.Context, nv common.NameVersion, inputFilePath 
 	if err != nil {
 		return nil, "", err
 	}
-	return blob, Hint(nv, ref.Repository, s.Repository, version), nil
-}
-
-func Hint(nv common.NameVersion, locator, repo, version string) string {
-	fmt.Printf("locator: %s, repo: %s, version %s\n", locator, repo, version)
-	repository := fmt.Sprintf("%s/%s", nv.GetName(), locator)
-	if repo != "" {
-		if strings.HasPrefix(repo, grammar.RepositorySeparator) {
-			repository = repo[1:]
-		} else {
-			repository = fmt.Sprintf("%s/%s", nv.GetName(), repo)
-		}
-	}
-	return fmt.Sprintf("%s:%s", repository, version)
+	return blob, ociartifact.Hint(nv, ref.Repository, s.Repository, version), nil
 }
 
 func ValidateRepository(fldPath *field.Path, allErrs field.ErrorList, repo string) field.ErrorList {

--- a/cmds/ocm/commands/ocmcmds/resources/add/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/resources/add/cmd_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
 	. "github.com/open-component-model/ocm/pkg/testutils"
 
@@ -158,6 +159,7 @@ var _ = Describe("Add resources", func() {
 
 		acc, err := env.OCMContext().AccessSpecForSpec(r.Access)
 		Expect(err).To(Succeed())
+		Expect(acc.(*localblob.AccessSpec).ReferenceName).To(Equal("test.de/x/mandelsoft/testchart:0.1.0"))
 		// sha is always different for helm artifact
 		// Expect(acc.(*localblob.AccessSpec).LocalReference).To(Equal("sha256.817db2696ed23f7779a7f848927e2958d2236e5483ad40875274462d8fa8ef9a"))
 

--- a/cmds/ocm/commands/ocmcmds/resources/add/testdata/helm.yaml
+++ b/cmds/ocm/commands/ocmcmds/resources/add/testdata/helm.yaml
@@ -4,6 +4,7 @@ type: helmChart
 input:
   type: helm
   path: testchart
+  repository: mandelsoft/testchart
 ---
 name: echoserver
 type: ociImage

--- a/pkg/contexts/ocm/accessmethods/ociartifact/utils.go
+++ b/pkg/contexts/ocm/accessmethods/ociartifact/utils.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ociartifact
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/open-component-model/ocm/pkg/common"
+	"github.com/open-component-model/ocm/pkg/contexts/oci/grammar"
+)
+
+func Hint(nv common.NameVersion, locator, repo, version string) string {
+	repository := fmt.Sprintf("%s/%s", nv.GetName(), locator)
+	if repo != "" {
+		if strings.HasPrefix(repo, grammar.RepositorySeparator) {
+			repository = repo[1:]
+		} else {
+			repository = fmt.Sprintf("%s/%s", nv.GetName(), repo)
+		}
+	}
+	if !strings.Contains(repository, ":") {
+		repository = fmt.Sprintf("%s:%s", repository, version)
+	}
+	return repository
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Support `repository` field for input type `helm`` to provide an explicit  repository
hint for helm charts.

Allow arbitrary resource versions for local resources during CV composition.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
