### PR TITLE
Support Consumer Providers + Migrate DockerConfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.0
+	github.com/aws/aws-sdk-go v1.15.11
 	github.com/aws/aws-sdk-go-v2 v1.17.7
 	github.com/aws/aws-sdk-go-v2/config v1.17.10
 	github.com/aws/aws-sdk-go-v2/credentials v1.12.24
@@ -110,10 +111,10 @@ require (
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d // indirect
 	github.com/fatih/color v1.13.0 // indirect
-	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/fvbommel/sortorder v1.0.2 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-gorp/gorp/v3 v3.1.0 // indirect
+	github.com/go-ini/ini v1.25.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect
@@ -132,7 +133,6 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
-	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.3.3 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
@@ -144,7 +144,6 @@ require (
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
 	github.com/lib/pq v1.10.7 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
-	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
@@ -152,7 +151,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/miekg/pkcs11 v1.1.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect
@@ -175,11 +173,7 @@ require (
 	github.com/rubenv/sql-migrate v1.2.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
-	github.com/spf13/afero v1.9.2 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
-	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/viper v1.14.0 // indirect
-	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/theupdateframework/notary v0.7.0 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
@@ -200,7 +194,6 @@ require (
 	google.golang.org/grpc v1.50.1 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/apiserver v0.26.1 // indirect
 	k8s.io/client-go v0.26.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,7 +5,6 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6AU=
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
-cloud.google.com/go v0.44.3/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
 cloud.google.com/go v0.50.0/go.mod h1:r9sluTvynVuxRIOHXQEHMFffphuXHOMZMycpNR5e6To=
@@ -18,7 +17,6 @@ cloud.google.com/go v0.62.0/go.mod h1:jmCYTdRCQuc1PHIIJ/maLInMho30T/Y0M4hTdTShOY
 cloud.google.com/go v0.65.0/go.mod h1:O5N8zS7uWy9vkA9vayVHs65eM1ubvY4h553ofrNHObY=
 cloud.google.com/go v0.72.0/go.mod h1:M+5Vjvlc2wnp6tjzE102Dw08nGShTscUx2nZMufOKPI=
 cloud.google.com/go v0.74.0/go.mod h1:VV1xSbzvo+9QJOxLDaJfTjx5e+MePCpCWwvftOeQmWk=
-cloud.google.com/go v0.75.0/go.mod h1:VGuuCn7PG0dwsd5XPVm2Mm3wlh3EL55/79EKB6hlPTY=
 cloud.google.com/go v0.78.0/go.mod h1:QjdrLG0uq+YwhjoVOLsS1t7TW8fs36kLs4XO5R5ECHg=
 cloud.google.com/go v0.79.0/go.mod h1:3bzgcEeQlzbuEAYu4mrWhKqWjmpprinYgKJLgKHnbb8=
 cloud.google.com/go v0.81.0/go.mod h1:mk/AM35KwGk/Nm2YSeZbxXdrNK3KZOYHmLkOqC2V6E0=
@@ -39,7 +37,6 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
-cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/14rcole/gopopulate v0.0.0-20180821133914-b175b219e774/go.mod h1:6/0dYRLLXyJjbkIPeeGyoJ/eKOSI0eU6eTlCBYibgd0=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8/go.mod h1:CzsSbkDixRphAF5hS6wbMKq0eI6ccJRb7/A0M6JBnwg=
@@ -135,6 +132,7 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535 h1:4daAzAu0S6Vi7/lbWECcX0j45yZReDZ56BQsrVBOEEY=
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
+github.com/aws/aws-sdk-go v1.15.11 h1:m45+Ru/wA+73cOZXiEGLDH2d9uLN3iHqMc0/z4noDXE=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go-v2 v1.16.16/go.mod h1:SwiyXi/1zTUZ6KIAmLK5V5ll8SiURNUYOqTerZPaF9k=
 github.com/aws/aws-sdk-go-v2 v1.17.1/go.mod h1:JLnGeGONAyi2lWXI1p0PCIOIy333JMVK1U7Hf0aRFLw=
@@ -489,7 +487,6 @@ github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
-github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/fvbommel/sortorder v1.0.2 h1:mV4o8B2hKboCdkJm+a7uX/SIpZob4JzUpc5GGnM45eo=
 github.com/fvbommel/sortorder v1.0.2/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
@@ -508,6 +505,7 @@ github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2
 github.com/go-gorp/gorp/v3 v3.0.2/go.mod h1:BJ3q1ejpV8cVALtcXvXaXyTOlMmJhWDxTmncaR6rwBY=
 github.com/go-gorp/gorp/v3 v3.1.0 h1:ItKF/Vbuj31dmV4jxA1qblpSwkl9g1typ24xoe70IGs=
 github.com/go-gorp/gorp/v3 v3.1.0/go.mod h1:dLEjIyyRNiXvNZ8PSmzpt1GsWAUK8kjVhEpjH8TixEw=
+github.com/go-ini/ini v1.25.4 h1:Mujh4R/dH6YL8bxuISne3xX2+qcQ9p0IxKAP6ExWoUo=
 github.com/go-ini/ini v1.25.4/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -671,7 +669,6 @@ github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20201023163331-3e6fc7fc9c4c/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20201203190320-1bf35d6f28c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
-github.com/google/pprof v0.0.0-20201218002935-b9804c9f04c2/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
@@ -690,7 +687,7 @@ github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5m
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
 github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2cUuW7uA/OeU=
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
-github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
@@ -723,7 +720,6 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
-github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
@@ -773,6 +769,7 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
@@ -797,7 +794,6 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kortschak/utter v1.0.1/go.mod h1:vSmSjbyrlKjjsL71193LmzBOKgwePk9DH6uFaWHIInc=
-github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -824,7 +820,6 @@ github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9
 github.com/linuxkit/virtsock v0.0.0-20201010232012-f8cee7dfc7a3/go.mod h1:3r6x7q95whyfWQpmGZTu3gk3v2YkMi05HEzl7Tf7YEo=
 github.com/magiconair/properties v1.5.3/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamhfG/Qzo=
-github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -833,18 +828,10 @@ github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mandelsoft/filepath v0.0.0-20200909114706-3df73d378d55/go.mod h1:n4xEiUD2HNHnn2w5ZKF0qgjDecHVCWAl5DxZ7+pcFU8=
-github.com/mandelsoft/filepath v0.0.0-20220503095057-4432a2285b68 h1:99GWPlKVS110Cm+/YRVRaUJN5CpTeWFazWg2sXJdf70=
-github.com/mandelsoft/filepath v0.0.0-20220503095057-4432a2285b68/go.mod h1:n4xEiUD2HNHnn2w5ZKF0qgjDecHVCWAl5DxZ7+pcFU8=
-github.com/mandelsoft/filepath v0.0.0-20230412192351-6fb993318d77 h1:PzArwSYH45sBwptcgeoCrjt8flsjY6Uaubmrz4cBw+0=
-github.com/mandelsoft/filepath v0.0.0-20230412192351-6fb993318d77/go.mod h1:lEtYp+3aDL+uhvq70cuk3iNHCoeY87kGdUzAmKDRGRQ=
-github.com/mandelsoft/filepath v0.0.0-20230412193842-b51f281bf48b h1:x018iYJ9pP4mNduIRDiucdDq4kIT/iJWDMtIeGRB8F8=
-github.com/mandelsoft/filepath v0.0.0-20230412193842-b51f281bf48b/go.mod h1:lEtYp+3aDL+uhvq70cuk3iNHCoeY87kGdUzAmKDRGRQ=
 github.com/mandelsoft/filepath v0.0.0-20230412200429-36b1eb66bd27 h1:VivN6K8H4H0G4bUmeQH68fQIROL5c8S2iyvVe4teufc=
 github.com/mandelsoft/filepath v0.0.0-20230412200429-36b1eb66bd27/go.mod h1:LxhqC7khDoRENwooP6f/vWvia9ivj6TqLYrR39zqkN0=
 github.com/mandelsoft/logging v0.0.0-20230331123830-36542ef18f6f h1:ZoqAURpfhE54QFLpcRot25aZEA0dfLVcGh0DmG5qLm4=
 github.com/mandelsoft/logging v0.0.0-20230331123830-36542ef18f6f/go.mod h1:HjtBPH5tsJygvyYEu2r/ZwOOBGcu+oR2sKH73VEnHtg=
-github.com/mandelsoft/spiff v1.3.0-beta-7.0.20230328214234-980037cf1bd7 h1:0dHDK+SxCJHTCLIDuafGyeoo50BPYlfjQqihgUA8e6E=
-github.com/mandelsoft/spiff v1.3.0-beta-7.0.20230328214234-980037cf1bd7/go.mod h1:TwEeOPuRZxlzQBCLEyVTlHmBSruSGGNdiQ2fovVJ8ao=
 github.com/mandelsoft/spiff v1.3.0-beta-7.0.20230412151612-088be0cbcd26 h1:IuVluKKXjKASZe6DvmhlJJNMO5opIFEuS1y3iuPVDGs=
 github.com/mandelsoft/spiff v1.3.0-beta-7.0.20230412151612-088be0cbcd26/go.mod h1:TwEeOPuRZxlzQBCLEyVTlHmBSruSGGNdiQ2fovVJ8ao=
 github.com/mandelsoft/vfs v0.0.0-20220805210647-bf14a11bfe31 h1:5gmUtnP0NYOODvS/gTeQOJKSu4W8bOUImDiKdAb/j1A=
@@ -901,7 +888,6 @@ github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUb
 github.com/mitchellh/mapstructure v0.0.0-20150613213606-2caf8efc9366/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
-github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/osext v0.0.0-20151018003038-5e2d6d41470f/go.mod h1:OkQIRizQZAeMln+1tSwduZz7+Af5oFlKirV/MSYes2A=
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
@@ -1032,7 +1018,6 @@ github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
@@ -1117,21 +1102,21 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a h1:pa8hGb/2YqsZKovtsgrwcDH1RZhVbTKCjLp47XpqCDs=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.9.2 h1:j49Hj62F0n+DaZ1dDCvhABaPNSGNkt32oRFxI33IEMw=
-github.com/spf13/afero v1.9.2/go.mod h1:iUV7ddyEEZPO5gA3zD4fJt6iStLlL+Lg4m2cihcDf8Y=
 github.com/spf13/cast v0.0.0-20150508191742-4d07383ffe94/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=
 github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
 github.com/spf13/jwalterweatherman v0.0.0-20141219030609-3d60171a6431/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
-github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.0/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1-0.20171106142849-4c012f6dcd95/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -1141,7 +1126,6 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v0.0.0-20150530192845-be5ff3e4840c/go.mod h1:A8kyI5cUJhb8N+3pkfONlcEcZbueH6nhAm0Fq7SrnBM=
 github.com/spf13/viper v1.14.0 h1:Rg7d3Lo706X9tHsJMUjdiwMpHB7W8WnSVOssIY+JElU=
-github.com/spf13/viper v1.14.0/go.mod h1:WT//axPky3FdvXHzGw33dNdXXXfFQqmEalje+egj8As=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20201008174630-78d3cae3a980/go.mod h1:AO3tvPzVZ/ayst6UlUKUv6rcPQInYe3IknH3jYhAKu8=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.0.0-20180129172003-8a3f7159479f/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -1163,7 +1147,6 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.4.1 h1:jyEFiXpy21Wm81FBN71l9VoMMV8H8jG+qIK3GCpY6Qs=
-github.com/subosito/gotenv v1.4.1/go.mod h1:ayKnFf/c6rvx/2iiLrJUk1e6plDbT3edrFNGqEflhK0=
 github.com/sylabs/sif/v2 v2.7.0/go.mod h1:TiyBWsgWeh5yBeQFNuQnvROwswqK7YJT8JA1L53bsXQ=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
@@ -1299,10 +1282,8 @@ golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210220033148-5ea612d1eb83/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
-golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20210817164053-32db794688a5/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
 golang.org/x/crypto v0.5.0 h1:U/0M97KRkSFvyD/3FSmdP5W5swImpNgle/EHFhOsQPE=
@@ -1516,7 +1497,6 @@ golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1545,7 +1525,6 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1639,7 +1618,6 @@ golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
@@ -1727,9 +1705,7 @@ google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20210108203827-ffc7fda8c3d7/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210222152913-aa3ee6e6a81c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20210226172003-ab064af71705/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210303154014-9728d6b83eeb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210310155132-4ce2db91004e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -1806,7 +1782,6 @@ gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKW
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
-gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/pipe.v2 v2.0.0-20140414041502-3c2ca4d52544/go.mod h1:UhTeH/yXCK/KY7TX24mqPkaQ7gZeqmWd/8SSS8B3aHw=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=

--- a/pkg/contexts/credentials/cpi/interface.go
+++ b/pkg/contexts/credentials/cpi/interface.go
@@ -35,8 +35,12 @@ type (
 )
 
 type (
-	ConsumerIdentity = internal.ConsumerIdentity
-	IdentityMatcher  = internal.IdentityMatcher
+	ProviderIdentity        = internal.ProviderIdentity
+	ConsumerProvider        = internal.ConsumerProvider
+	ConsumerIdentity        = internal.ConsumerIdentity
+	IdentityMatcher         = internal.IdentityMatcher
+	IdentityMatcherInfo     = internal.IdentityMatcherInfo
+	IdentityMatcherRegistry = internal.IdentityMatcherRegistry
 )
 
 var DefaultContext = internal.DefaultContext

--- a/pkg/contexts/credentials/interface.go
+++ b/pkg/contexts/credentials/interface.go
@@ -36,6 +36,7 @@ type (
 )
 
 type (
+	ProviderIdentity        = internal.ProviderIdentity
 	ConsumerIdentity        = internal.ConsumerIdentity
 	IdentityMatcher         = internal.IdentityMatcher
 	IdentityMatcherInfo     = internal.IdentityMatcherInfo

--- a/pkg/contexts/credentials/internal/context.go
+++ b/pkg/contexts/credentials/internal/context.go
@@ -18,8 +18,20 @@ import (
 // CONTEXT_TYPE is the global type for a credential context.
 const CONTEXT_TYPE = "credentials" + datacontext.OCM_CONTEXT_SUFFIX
 
+// ProviderIdentity is used to uniquely identify a provider
+// for a configured consumer id. If non-empty it
+// must start with a DNSname identifying the origin of the
+// provider followed by a slash and a local arbitrary identity.
+type ProviderIdentity string
+
 type ContextProvider interface {
 	CredentialsContext() Context
+}
+
+type ConsumerProvider interface {
+	Unregister(id ProviderIdentity)
+	Get(id ConsumerIdentity) (CredentialsSource, bool)
+	Match(id ConsumerIdentity, cur ConsumerIdentity, matcher IdentityMatcher) (CredentialsSource, ConsumerIdentity)
 }
 
 type Context interface {
@@ -38,8 +50,12 @@ type Context interface {
 	CredentialsForSpec(spec CredentialsSpec, creds ...CredentialsSource) (Credentials, error)
 	CredentialsForConfig(data []byte, unmarshaler runtime.Unmarshaler, cred ...CredentialsSource) (Credentials, error)
 
+	RegisterConsumerProvider(id ProviderIdentity, provider ConsumerProvider)
+	UnregisterConsumerProvider(id ProviderIdentity)
+
 	GetCredentialsForConsumer(ConsumerIdentity, ...IdentityMatcher) (CredentialsSource, error)
 	SetCredentialsForConsumer(identity ConsumerIdentity, creds CredentialsSource)
+	SetCredentialsForConsumerWithProvider(pid ProviderIdentity, identity ConsumerIdentity, creds CredentialsSource)
 
 	SetAlias(name string, spec RepositorySpec, creds ...CredentialsSource) error
 
@@ -66,8 +82,6 @@ func DefinedForContext(ctx context.Context) (Context, bool) {
 	return nil, ok
 }
 
-////////////////////////////////////////////////////////////////////////////////
-
 type _context struct {
 	datacontext.Context
 
@@ -75,7 +89,7 @@ type _context struct {
 	updater                  cfgcpi.Updater
 	knownRepositoryTypes     RepositoryTypeScheme
 	consumerIdentityMatchers IdentityMatcherRegistry
-	consumers                *_consumers
+	consumerProviders        *consumerProviderRegistry
 }
 
 var _ Context = &_context{}
@@ -85,7 +99,7 @@ func newContext(configctx config.Context, reposcheme RepositoryTypeScheme, consu
 		sharedattributes:         configctx.AttributesContext(),
 		knownRepositoryTypes:     reposcheme,
 		consumerIdentityMatchers: consumerMatchers,
-		consumers:                newConsumers(),
+		consumerProviders:        newConsumerProviderRegistry(),
 	}
 	c.Context = datacontext.NewContextBase(c, CONTEXT_TYPE, key, configctx.GetAttributes(), delegates)
 	c.updater = cfgcpi.NewUpdater(configctx, c)
@@ -164,24 +178,29 @@ func (c *_context) GetCredentialsForConsumer(identity ConsumerIdentity, matchers
 	}
 
 	m := defaultMatcher(matchers...)
-	var consumer *_consumer
+	var credsrc CredentialsSource
 	if m == nil {
-		consumer = c.consumers.Get(identity)
+		credsrc, _ = c.consumerProviders.Get(identity)
 	} else {
-		consumer = c.consumers.Match(identity, m)
+		credsrc, _ = c.consumerProviders.Match(identity, nil, m)
 	}
-	if consumer == nil {
-		consumer = c.consumers.Get(emptyIdentity)
+	if credsrc == nil {
+		credsrc, _ = c.consumerProviders.Get(emptyIdentity)
 	}
-	if consumer == nil {
+	if credsrc == nil {
 		return nil, ErrUnknownConsumer(identity.String())
 	}
-	return consumer.GetCredentials(), nil
+	return credsrc, nil
 }
 
 func (c *_context) SetCredentialsForConsumer(identity ConsumerIdentity, creds CredentialsSource) {
 	c.Update()
-	c.consumers.Set(identity, creds)
+	c.consumerProviders.Set(identity, "", creds)
+}
+
+func (c *_context) SetCredentialsForConsumerWithProvider(pid ProviderIdentity, identity ConsumerIdentity, creds CredentialsSource) {
+	c.Update()
+	c.consumerProviders.Set(identity, pid, creds)
 }
 
 func (c *_context) ConsumerIdentityMatchers() IdentityMatcherRegistry {
@@ -198,4 +217,12 @@ func (c *_context) SetAlias(name string, spec RepositorySpec, creds ...Credentia
 		return a.SetAlias(c, name, spec, CredentialsChain(creds))
 	}
 	return errors.ErrNotImplemented("interface", "AliasRegistry", reflect.TypeOf(t).String())
+}
+
+func (c *_context) RegisterConsumerProvider(id ProviderIdentity, provider ConsumerProvider) {
+	c.consumerProviders.Register(id, provider)
+}
+
+func (c *_context) UnregisterConsumerProvider(id ProviderIdentity) {
+	c.consumerProviders.Unregister(id)
 }

--- a/pkg/contexts/credentials/internal/context.go
+++ b/pkg/contexts/credentials/internal/context.go
@@ -12,6 +12,7 @@ import (
 	cfgcpi "github.com/open-component-model/ocm/pkg/contexts/config/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/finalizer"
 	"github.com/open-component-model/ocm/pkg/runtime"
 )
 
@@ -22,7 +23,7 @@ const CONTEXT_TYPE = "credentials" + datacontext.OCM_CONTEXT_SUFFIX
 // for a configured consumer id. If non-empty it
 // must start with a DNSname identifying the origin of the
 // provider followed by a slash and a local arbitrary identity.
-type ProviderIdentity string
+type ProviderIdentity = finalizer.ObjectIdentity
 
 type ContextProvider interface {
 	CredentialsContext() Context
@@ -83,7 +84,7 @@ func DefinedForContext(ctx context.Context) (Context, bool) {
 }
 
 type _context struct {
-	datacontext.Context
+	datacontext.InternalContext
 
 	sharedattributes         datacontext.AttributesContext
 	updater                  cfgcpi.Updater
@@ -101,7 +102,7 @@ func newContext(configctx config.Context, reposcheme RepositoryTypeScheme, consu
 		consumerIdentityMatchers: consumerMatchers,
 		consumerProviders:        newConsumerProviderRegistry(),
 	}
-	c.Context = datacontext.NewContextBase(c, CONTEXT_TYPE, key, configctx.GetAttributes(), delegates)
+	c.InternalContext = datacontext.NewContextBase(c, CONTEXT_TYPE, key, configctx.GetAttributes(), delegates)
 	c.updater = cfgcpi.NewUpdater(configctx, c)
 	return c
 }

--- a/pkg/contexts/credentials/ref_test.go
+++ b/pkg/contexts/credentials/ref_test.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package credentials_test
+
+import (
+	"runtime"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/open-component-model/ocm/pkg/contexts/credentials"
+	"github.com/open-component-model/ocm/pkg/finalizer"
+)
+
+var _ = Describe("area test", func() {
+	It("can access the default context", func() {
+		ctx := credentials.New()
+
+		r := finalizer.GetRuntimeFinalizationRecorder(ctx)
+		Expect(r).NotTo(BeNil())
+
+		runtime.GC()
+		time.Sleep(time.Second)
+		ctx.GetType()
+		Expect(r.Get()).To(BeNil())
+
+		ctx = nil
+		runtime.GC()
+		time.Sleep(time.Second)
+
+		Expect(r.Get()).To(ContainElement(ContainSubstring(credentials.CONTEXT_TYPE)))
+	})
+})

--- a/pkg/contexts/credentials/repositories/dockerconfig/credentials.go
+++ b/pkg/contexts/credentials/repositories/dockerconfig/credentials.go
@@ -5,6 +5,7 @@
 package dockerconfig
 
 import (
+	"github.com/docker/cli/cli/config/configfile"
 	dockercred "github.com/docker/cli/cli/config/credentials"
 	"github.com/docker/cli/cli/config/types"
 
@@ -14,24 +15,24 @@ import (
 )
 
 type Credentials struct {
-	repo  *Repository
-	name  string
-	store dockercred.Store
+	config *configfile.ConfigFile
+	name   string
+	store  dockercred.Store
 }
 
 var _ cpi.Credentials = (*Credentials)(nil)
 
 // NewCredentials describes a default getter method for a authentication method.
-func NewCredentials(repo *Repository, name string, store dockercred.Store) cpi.Credentials {
+func NewCredentials(cfg *configfile.ConfigFile, name string, store dockercred.Store) cpi.Credentials {
 	return &Credentials{
-		repo:  repo,
-		name:  name,
-		store: store,
+		config: cfg,
+		name:   name,
+		store:  store,
 	}
 }
 
 func (c *Credentials) get() common.Properties {
-	auth, err := c.repo.config.GetAuthConfig(c.name)
+	auth, err := c.config.GetAuthConfig(c.name)
 	if err != nil {
 		return common.Properties{}
 	}
@@ -42,7 +43,7 @@ func (c *Credentials) Credentials(context cpi.Context, source ...cpi.Credentials
 	var auth types.AuthConfig
 	var err error
 	if c.store == nil {
-		auth, err = c.repo.config.GetAuthConfig(c.name)
+		auth, err = c.config.GetAuthConfig(c.name)
 	} else {
 		auth, err = c.store.Get(c.name)
 	}

--- a/pkg/contexts/credentials/repositories/dockerconfig/provider.go
+++ b/pkg/contexts/credentials/repositories/dockerconfig/provider.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dockerconfig
+
+import (
+	"github.com/docker/cli/cli/config/configfile"
+	dockercred "github.com/docker/cli/cli/config/credentials"
+
+	"github.com/open-component-model/ocm/pkg/contexts/credentials/cpi"
+	"github.com/open-component-model/ocm/pkg/contexts/credentials/internal"
+	"github.com/open-component-model/ocm/pkg/contexts/oci/identity"
+)
+
+const PROVIDER = "ocm.software/" + Type
+
+type ConsumerProvider struct {
+	cfg *configfile.ConfigFile
+}
+
+var _ cpi.ConsumerProvider = (*ConsumerProvider)(nil)
+
+func (p *ConsumerProvider) Unregister(id internal.ProviderIdentity) {
+}
+
+func (p *ConsumerProvider) Match(req cpi.ConsumerIdentity, cur cpi.ConsumerIdentity, m cpi.IdentityMatcher) (cpi.CredentialsSource, cpi.ConsumerIdentity) {
+	return p.get(req, cur, m)
+}
+
+func (p *ConsumerProvider) Get(req cpi.ConsumerIdentity) (cpi.CredentialsSource, bool) {
+	creds, _ := p.get(req, nil, cpi.CompleteMatch)
+	return creds, creds != nil
+}
+
+func (p *ConsumerProvider) get(req cpi.ConsumerIdentity, cur cpi.ConsumerIdentity, m cpi.IdentityMatcher) (cpi.CredentialsSource, cpi.ConsumerIdentity) {
+	cfg := p.cfg
+	all := cfg.GetAuthConfigs()
+	defaultStore := dockercred.DetectDefaultStore(cfg.CredentialsStore)
+	store := dockercred.NewNativeStore(cfg, defaultStore)
+
+	var creds cpi.CredentialsSource
+
+	for h, a := range all {
+		hostname := dockercred.ConvertToHostname(h)
+		if hostname == "index.docker.io" {
+			hostname = "docker.io"
+		}
+		id := cpi.ConsumerIdentity{
+			cpi.ATTR_TYPE:        identity.CONSUMER_TYPE,
+			identity.ID_HOSTNAME: hostname,
+		}
+		if m(req, cur, id) {
+			if IsEmptyAuthConfig(a) {
+				creds = NewCredentials(cfg, h, store)
+			} else {
+				creds = newCredentials(a)
+			}
+			cur = id
+		}
+	}
+	for h, helper := range cfg.CredentialHelpers {
+		hostname := dockercred.ConvertToHostname(h)
+		if hostname == "index.docker.io" {
+			hostname = "docker.io"
+		}
+		id := cpi.ConsumerIdentity{
+			cpi.ATTR_TYPE:        identity.CONSUMER_TYPE,
+			identity.ID_HOSTNAME: hostname,
+		}
+		if m(req, cur, id) {
+			creds = NewCredentials(cfg, h, dockercred.NewNativeStore(cfg, helper))
+			cur = id
+		}
+	}
+	return creds, cur
+}

--- a/pkg/contexts/credentials/repositories/dockerconfig/provider.go
+++ b/pkg/contexts/credentials/repositories/dockerconfig/provider.go
@@ -13,7 +13,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/oci/identity"
 )
 
-const PROVIDER = "ocm.software/" + Type
+const PROVIDER = "ocm.software/credentialprovider/" + Type
 
 type ConsumerProvider struct {
 	cfg *configfile.ConfigFile

--- a/pkg/contexts/credentials/repositories/dockerconfig/repository.go
+++ b/pkg/contexts/credentials/repositories/dockerconfig/repository.go
@@ -18,6 +18,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/cpi"
 	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/finalizer"
 )
 
 type Repository struct {
@@ -85,6 +86,7 @@ func (r *Repository) Read(force bool) error {
 	var (
 		data []byte
 		err  error
+		id   finalizer.ObjectIdentity
 	)
 	if r.path != "" {
 		path := r.path
@@ -97,8 +99,10 @@ func (r *Repository) Read(force bool) error {
 		if err != nil {
 			return fmt.Errorf("failed to read file '%s': %w", path, err)
 		}
+		id = cpi.ProviderIdentity(PROVIDER + "/" + path)
 	} else if len(r.data) > 0 {
 		data = r.data
+		id = finalizer.NewObjectIdentity(PROVIDER)
 	}
 
 	cfg, err := config.LoadFromReader(bytes.NewBuffer(data))
@@ -106,7 +110,7 @@ func (r *Repository) Read(force bool) error {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
 	if r.propagate {
-		r.ctx.RegisterConsumerProvider(cpi.ProviderIdentity(PROVIDER+"//"+path), &ConsumerProvider{cfg})
+		r.ctx.RegisterConsumerProvider(id, &ConsumerProvider{cfg})
 	}
 	r.config = cfg
 	return nil

--- a/pkg/finalizer/object.go
+++ b/pkg/finalizer/object.go
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package finalizer
+
+import (
+	"fmt"
+	"runtime"
+	"sync"
+)
+
+// NumberRange can be used as source for successive id numbers to tag
+// elements, since debuggers not always sow object addresses.
+type NumberRange struct {
+	id   uint64
+	lock sync.Mutex
+}
+
+func (n *NumberRange) NextId() uint64 {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+
+	n.id++
+	return n.id
+}
+
+var objectrange = NumberRange{}
+
+type ObjectIdentity string
+
+func (i ObjectIdentity) String() string {
+	return string(i)
+}
+
+func NewObjectIdentity(kind string) ObjectIdentity {
+	return ObjectIdentity(fmt.Sprintf("%s/%d", kind, objectrange.NextId()))
+}
+
+type RuntimeFinalizationRecoder struct {
+	lock sync.Mutex
+	ids  []ObjectIdentity
+}
+
+func (r *RuntimeFinalizationRecoder) Get() []ObjectIdentity {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return append(r.ids[:0:0], r.ids...)
+}
+
+func (r *RuntimeFinalizationRecoder) Record(id ObjectIdentity) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.ids = append(r.ids, id)
+}
+
+func (r *RuntimeFinalizationRecoder) IsFinalized(objs ...ObjectIdentity) bool {
+	for _, o := range objs {
+		found := false
+		for _, f := range r.ids {
+			if f == o {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return len(r.ids) != 0
+}
+
+type RuntimeFinalizer struct {
+	id       ObjectIdentity
+	recorder *RuntimeFinalizationRecoder
+}
+
+func fi(o *RuntimeFinalizer) {
+	o.finalize()
+}
+
+func NewRuntimeFinalizer(id ObjectIdentity, r *RuntimeFinalizationRecoder) *RuntimeFinalizer {
+	f := &RuntimeFinalizer{
+		id:       id,
+		recorder: r,
+	}
+
+	runtime.SetFinalizer(f, fi)
+	return f
+}
+
+func (f *RuntimeFinalizer) finalize() {
+	if f.recorder != nil {
+		f.recorder.Record(f.id)
+		f.recorder = nil
+	}
+}
+
+type RecorderProvider interface {
+	GetRecorder() *RuntimeFinalizationRecoder
+}
+
+func GetRuntimeFinalizationRecorder(o any) *RuntimeFinalizationRecoder {
+	if r, ok := o.(RecorderProvider); ok {
+		return r.GetRecorder()
+	}
+	return nil
+}

--- a/pkg/finalizer/object_test.go
+++ b/pkg/finalizer/object_test.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package finalizer_test
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/open-component-model/ocm/pkg/finalizer"
+)
+
+type ObjectType struct {
+	kind string
+	id   finalizer.ObjectIdentity
+	fi   *finalizer.RuntimeFinalizer
+}
+
+func NewOType(kind string, r *finalizer.RuntimeFinalizationRecoder) *ObjectType {
+	id := finalizer.NewObjectIdentity(kind)
+	o := &ObjectType{
+		kind: kind,
+		id:   id,
+		fi:   finalizer.NewRuntimeFinalizer(id, r),
+	}
+	return o
+}
+
+func (o *ObjectType) Id() finalizer.ObjectIdentity {
+	return o.id
+}
+
+var _ = Describe("runtime finalizer", func() {
+	It("finalize with arbitrary method", func() {
+		r := &finalizer.RuntimeFinalizationRecoder{}
+
+		o1 := NewOType("test1", r)
+		o2 := NewOType("test1", r)
+
+		id1 := o1.Id()
+		id2 := o2.Id()
+
+		runtime.GC()
+		time.Sleep(time.Second)
+
+		fmt.Printf("still used (%s,%s)\n", o1.Id(), o2.Id())
+		Expect(len(r.Get())).To(Equal(0))
+
+		o1 = nil
+		runtime.GC()
+		time.Sleep(time.Second)
+		fmt.Printf("still used (%s)\n", o2.Id())
+		Expect(r.Get()).To(Equal([]finalizer.ObjectIdentity{id1}))
+
+		o2 = nil
+		runtime.GC()
+		time.Sleep(time.Second)
+		Expect(r.Get()).To(Equal([]finalizer.ObjectIdentity{id1, id2}))
+	})
+})

--- a/pkg/generics/map.go
+++ b/pkg/generics/map.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package generics
+
+func MapKeys[K comparable, V any](m map[K]V) Set[K] {
+	s := Set[K]{}
+	for k := range m {
+		s.Add(k)
+	}
+	return s
+}
+
+func MapKeyArray[K comparable, V any](m map[K]V) []K {
+	a := make([]K, len(m), len(m))
+	i := 0
+	for k := range m {
+		a[i] = k
+		i++
+	}
+	return a
+}
+
+func MapValues[K comparable, V any](m map[K]V) []V {
+	a := make([]V, len(m), len(m))
+	i := 0
+	for _, v := range m {
+		a[i] = v
+		i++
+	}
+	return a
+}

--- a/pkg/generics/map.go
+++ b/pkg/generics/map.go
@@ -13,7 +13,7 @@ func MapKeys[K comparable, V any](m map[K]V) Set[K] {
 }
 
 func MapKeyArray[K comparable, V any](m map[K]V) []K {
-	a := make([]K, len(m), len(m))
+	a := make([]K, len(m))
 	i := 0
 	for k := range m {
 		a[i] = k
@@ -23,7 +23,7 @@ func MapKeyArray[K comparable, V any](m map[K]V) []K {
 }
 
 func MapValues[K comparable, V any](m map[K]V) []V {
-	a := make([]V, len(m), len(m))
+	a := make([]V, len(m))
 	i := 0
 	for _, v := range m {
 		a[i] = v


### PR DESCRIPTION
**What this PR does / why we need it**:

Instead of propagating single credentials for single consumers, it is possible now
to add complete CosumerProviders handling consumer requests.

The explicit consumer registry has been replaced by an internal standard consumer provider
and the Docker Config repository has been migrated to provide such a consumer provider.

Consumer providers and entries now have an optional provider id, which can be used
to clean up all setting from one provider. This can be used to refresh or delete providers,
again.

Additionally, the contexts now feature a unique Id for debugging and logging.
They also offer a possibility now to check, whether a context has been garbage collected
as expected when getting rid of a context.

The Credentials Context now has a test for this.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
