### PR TITLE
simple data localization

### DIFF
--- a/pkg/contexts/ocm/utils/localize/README.md
+++ b/pkg/contexts/ocm/utils/localize/README.md
@@ -48,3 +48,7 @@ Such a specification object can be applied by the function `Instantiate`
 together with configuration values to
 a component version. As substitution result it returns a virtual filesystem
 with the snapshot according to the resolved substitutions.
+
+Additionally, there is a set of more basic types and methods, which can be used
+to describe end execute localizations for single data objects (see `ImageMappings`,
+`LocalizeMappings` and `SubstituteMappings`).

--- a/pkg/contexts/ocm/utils/localize/localize.go
+++ b/pkg/contexts/ocm/utils/localize/localize.go
@@ -5,78 +5,44 @@
 package localize
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/utils"
-	"github.com/open-component-model/ocm/pkg/errors"
 )
 
+// Localize maps a list of filesystem related localization requests to an
+// appropriate set of substitution requests.
 func Localize(mappings []Localization, cv ocm.ComponentVersionAccess, resolver ocm.ComponentVersionResolver) (Substitutions, error) {
 	var result Substitutions
-	ctx := cv.GetContext()
 
 	for i, v := range mappings {
-		name := "image mapping"
-		if v.Name != "" {
-			name = fmt.Sprintf("%s %q", name, v.Name)
-		}
-		acc, rcv, err := utils.ResolveResourceReference(cv, v.ResourceReference, resolver)
+		m, err := v.Evaluate(i, cv, resolver)
 		if err != nil {
-			return nil, errors.ErrNotFoundWrap(err, "mapping", fmt.Sprintf("%d (%s)", i+1, &v.ResourceReference))
+			return nil, err
 		}
-		rcv.Close()
-		ref, err := utils.GetOCIArtifactRef(ctx, acc)
+		for _, r := range m {
+			result.AddValueMapping(&r, v.FilePath)
+		}
+	}
+	return result, nil
+}
+
+// LocalizeMappings maps a set of pure image mappings into
+// an appropriate set of value mapping request for a single data object.
+func LocalizeMappings(mappings ImageMappings, cv ocm.ComponentVersionAccess, resolver ocm.ComponentVersionResolver) (ValueMappings, error) {
+	var result ValueMappings
+
+	for i, v := range mappings {
+		m, err := v.Evaluate(i, cv, resolver)
 		if err != nil {
-			return nil, errors.Wrapf(err, "mapping %d: cannot resolve resource %s to an OCI Reference", i+1, v)
+			return nil, err
 		}
-		ix := strings.Index(ref, ":")
-		if ix < 0 {
-			ix = strings.Index(ref, "@")
-			if ix < 0 {
-				return nil, errors.Wrapf(err, "mapping %d: image tag or digest missing (%s)", i+1, ref)
-			}
-		}
-		repo := ref[:ix]
-		tag := ref[ix+1:]
-
-		cnt := 0
-		if v.Repository != "" {
-			cnt++
-		}
-		if v.Tag != "" {
-			cnt++
-		}
-		if v.Image != "" {
-			cnt++
-		}
-		if cnt == 0 {
-			return nil, fmt.Errorf("no substitution target given for %s", name)
-		}
-
-		if v.Repository != "" {
-			if err := result.Add(substitutionName(v.Name, "repository", cnt), v.FilePath, v.Repository, repo); err != nil {
-				return nil, errors.Wrapf(err, "setting repository for %s", substitutionName(v.Name, "repository", cnt))
-			}
-		}
-		if v.Tag != "" {
-			if err := result.Add(substitutionName(v.Name, "tag", cnt), v.FilePath, v.Tag, tag); err != nil {
-				return nil, errors.Wrapf(err, "setting tag for %s", substitutionName(v.Name, "tag", cnt))
-			}
-		}
-		if v.Image != "" {
-			if err := result.Add(substitutionName(v.Name, "image", cnt), v.FilePath, v.Image, ref); err != nil {
-				return nil, errors.Wrapf(err, "setting image for %s", substitutionName(v.Name, "image", cnt))
-			}
-		}
+		result = append(result, m...)
 	}
 	return result, nil
 }
 
 func substitutionName(name, sub string, cnt int) string {
 	if name == "" {
-		return ""
+		return sub
 	}
 	if cnt <= 1 {
 		return name

--- a/pkg/contexts/ocm/utils/localize/localize_test.go
+++ b/pkg/contexts/ocm/utils/localize/localize_test.go
@@ -74,7 +74,7 @@ var _ = Describe("image value mapping", func() {
 		subst, err := localize.Localize(mappings, cv, nil)
 		Expect(err).To(Succeed())
 		Expect(subst).To(Equal(Substitutions(`
-- name: test1
+- name: image mapping "test1"
   file: file1
   path: a.b.img
   value: ghcr.io/mandelsoft/test:v1
@@ -95,15 +95,15 @@ var _ = Describe("image value mapping", func() {
 		subst, err := localize.Localize(mappings, cv, nil)
 		Expect(err).To(Succeed())
 		Expect(subst).To(Equal(Substitutions(`
-- name: test1-repository
+- name: image mapping "test1"-repository
   file: file1
   path: a.b.rep
   value: ghcr.io/mandelsoft/test
-- name: test1-tag
+- name: image mapping "test1"-tag
   file: file1
   path: a.b.tag
   value: v1
-- name: test1-image
+- name: image mapping "test1"-image
   file: file1
   path: a.b.img
   value: ghcr.io/mandelsoft/test:v1

--- a/pkg/contexts/ocm/utils/localize/subst.go
+++ b/pkg/contexts/ocm/utils/localize/subst.go
@@ -49,6 +49,29 @@ func Substitute(subs Substitutions, fs vfs.FileSystem) error {
 	return nil
 }
 
+// SubstituteMappings substitutes value mappings for a dedicated substitution target.
+func SubstituteMappings(subs ValueMappings, target subst.SubstitutionTarget) error {
+	for i, s := range subs {
+		if err := target.SubstituteByData(s.ValuePath, s.Value); err != nil {
+			return errors.Wrapf(err, "entry %d: cannot substitute value", i+1)
+		}
+	}
+	return nil
+}
+
+// SubstituteMappingsForData substitutes value mappings for some data.
+func SubstituteMappingsForData(subs ValueMappings, data []byte) ([]byte, error) {
+	target, err := subst.Parse(data)
+	if err != nil {
+		return nil, err
+	}
+	err = SubstituteMappings(subs, target)
+	if err != nil {
+		return nil, err
+	}
+	return target.Content()
+}
+
 func Set(content *ast.File, path string, value *ast.File) error {
 	p, err := yaml.PathString("$." + path)
 	if err != nil {

--- a/pkg/contexts/ocm/utils/localize/target_test.go
+++ b/pkg/contexts/ocm/utils/localize/target_test.go
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package localize_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/open-component-model/ocm/pkg/testutils"
+
+	"github.com/mandelsoft/vfs/pkg/vfs"
+
+	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/common/accessobj"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/ociartifact"
+	v1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/ctf"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/utils/localize"
+	"github.com/open-component-model/ocm/pkg/env/builder"
+)
+
+var _ = Describe("value substitution in single target", func() {
+
+	Context("localize", func() {
+		const (
+			ARCHIVE   = "archive.ctf"
+			COMPONENT = "github.com/comp"
+			VERSION   = "1.0.0"
+			IMAGE     = "image"
+		)
+
+		var (
+			repo ocm.Repository
+			cv   ocm.ComponentVersionAccess
+			env  *builder.Builder
+		)
+
+		BeforeEach(func() {
+			env = builder.NewBuilder(nil)
+			env.OCMCommonTransport(ARCHIVE, accessio.FormatDirectory, func() {
+				env.Component(COMPONENT, func() {
+					env.Version(VERSION, func() {
+						env.Provider("mandelsoft")
+						env.Resource(IMAGE, "", "Spiff", v1.LocalRelation, func() {
+							env.Access(ociartifact.New("ghcr.io/mandelsoft/test:v1"))
+						})
+					})
+				})
+			})
+
+			var err error
+			repo, err = ctf.Open(ocm.DefaultContext(), accessobj.ACC_READONLY, ARCHIVE, 0, env)
+			Expect(err).To(Succeed())
+
+			cv, err = repo.LookupComponentVersion(COMPONENT, VERSION)
+			Expect(err).To(Succeed())
+		})
+
+		AfterEach(func() {
+			Expect(cv.Close()).To(Succeed())
+			Expect(repo.Close()).To(Succeed())
+			vfs.Cleanup(env)
+		})
+
+		It("uses image ref data from component version", func() {
+			mappings := ImageMappings(`
+- name: test1
+  image: a.b.img
+  resource:
+    name: image
+`)
+			subst, err := localize.LocalizeMappings(mappings, cv, nil)
+			Expect(err).To(Succeed())
+			Expect(subst).To(Equal(ValueMappings(`
+- name: image mapping "test1"
+  path: a.b.img
+  value: ghcr.io/mandelsoft/test:v1
+`)))
+		})
+
+		It("uses multiple resolved image ref data from component version", func() {
+
+			mappings := ImageMappings(`
+- name: test1
+  repository: a.b.rep
+  tag: a.b.tag  
+  image: a.b.img
+  resource:
+    name: image
+`)
+			subst, err := localize.LocalizeMappings(mappings, cv, nil)
+			Expect(err).To(Succeed())
+			Expect(subst).To(Equal(ValueMappings(`
+- name: image mapping "test1"-repository
+  path: a.b.rep
+  value: ghcr.io/mandelsoft/test
+- name: image mapping "test1"-tag
+  path: a.b.tag
+  value: v1
+- name: image mapping "test1"-image
+  path: a.b.img
+  value: ghcr.io/mandelsoft/test:v1
+`)))
+		})
+	})
+
+	Context("substitute", func() {
+		var data = []byte(`
+manifest:
+  value1: orig1
+  value2: orig2
+`)
+
+		It("handles simple values substitution", func() {
+			subs := ValueMappings(`
+- name: test1
+  path: manifest.value1
+  value: config1
+- name: test2
+  path: manifest.value2
+  value: config2
+`)
+			result, err := localize.SubstituteMappingsForData(subs, data)
+			Expect(err).To(Succeed())
+
+			Expect(string(result)).To(StringEqualTrimmedWithContext(`
+manifest:
+  value1: config1
+  value2: config2
+`))
+		})
+
+		It("handles json substitution", func() {
+			subs := ValueMappings(`
+- name: test1
+  path: manifest.value1
+  value:
+    some:
+      value: 1
+`)
+			result, err := localize.SubstituteMappingsForData(subs, data)
+			Expect(err).To(Succeed())
+
+			Expect(string(result)).To(StringEqualTrimmedWithContext(`
+manifest:
+  value1:
+      some:
+        value: 1
+  value2: orig2
+`))
+		})
+	})
+})

--- a/pkg/contexts/ocm/utils/localize/utils_test.go
+++ b/pkg/contexts/ocm/utils/localize/utils_test.go
@@ -34,6 +34,18 @@ func Substitutions(data string) localize.Substitutions {
 	return v
 }
 
+func ImageMappings(data string) localize.ImageMappings {
+	var v localize.ImageMappings
+	Expect(runtime.DefaultYAMLEncoding.Unmarshal([]byte(data), &v)).To(Succeed())
+	return v
+}
+
+func ValueMappings(data string) localize.ValueMappings {
+	var v localize.ValueMappings
+	Expect(runtime.DefaultYAMLEncoding.Unmarshal([]byte(data), &v)).To(Succeed())
+	return v
+}
+
 func InstRules(data string) *localize.InstantiationRules {
 	var v localize.InstantiationRules
 	Expect(runtime.DefaultYAMLEncoding.Unmarshal([]byte(data), &v)).To(Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR deals with localization on a single data object.

The change introduces some basic functions around a type `ValueMappings` , which just describes a set of substitution rules, which can be applied to a single data object (`SubstituteMappings`) . With `LocalizeMappings` a set of (pure non-filename based) localization rules can be mapped to such value mappings combined with config mappings and then applied to a single byte array,

**Which issue(s) this PR fixes**:
Fixes #300

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
