### PR TITLE
fix CTF type usage for creation

### DIFF
--- a/cmds/ocm/commands/common/options/formatoption/option.go
+++ b/cmds/ocm/commands/common/options/formatoption/option.go
@@ -36,6 +36,8 @@ type Option struct {
 	List    []string
 	Default accessio.FileFormat
 	Format  accessio.FileFormat
+
+	flag *pflag.Flag
 }
 
 func (o *Option) setDefault() {
@@ -50,6 +52,7 @@ func (o *Option) setDefault() {
 func (o *Option) AddFlags(fs *pflag.FlagSet) {
 	o.setDefault()
 	fs.StringVarP(&o.format, "type", "t", string(o.Default), fmt.Sprintf("archive format (%s)", strings.Join(o.List, ", ")))
+	o.flag = fs.Lookup("type")
 }
 
 func (o *Option) Configure(ctx clictx.Context) error {
@@ -77,6 +80,18 @@ target archive to use. The following formats are supported:
 		s = s + "- " + k + "\n"
 	}
 	return s + "\nThe default format is <code>directory</code>.\n"
+}
+
+func (o *Option) IsChanged() bool {
+	return o.flag != nil && o.flag.Changed
+}
+
+func (o *Option) ChangedFormat() accessio.FileFormat {
+	if o.IsChanged() {
+		return o.Format
+	} else {
+		return ""
+	}
 }
 
 func (o *Option) Mode() vfs.FileMode {

--- a/cmds/ocm/commands/ocmcmds/componentarchive/transfer/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/componentarchive/transfer/cmd.go
@@ -68,8 +68,8 @@ func (o *Command) Run() error {
 	}
 	session.Closer(source)
 
-	format := formatoption.From(o)
-	target, err := ocm.AssureTargetRepository(session, o.Context.OCMContext(), o.TargetName, ocm.CommonTransportFormat, format.Format, o.Context.FileSystem())
+	format := formatoption.From(o).ChangedFormat()
+	target, err := ocm.AssureTargetRepository(session, o.Context.OCMContext(), o.TargetName, ocm.CommonTransportFormat, format, o.Context.FileSystem())
 	if err != nil {
 		return err
 	}

--- a/cmds/ocm/commands/ocmcmds/components/transfer/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/components/transfer/cmd.go
@@ -103,7 +103,7 @@ func (o *Command) Run() error {
 		return err
 	}
 
-	target, err := ocm.AssureTargetRepository(session, o.Context.OCMContext(), o.TargetName, ocm.CommonTransportFormat, formatoption.From(o).Format, o.Context.FileSystem())
+	target, err := ocm.AssureTargetRepository(session, o.Context.OCMContext(), o.TargetName, ocm.CommonTransportFormat, formatoption.From(o).ChangedFormat(), o.Context.FileSystem())
 	if err != nil {
 		return err
 	}

--- a/cmds/ocm/commands/ocmcmds/components/transfer/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/transfer/cmd_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
 	. "github.com/open-component-model/ocm/pkg/contexts/oci/testhelper"
 	. "github.com/open-component-model/ocm/pkg/testutils"
@@ -176,6 +177,22 @@ transferring version "github.com/mandelsoft/test2:v1"...
 		Expect(tgt.ExistsComponentVersion(COMPONENT2, VERSION)).To(BeTrue())
 
 		CheckComponent(env, ldesc, tgt)
+	})
+
+	It("transfers ctf to tgz with type option", func() {
+		buf := bytes.NewBuffer(nil)
+		Expect(env.CatchOutput(buf).Execute("transfer", "components", "--copy-resources", "--type", accessio.FormatTGZ.String(), ARCH, ARCH, OUT)).To(Succeed())
+		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
+transferring version "github.com/mandelsoft/test:v1"...
+...resource 0...
+...resource 1(ocm/value:v2.0)...
+...resource 2(ocm/ref:v2.0)...
+...adding component version...
+1 versions transferred
+`))
+
+		Expect(env.FileExists(OUT)).To(BeTrue())
+		Check(env, ldesc, OUT)
 	})
 
 	It("transfers ctf to tgz", func() {

--- a/cmds/ocm/commands/ocmcmds/ctf/transfer/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/ctf/transfer/cmd.go
@@ -94,7 +94,7 @@ func (o *Command) Run() error {
 	if err != nil {
 		return errors.Wrapf(err, "cannot open source")
 	}
-	target, err := ocm.AssureTargetRepository(session, o.Context.OCMContext(), o.TargetName, ocm.CommonTransportFormat, formatoption.From(o).Format, o.Context.FileSystem())
+	target, err := ocm.AssureTargetRepository(session, o.Context.OCMContext(), o.TargetName, ocm.CommonTransportFormat, formatoption.From(o).ChangedFormat(), o.Context.FileSystem())
 	if err != nil {
 		return err
 	}

--- a/pkg/contexts/ocm/utils.go
+++ b/pkg/contexts/ocm/utils.go
@@ -43,10 +43,13 @@ func AssureTargetRepository(session Session, ctx Context, targetref string, opts
 	if err != nil {
 		return nil, err
 	}
-	if archive != "" && ref.Type != "" {
+	if ref.Type != "" {
+		format = accessio.FileFormat(ref.Type)
+	}
+	if archive != "" && format != "" {
 		for _, f := range ctf.SupportedFormats() {
-			if f.String() == ref.Type {
-				ref.Type = archive + "+" + ref.Type
+			if f == format {
+				ref.Type = archive + "+" + format.String()
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

The `--type` option is ignored if a CTF is target of a transfer operation and the CTF has to be created.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
