### PR TITLE
provide selectors on access level of ocm context

### DIFF
--- a/cmds/ocm/commands/ocmcmds/references/add/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/references/add/cmd_test.go
@@ -22,7 +22,7 @@ const VERSION = "v1.1.1"
 const REF = "github.com/mandelsoft/ref"
 
 func CheckReference(env *TestEnv, cd *compdesc.ComponentDescriptor, name string, add ...func(compdesc.ComponentReference)) {
-	rs := cd.GetReferencesByName(name)
+	rs, _ := cd.GetReferencesByName(name)
 	if len(rs) != 1 {
 		Fail(fmt.Sprintf("%d reference(s) with name %s found", len(rs), name), 1)
 	}

--- a/pkg/contexts/ocm/compdesc/helper.go
+++ b/pkg/contexts/ocm/compdesc/helper.go
@@ -275,27 +275,23 @@ func (cd *ComponentDescriptor) GetReferenceByIdentity(id v1.Identity) (Component
 }
 
 // GetReferencesByName returns references that match the given name.
-func (cd *ComponentDescriptor) GetReferencesByName(name string) []ComponentReference {
-	var refs []ComponentReference
-	for _, ref := range cd.References {
-		if ref.Name == name {
-			refs = append(refs, ref)
-		}
-	}
-	return refs
+func (cd *ComponentDescriptor) GetReferencesByName(name string, selectors ...IdentitySelector) (References, error) {
+	return cd.GetReferencesBySelectors(
+		append(selectors, ByName(name)),
+		nil)
 }
 
-// GetResourcesByIdentitySelectors returns resources that match the given identity selectors.
+// GetReferencesByIdentitySelectors returns resources that match the given identity selectors.
 func (cd *ComponentDescriptor) GetReferencesByIdentitySelectors(selectors ...IdentitySelector) (References, error) {
 	return cd.GetReferencesBySelectors(selectors, nil)
 }
 
-// GetResourcesByResourceSelectors returns resources that match the given resource selectors.
+// GetReferencesByReferenceSelectors returns resources that match the given resource selectors.
 func (cd *ComponentDescriptor) GetReferencesByReferenceSelectors(selectors ...ReferenceSelector) (References, error) {
 	return cd.GetReferencesBySelectors(nil, selectors)
 }
 
-// GetResourcesBySelectors returns resources that match the given selector.
+// GetReferencesBySelectors returns resources that match the given selector.
 func (cd *ComponentDescriptor) GetReferencesBySelectors(selectors []IdentitySelector, referenceSelectors []ReferenceSelector) (References, error) {
 	references := make(References, 0)
 	for i := range cd.References {

--- a/pkg/contexts/ocm/cpi/dummy.go
+++ b/pkg/contexts/ocm/cpi/dummy.go
@@ -117,3 +117,23 @@ func (d *DummyComponentVersionAccess) Close() error {
 func (d *DummyComponentVersionAccess) Dup() (ComponentVersionAccess, error) {
 	return d, nil
 }
+
+func (d *DummyComponentVersionAccess) GetResourcesByIdentitySelectors(selectors ...compdesc.IdentitySelector) ([]internal.ResourceAccess, error) {
+	return nil, nil
+}
+
+func (d *DummyComponentVersionAccess) GetResourcesByResourceSelectors(selectors ...compdesc.ResourceSelector) ([]internal.ResourceAccess, error) {
+	return nil, nil
+}
+
+func (d *DummyComponentVersionAccess) GetReferencesByName(name string, selectors ...compdesc.IdentitySelector) (compdesc.References, error) {
+	return nil, nil
+}
+
+func (d *DummyComponentVersionAccess) GetReferencesByIdentitySelectors(selectors ...compdesc.IdentitySelector) (compdesc.References, error) {
+	return nil, nil
+}
+
+func (d *DummyComponentVersionAccess) GetReferencesByReferenceSelectors(selectors ...compdesc.ReferenceSelector) (compdesc.References, error) {
+	return nil, nil
+}

--- a/pkg/contexts/ocm/cpi/interface.go
+++ b/pkg/contexts/ocm/cpi/interface.go
@@ -9,6 +9,7 @@ package cpi
 import (
 	"github.com/mandelsoft/logging"
 
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/internal"
 	"github.com/open-component-model/ocm/pkg/registrations"
 	"github.com/open-component-model/ocm/pkg/runtime"
@@ -57,6 +58,7 @@ type (
 	GenericRepositorySpec            = internal.GenericRepositorySpec
 	RepositoryType                   = internal.RepositoryType
 	ComponentReference               = internal.ComponentReference
+	References                       = compdesc.References
 )
 
 type (

--- a/pkg/contexts/ocm/cpi/support/container.go
+++ b/pkg/contexts/ocm/cpi/support/container.go
@@ -16,9 +16,9 @@ type BlobContainer interface {
 	GetBlobData(name string) (cpi.DataAccess, error)
 
 	// GetStorageContext creates a storage context for blobs
-	// that is used to feed blob handlers for specific blob starage methods.
+	// that is used to feed blob handlers for specific blob storage methods.
 	// If no handler accepts the blob, the AddBlobFor method will
-	// be ued toi store the blob
+	// be used to store the blob
 	GetStorageContext(cv cpi.ComponentVersionAccess) cpi.StorageContext
 
 	// AddBlobFor stores a local blob together with the component and

--- a/pkg/contexts/ocm/cpi/support/references.go
+++ b/pkg/contexts/ocm/cpi/support/references.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package support
+
+import (
+	"fmt"
+
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
+	"github.com/open-component-model/ocm/pkg/utils/selector"
+)
+
+// GetReferencesByIdentitySelectors returns references that match the given identity selectors.
+func (s *ComponentVersionAccess) GetReferencesByIdentitySelectors(selectors ...compdesc.IdentitySelector) (compdesc.References, error) {
+	return s.GetReferencesBySelectors(selectors, nil)
+}
+
+// GetReferencesByReferenceSelectors returns references that match the given resource selectors.
+func (s *ComponentVersionAccess) GetReferencesByReferenceSelectors(selectors ...compdesc.ReferenceSelector) (compdesc.References, error) {
+	return s.GetReferencesBySelectors(nil, selectors)
+}
+
+// GetReferencesBySelectors returns references that match the given selector.
+func (s *ComponentVersionAccess) GetReferencesBySelectors(selectors []compdesc.IdentitySelector, referenceSelectors []compdesc.ReferenceSelector) (compdesc.References, error) {
+	references := make(compdesc.References, 0)
+	refs := s.GetDescriptor().References
+	for i := range refs {
+		selctx := compdesc.NewReferenceSelectionContext(i, refs)
+		if len(selectors) > 0 {
+			ok, err := selector.MatchSelectors(selctx.Identity(), selectors...)
+			if err != nil {
+				return nil, fmt.Errorf("unable to match selector for resource %s: %w", selctx.Name, err)
+			}
+			if !ok {
+				continue
+			}
+		}
+		ok, err := compdesc.MatchReferencesByReferenceSelector(selctx, referenceSelectors...)
+		if err != nil {
+			return nil, fmt.Errorf("unable to match selector for resource %s: %w", selctx.Name, err)
+		}
+		if !ok {
+			continue
+		}
+		references = append(references, *selctx.ComponentReference)
+	}
+	if len(references) == 0 {
+		return references, compdesc.NotFound
+	}
+	return references, nil
+}

--- a/pkg/contexts/ocm/cpi/support/resources.go
+++ b/pkg/contexts/ocm/cpi/support/resources.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package support
+
+import (
+	"fmt"
+
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
+	"github.com/open-component-model/ocm/pkg/utils/selector"
+)
+
+// GetResourcesByIdentitySelectors returns resources that match the given identity selectors.
+func (s *ComponentVersionAccess) GetResourcesByIdentitySelectors(selectors ...compdesc.IdentitySelector) ([]cpi.ResourceAccess, error) {
+	return s.GetResourcesBySelectors(selectors, nil)
+}
+
+// GetResourcesByResourceSelectors returns resources that match the given resource selectors.
+func (s *ComponentVersionAccess) GetResourcesByResourceSelectors(selectors ...compdesc.ResourceSelector) ([]cpi.ResourceAccess, error) {
+	return s.GetResourcesBySelectors(nil, selectors)
+}
+
+// GetResourcesBySelectors returns resources that match the given selector.
+func (s *ComponentVersionAccess) GetResourcesBySelectors(selectors []compdesc.IdentitySelector, resourceSelectors []compdesc.ResourceSelector) ([]cpi.ResourceAccess, error) {
+	resources := make([]cpi.ResourceAccess, 0)
+	rscs := s.GetDescriptor().Resources
+	for i := range rscs {
+		selctx := compdesc.NewResourceSelectionContext(i, rscs)
+		if len(selectors) > 0 {
+			ok, err := selector.MatchSelectors(selctx.Identity(), selectors...)
+			if err != nil {
+				return nil, fmt.Errorf("unable to match selector for resource %s: %w", selctx.Name, err)
+			}
+			if !ok {
+				continue
+			}
+		}
+		ok, err := compdesc.MatchResourceByResourceSelector(selctx, resourceSelectors...)
+		if err != nil {
+			return nil, fmt.Errorf("unable to match selector for resource %s: %w", selctx.Name, err)
+		}
+		if !ok {
+			continue
+		}
+		r, err := s.GetResourceByIndex(i)
+		if err != nil {
+			return nil, err
+		}
+		resources = append(resources, r)
+	}
+	if len(resources) == 0 {
+		return resources, compdesc.NotFound
+	}
+	return resources, nil
+}

--- a/pkg/contexts/ocm/interface.go
+++ b/pkg/contexts/ocm/interface.go
@@ -7,6 +7,7 @@ package ocm
 import (
 	"context"
 
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/internal"
 	"github.com/open-component-model/ocm/pkg/runtime"
@@ -51,6 +52,7 @@ type (
 	RepositoryTypeScheme             = internal.RepositoryTypeScheme
 	AccessTypeScheme                 = internal.AccessTypeScheme
 	ComponentReference               = internal.ComponentReference
+	References                       = compdesc.References
 )
 
 type (

--- a/pkg/contexts/ocm/internal/context.go
+++ b/pkg/contexts/ocm/internal/context.go
@@ -47,6 +47,8 @@ type Context interface {
 
 	RepositoryForSpec(spec RepositorySpec, creds ...credentials.CredentialsSource) (Repository, error)
 	RepositoryForConfig(data []byte, unmarshaler runtime.Unmarshaler, creds ...credentials.CredentialsSource) (Repository, error)
+	RepositorySpecForConfig(data []byte, unmarshaler runtime.Unmarshaler) (RepositorySpec, error)
+
 	AccessSpecForSpec(spec compdesc.AccessSpec) (AccessSpec, error)
 	AccessSpecForConfig(data []byte, unmarshaler runtime.Unmarshaler) (AccessSpec, error)
 
@@ -193,6 +195,10 @@ func (c *_context) RepositoryForConfig(data []byte, unmarshaler runtime.Unmarsha
 		return nil, err
 	}
 	return c.RepositoryForSpec(spec, creds...)
+}
+
+func (c *_context) RepositorySpecForConfig(data []byte, unmarshaler runtime.Unmarshaler) (RepositorySpec, error) {
+	return c.knownRepositoryTypes.DecodeRepositorySpec(data, unmarshaler)
 }
 
 func (c *_context) AccessMethods() AccessTypeScheme {

--- a/pkg/contexts/ocm/internal/repository.go
+++ b/pkg/contexts/ocm/internal/repository.go
@@ -54,6 +54,7 @@ type ComponentAccess interface {
 	Close() error
 	Dup() (ComponentAccess, error)
 }
+
 type (
 	ResourceMeta       = compdesc.ResourceMeta
 	ComponentReference = compdesc.ComponentReference
@@ -89,6 +90,8 @@ type ComponentVersionAccess interface {
 	GetResource(meta metav1.Identity) (ResourceAccess, error)
 	GetResourceByIndex(i int) (ResourceAccess, error)
 	GetResourcesByName(name string, selectors ...compdesc.IdentitySelector) ([]ResourceAccess, error)
+	GetResourcesByIdentitySelectors(selectors ...compdesc.IdentitySelector) ([]ResourceAccess, error)
+	GetResourcesByResourceSelectors(selectors ...compdesc.ResourceSelector) ([]ResourceAccess, error)
 
 	GetSources() []SourceAccess
 	GetSource(meta metav1.Identity) (SourceAccess, error)
@@ -96,6 +99,9 @@ type ComponentVersionAccess interface {
 
 	GetReference(meta metav1.Identity) (ComponentReference, error)
 	GetReferenceByIndex(i int) (ComponentReference, error)
+	GetReferencesByName(name string, selectors ...compdesc.IdentitySelector) (compdesc.References, error)
+	GetReferencesByIdentitySelectors(selectors ...compdesc.IdentitySelector) (compdesc.References, error)
+	GetReferencesByReferenceSelectors(selectors ...compdesc.ReferenceSelector) (compdesc.References, error)
 
 	// AccessMethod provides an access method implementation for
 	// an access spec. This might be a repository local implementation
@@ -108,7 +114,7 @@ type ComponentVersionAccess interface {
 	// not supported by the actual repository type.
 	AccessMethod(AccessSpec) (AccessMethod, error)
 
-	// AddBlob adds a local blob and returns an appropriate local access spec
+	// AddBlob adds a local blob and returns an appropriate local access spec.
 	AddBlob(blob BlobAccess, artType, refName string, global AccessSpec) (AccessSpec, error)
 
 	SetResourceBlob(meta *ResourceMeta, blob BlobAccess, refname string, global AccessSpec) error

--- a/pkg/contexts/ocm/internal/repotypes.go
+++ b/pkg/contexts/ocm/internal/repotypes.go
@@ -93,6 +93,7 @@ func (t *repositoryTypeScheme) DecodeRepositorySpec(data []byte, unmarshaler run
 	if spec, ok := obj.(RepositorySpec); ok {
 		return spec, nil
 	}
+
 	return nil, fmt.Errorf("invalid access spec type: yield %T instead of RepositorySpec", obj)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The selection feature on the level of the component descriptor
has been used to support similar functionality on at a ComponentVersionAccess.
Thereby the method signatures have been aligned. Unfortunately the 
signature on CD level for the reference selection had to be changed here.

To support this, the support implementation for ComponentVersionAccess implementations
has been lifted to a true wrapper around an implementation object, which provides
all methods, which can be implemented in a generic manner on top of the implementation object.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
