### PR TITLE
improve ocm ref parsing

### DIFF
--- a/pkg/contexts/oci/grammar/grammar.go
+++ b/pkg/contexts/oci/grammar/grammar.go
@@ -97,6 +97,11 @@ var (
 		DomainRegexp,
 		Optional(Literal(`:`), Match(`[0-9]+`)))
 
+	// HostPortRegexp describes a non-DNS simple hostname like localhost.
+	HostPortRegexp = Sequence(
+		DomainComponentRegexp,
+		Optional(Literal(`:`), Match(`[0-9]+`)))
+
 	PathRegexp = Sequence(
 		Optional(Literal("/")),
 		Match(`[a-zA-Z0-9-_.]+(?:/[a-zA-Z0-9-_.]+)+`))

--- a/pkg/contexts/ocm/cpi/ref.go
+++ b/pkg/contexts/ocm/cpi/ref.go
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cpi
+
+import (
+	"sync"
+)
+
+type ParseHandler func(u *UniformRepositorySpec) error
+
+type registry struct {
+	lock     sync.RWMutex
+	handlers map[string]ParseHandler
+}
+
+func (r *registry) Register(ty string, h ParseHandler) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.handlers[ty] = h
+}
+
+func (r *registry) Get(ty string) ParseHandler {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	return r.handlers[ty]
+}
+
+func (r *registry) Handle(u UniformRepositorySpec) (UniformRepositorySpec, error) {
+	h := r.Get(u.Type)
+	if h != nil {
+		err := h(&u)
+		return u, err
+	}
+	return u, nil
+}
+
+var parseregistry = &registry{handlers: map[string]ParseHandler{}}
+
+func RegisterRefParseHandler(ty string, h ParseHandler) {
+	parseregistry.Register(ty, h)
+}
+
+func GetRefParseHandler(ty string, h ParseHandler) {
+	parseregistry.Get(ty)
+}
+
+func HandleRef(u UniformRepositorySpec) (UniformRepositorySpec, error) {
+	return parseregistry.Handle(u)
+}

--- a/pkg/contexts/ocm/internal/uniform.go
+++ b/pkg/contexts/ocm/internal/uniform.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/open-component-model/ocm/pkg/contexts/oci/repositories/ocireg"
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/runtime"
 	"github.com/open-component-model/ocm/pkg/utils"
@@ -48,7 +47,7 @@ func (r *UniformRepositorySpec) CredHost() string {
 
 func (u *UniformRepositorySpec) String() string {
 	t := u.Type
-	if t != "" && !ocireg.IsKind(t) {
+	if t != "" {
 		t += "::"
 	}
 	if u.Info != "" {

--- a/pkg/contexts/ocm/ref_test.go
+++ b/pkg/contexts/ocm/ref_test.go
@@ -5,9 +5,12 @@
 package ocm_test
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/open-component-model/ocm/pkg/contexts/oci/repositories/ocireg"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 )
 
@@ -54,19 +57,29 @@ func CheckRef(ref, ut, h, us, c, uv, i string) {
 
 var _ = Describe("ref parsing", func() {
 	Context("complete refs", func() {
-		t := "OCIRepository"
+		t := ocireg.Type
 		s := "mandelsoft/cnudie"
 		v := "v1"
 
 		h := "ghcr.io"
 		c := "github.com/mandelsoft/ocm"
 
-		It("without info", func() {
-			for _, ut := range []string{"", t} {
-				for _, us := range []string{"", s} {
-					for _, uv := range []string{"", v} {
-						ref := Type(ut) + h + Sub(us) + "//" + c + Vers(uv)
-						CheckRef(ref, ut, h, us, c, uv, "")
+		Context("without info", func() {
+			for _, ut := range []string{t, ""} {
+				for _, uh := range []string{h, h + ":3030", "localhost", "localhost:3030"} {
+					for _, us := range []string{"", s} {
+						for _, uv := range []string{"", v} {
+							ref := Type(ut) + uh + Sub(us) + "//" + c + Vers(uv)
+							ut, uh, us, uv := ut, uh, us, uv
+
+							It("parses ref "+ref, func() {
+								if ut == "" && strings.HasPrefix(uh, "localhost") {
+									CheckRef(ref, ut, "", "", c, uv, uh+Sub(us))
+								} else {
+									CheckRef(ref, ut, uh, us, c, uv, "")
+								}
+							})
+						}
 					}
 				}
 			}

--- a/pkg/contexts/ocm/ref_test.go
+++ b/pkg/contexts/ocm/ref_test.go
@@ -10,8 +10,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/open-component-model/ocm/pkg/contexts/oci/repositories/ocireg"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/ocireg"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 )
 
 func Type(t string) string {
@@ -106,6 +107,16 @@ var _ = Describe("ref parsing", func() {
 			CheckRef("directory::file//bla.blob/comp", "directory", "", "", "bla.blob/comp", "", "file")
 			CheckRef("directory::./file.io//bla.blob/comp", "directory", "", "", "bla.blob/comp", "", "./file.io")
 			CheckRef("any::file.io//bla.blob/comp", "any", "file.io", "", "bla.blob/comp", "", "")
+		})
+	})
+
+	Context("map to spec", func() {
+		It("handles localhost", func() {
+			ctx := ocm.New()
+
+			ref := Must(ocm.ParseRef("OCIRegistry::localhost:80/test//github.vom/mandelsoft/test"))
+			spec := Must(ctx.MapUniformRepositorySpec(&ref.UniformRepositorySpec))
+			Expect(spec).To(Equal(ocireg.NewRepositorySpec("localhost:80", ocireg.NewComponentRepositoryMeta("test", ""))))
 		})
 	})
 })

--- a/pkg/contexts/ocm/repositories/genericocireg/uniform.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/uniform.go
@@ -5,6 +5,9 @@
 package genericocireg
 
 import (
+	"strings"
+
+	"github.com/open-component-model/ocm/pkg/contexts/oci/grammar"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/repositories/ocireg"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/attrs/compatattr"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
@@ -12,6 +15,7 @@ import (
 
 func init() {
 	cpi.RegisterRepositorySpecHandler(&repospechandler{}, "*")
+	cpi.RegisterRefParseHandler(Type, HandleRef)
 }
 
 type repospechandler struct{}
@@ -28,4 +32,24 @@ func (h *repospechandler) MapReference(ctx cpi.Context, u *cpi.UniformRepository
 		return NewRepositorySpec(ocireg.NewLegacyRepositorySpec(u.Host), meta), nil
 	}
 	return NewRepositorySpec(ocireg.NewRepositorySpec(u.Host), meta), nil
+}
+
+func HandleRef(u *cpi.UniformRepositorySpec) error {
+	if u.Host == "" && u.Info != "" && u.SubPath == "" {
+		host := ""
+		subp := ""
+		idx := strings.Index(u.Info, grammar.RepositorySeparator)
+		if idx > 0 {
+			host = u.Info[:idx]
+			subp = u.Info[idx+1:]
+		} else {
+			host = u.Info
+		}
+		if grammar.HostPortRegexp.MatchString(host) || grammar.DomainPortRegexp.MatchString(host) {
+			u.Host = host
+			u.SubPath = subp
+			u.Info = ""
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

localhost or other potentially non DNS like host name parts in OCM ref expressions are not handled
correctly, even if the repository type prefix is given.

To solve the general ref parsing there is already a type UniformRepositorySpec, which holds various
parts of a reference and which is then mapped by heuristics to dedicated repository specs.

The problem here is that these heuristics cannot be unique if the intended type is not known.

Now we add type specific handlers, which can normalize the uniform spec according to the constraints
of the dedicated type.

Additionally, the OCIRegistry handler for mapping of URSs has been extended to handle the Info field, if host is not set,


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
