### PR TITLE
support for helm artifact downloading from OCI artifacts for landscaper

### DIFF
--- a/pkg/contexts/credentials/builtin/github/github.go
+++ b/pkg/contexts/credentials/builtin/github/github.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package github
+
+import (
+	"os"
+
+	"github.com/open-component-model/ocm/pkg/common"
+	"github.com/open-component-model/ocm/pkg/contexts/credentials/cpi"
+	"github.com/open-component-model/ocm/pkg/contexts/oci/identity"
+)
+
+const CONSUMER_TYPE = "Github"
+
+const GITHUB = "github.com"
+
+func init() {
+	t := os.Getenv("GITHUB_TOKEN")
+	if t != "" {
+		host := os.Getenv("GITHUB_HOST")
+		if host == "" {
+			host = GITHUB
+		}
+
+		id := cpi.ConsumerIdentity{
+			identity.ID_TYPE:     CONSUMER_TYPE,
+			identity.ID_HOSTNAME: host,
+		}
+		if src, err := cpi.DefaultContext.GetCredentialsForConsumer(id); err != nil || src == nil {
+			creds := cpi.NewCredentials(common.Properties{cpi.ATTR_IDENTITY_TOKEN: t})
+			cpi.DefaultContext.SetCredentialsForConsumer(id, creds)
+		}
+	}
+}

--- a/pkg/contexts/credentials/doc.go
+++ b/pkg/contexts/credentials/doc.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package credentials handles the access to credentials for consumers of
+// credential sets.
+//
+// A credentials set is just a set of simple key/values pair,
+// for example username and password.
+// Every credential consumer, for example repository implementation of other
+// context types, (OCI repositories, OCM repositories, ...) uses the same
+// procedure to get to its credentials:
+//  1. it composes a most significant typed ConsumerIdentity for every request. This
+//     is a set of name/value pairs describing the access context. For an OCI
+//     registry, this is for example:
+//     - the type (OCIRegistry)
+//     - the hostname
+//     - an optional port
+//     - the repository path
+//  2. it then requests credentials from its credentials Context for this consumer.
+//  3. the credentials context matches the requested consumer against configured
+//     consumers using a dedicated matcher. (For example: finding the consumer
+//     specification with the longest matching repository path prefix (for OCI))
+//  4. the credentials for the best matching entry are then returned to the requester.
+//
+// The credentials context is the mediator between credential providers and
+// credential consumers. Here
+//   - it is possible to explicitly configure credentials for consumer ids
+//   - it is possible to manage credential repositories providing named
+//     credential sets and
+//   - to map dedicated such sets to consumer ids.
+//   - specialized credential repositories, may propagate their contained
+//     credentials to auto-calculated consumer ids.
+//
+// This way, there is a special credential repository type DockerConfig. It
+// knows what its credentials are meant for (for accessing OCI registries). When
+// instantiating such a repository, it automatically exposes its credentials
+// under the appropriate consumer ids used by the OCI repository implementation.
+// But docker does not allow for separate credentials for different repository
+// prefixes in OCI registries (for example organisations in ghcr.io), only per
+// host. Therefore, the propagated consumer ids do not provide the path
+// property of a consumer id. Together with the path prefix matcher, those id
+// settings therefore match all OCI credential requests for all repository paths
+// of a dedicated host, as long as there is no more significant setting.
+//
+// The credentials context also provides a configuration objeect managed by
+// a ConfigurationContext and used to configure a credentials context. The
+// serialization form of this object can be put into a configuration object of
+// the configuration context. For example, the .ocmconfig file is then a
+// serialization of such an object which is initially read by the OCM CLI to
+// configure the used ConfigurationContext.
+// If it describes a credentials configuration this one is applied to the
+// credentials context. Such a credentials config object allows to
+//   - describe direct consumer id to credential set mappings
+//   - describe the instantiation of credential repositories (for example a
+//     dockerconfig repo)
+//   - the mapping of credential sets of any credential repository to consumer
+//     ids (for example mapping of vault entries to consumers (vault not
+//     implemented yet)
+//
+// As for very context type the Context is the central element of this package.
+// It provides access to the complete functionality by bundling all the settings
+// required to provide credentials to its clients.
+package credentials

--- a/pkg/contexts/ocm/accessmethods/github/method.go
+++ b/pkg/contexts/ocm/accessmethods/github/method.go
@@ -22,6 +22,7 @@ import (
 	hd "github.com/open-component-model/ocm/pkg/common/accessio/downloader/http"
 	"github.com/open-component-model/ocm/pkg/common/accessobj"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
+	github2 "github.com/open-component-model/ocm/pkg/contexts/credentials/builtin/github"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/identity/hostpath"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/identity"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
@@ -41,7 +42,7 @@ const (
 	LegacyTypeV1 = LegacyType + runtime.VersionSeparator + "v1"
 )
 
-const CONSUMER_TYPE = "Github"
+const CONSUMER_TYPE = github2.CONSUMER_TYPE
 
 const ShaLength = 40
 

--- a/pkg/contexts/ocm/download/handlers/helm/download.go
+++ b/pkg/contexts/ocm/download/handlers/helm/download.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package blob
+
+import (
+	"github.com/mandelsoft/vfs/pkg/vfs"
+
+	"github.com/open-component-model/ocm/pkg/common"
+	"github.com/open-component-model/ocm/pkg/contexts/oci"
+	"github.com/open-component-model/ocm/pkg/finalizer"
+)
+
+func Download(p common.Printer, ctx oci.Context, ref string, path string, fs vfs.FileSystem) (err error) {
+	var finalize finalizer.Finalizer
+	defer finalize.FinalizeWithErrorPropagationf(&err, "downloading helm chart %q", ref)
+
+	r, err := oci.ParseRef(ref)
+	if err != nil {
+		return err
+	}
+
+	spec, err := ctx.MapUniformRepositorySpec(&r.UniformRepositorySpec)
+	if err != nil {
+		return err
+	}
+
+	repo, err := ctx.RepositoryForSpec(spec)
+	if err != nil {
+		return err
+	}
+	finalize.Close(repo)
+
+	art, err := repo.LookupArtifact(r.Repository, r.Version())
+	if err != nil {
+		return err
+	}
+	finalize.Close(art)
+
+	return download(p, art, path, fs)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR separates the OCM specific part of the OCM helm downloader from the generic OCI specific part
to make it reusable for other clients.

Additionally it add doc for the credential handling with credential context.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
