### PR TITLE
cleanup OCI layers in OCM mapping

### DIFF
--- a/pkg/contexts/ocm/compdesc/componentdescriptor.go
+++ b/pkg/contexts/ocm/compdesc/componentdescriptor.go
@@ -573,6 +573,14 @@ func (o *ResourceMeta) Copy() *ResourceMeta {
 	return r
 }
 
+func NewResourceMeta(name string, typ string, relation metav1.ResourceRelation) *ResourceMeta {
+	return &ResourceMeta{
+		ElementMeta: ElementMeta{Name: name},
+		Type:        typ,
+		Relation:    relation,
+	}
+}
+
 type References []ComponentReference
 
 func (r References) Len() int {

--- a/pkg/contexts/ocm/repositories/genericocireg/logging.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/logging.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package genericocireg
+
+import (
+	"github.com/mandelsoft/logging"
+
+	ocmlog "github.com/open-component-model/ocm/pkg/logging"
+)
+
+var REALM = ocmlog.DefineSubRealm("OCM to OCI Registry Mapping", "ocimapping")
+
+func Logger(ctx logging.ContextProvider, messageContext ...logging.MessageContext) logging.Logger {
+	return ctx.LoggingContext().Logger(append([]logging.MessageContext{REALM}, messageContext...))
+}

--- a/pkg/contexts/ocm/signing/signing_test.go
+++ b/pkg/contexts/ocm/signing/signing_test.go
@@ -7,6 +7,7 @@ package signing_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	. "github.com/open-component-model/ocm/pkg/contexts/oci/testhelper"
 	. "github.com/open-component-model/ocm/pkg/contexts/ocm/signing"
 	. "github.com/open-component-model/ocm/pkg/env/builder"

--- a/pkg/contexts/ocm/utils/resource.go
+++ b/pkg/contexts/ocm/utils/resource.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"github.com/open-component-model/ocm/pkg/contexts/ocm"
+)
+
+func GetResourceData(acc ocm.ResourceAccess) ([]byte, error) {
+	m, err := acc.AccessMethod()
+	if err != nil {
+		return nil, err
+	}
+	defer m.Close()
+	return m.Get()
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

If a component version is updated in an OCI based component respository,
new local blob content is just added as new layers, but if an already existing local resource
is modified, then old layer holding the old blob content is not removed again.

As a result the OCI artifact is growing with every update. 

This has no influence on the OCM functionality, even transports are not affected,
but on the OCI side the artifact is growing.

This PR now identifies the required layers and removes the obsolete ones again from the layer list of the OCI
artifact when a ComponentVersionAccess is updated on the underlying OCI storage backend.

Unfortunately with some legacy CNUDIE access method (localOCIBlob) this is not always possible, because
the MediaType is not stored in the access specification, but in the OCI manifest, only. If the same content 
is used by multiple OCM resources, but with different MediaTypes, always the oldest layer is deleted.
But this was basically a problem also for the legacy implementation.

**Which issue(s) this PR fixes**:
Fixes #323

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
