### PR TITLE
provide digest error for OCI artifacts

### DIFF
--- a/pkg/contexts/ocm/accessmethods/ociartifact/method.go
+++ b/pkg/contexts/ocm/accessmethods/ociartifact/method.go
@@ -186,6 +186,11 @@ func (m *accessMethod) getArtifact() (oci.ArtifactAccess, *oci.RefSpec, error) {
 }
 
 func (m *accessMethod) Digest() digest.Digest {
+	d, _ := m.GetDigest()
+	return d
+}
+
+func (m *accessMethod) GetDigest() (digest.Digest, error) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
@@ -194,11 +199,11 @@ func (m *accessMethod) Digest() digest.Digest {
 		m.art = art
 		blob, err := art.Blob()
 		if err == nil {
-			return blob.Digest()
+			return blob.Digest(), nil
 		}
 		m.finalizer.Close(blob)
 	}
-	return ""
+	return "", err
 }
 
 func (m *accessMethod) Get() ([]byte, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Signing a resource of access type ociArtifact the digest must be determined. This fails if there is a permission problem.
The actually used Digest method (as part of the BlobAccess interface) does not provide an error return value,
therefore the signing error does not tell the reason for the failed signing.

The BlobAccess interface is very basic and used all over the code, therefore it is hard to change.
But the actual problem arises from accessing the access method. Here a better method with error return
is added to provide the fail reason, if the digest determination fails.  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
