### PR TITLE
clean up usage of internal package

### DIFF
--- a/pkg/contexts/credentials/identity/hostpath/id_test.go
+++ b/pkg/contexts/credentials/identity/hostpath/id_test.go
@@ -7,13 +7,13 @@ package hostpath_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/open-component-model/ocm/pkg/contexts/credentials/cpi"
 
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/identity/hostpath"
-	"github.com/open-component-model/ocm/pkg/contexts/credentials/internal"
 )
 
-func IdentityMatcher(pattern, cur, id internal.ConsumerIdentity) bool {
+func IdentityMatcher(pattern, cur, id cpi.ConsumerIdentity) bool {
 	return hostpath.IdentityMatcher("OCIRegistry")(pattern, cur, id)
 }
 

--- a/pkg/contexts/credentials/repositories/dockerconfig/provider.go
+++ b/pkg/contexts/credentials/repositories/dockerconfig/provider.go
@@ -7,6 +7,7 @@ package dockerconfig
 import (
 	"github.com/docker/cli/cli/config/configfile"
 	dockercred "github.com/docker/cli/cli/config/credentials"
+
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/identity"
 )

--- a/pkg/contexts/credentials/repositories/dockerconfig/provider.go
+++ b/pkg/contexts/credentials/repositories/dockerconfig/provider.go
@@ -7,9 +7,7 @@ package dockerconfig
 import (
 	"github.com/docker/cli/cli/config/configfile"
 	dockercred "github.com/docker/cli/cli/config/credentials"
-
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/cpi"
-	"github.com/open-component-model/ocm/pkg/contexts/credentials/internal"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/identity"
 )
 
@@ -21,7 +19,7 @@ type ConsumerProvider struct {
 
 var _ cpi.ConsumerProvider = (*ConsumerProvider)(nil)
 
-func (p *ConsumerProvider) Unregister(id internal.ProviderIdentity) {
+func (p *ConsumerProvider) Unregister(id cpi.ProviderIdentity) {
 }
 
 func (p *ConsumerProvider) Match(req cpi.ConsumerIdentity, cur cpi.ConsumerIdentity, m cpi.IdentityMatcher) (cpi.CredentialsSource, cpi.ConsumerIdentity) {

--- a/pkg/contexts/credentials/repositories/gardenerconfig/repository.go
+++ b/pkg/contexts/credentials/repositories/gardenerconfig/repository.go
@@ -18,7 +18,6 @@ import (
 	"github.com/mandelsoft/vfs/pkg/vfs"
 
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/cpi"
-	"github.com/open-component-model/ocm/pkg/contexts/credentials/internal"
 	gardenercfgcpi "github.com/open-component-model/ocm/pkg/contexts/credentials/repositories/gardenerconfig/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext/attrs/vfsattr"
 	"github.com/open-component-model/ocm/pkg/errors"
@@ -116,7 +115,7 @@ func (r *Repository) read(force bool) error {
 		return fmt.Errorf("unable to parse config: %w", err)
 	}
 
-	r.creds = map[string]internal.Credentials{}
+	r.creds = map[string]cpi.Credentials{}
 	for _, cred := range creds {
 		credName := cred.Name()
 		if _, ok := r.creds[credName]; !ok {

--- a/pkg/contexts/ocm/accessmethods/localblob/method.go
+++ b/pkg/contexts/ocm/accessmethods/localblob/method.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/internal"
 	"github.com/open-component-model/ocm/pkg/runtime"
 )
 
@@ -35,7 +34,7 @@ func New(local, hint string, mediaType string, global cpi.AccessSpec) *AccessSpe
 		LocalReference:      local,
 		ReferenceName:       hint,
 		MediaType:           mediaType,
-		GlobalAccess:        internal.NewAccessSpecRef(global),
+		GlobalAccess:        cpi.NewAccessSpecRef(global),
 	}
 }
 
@@ -109,7 +108,7 @@ type AccessSpecV1 struct {
 
 	// GlobalAccess is an optional field describing a possibility
 	// for a global access. If given, it MUST describe a global access method.
-	GlobalAccess *internal.AccessSpecRef `json:"globalAccess,omitempty"`
+	GlobalAccess *cpi.AccessSpecRef `json:"globalAccess,omitempty"`
 	// ReferenceName is an optional static name the object should be
 	// use in a local repository context. It is use by a repository
 	// to optionally determine a globally referencable access according
@@ -133,7 +132,7 @@ func (_ converterV1) ConvertFrom(object cpi.AccessSpec) (runtime.TypedObject, er
 		ObjectVersionedType: runtime.NewVersionedObjectType(in.Type),
 		LocalReference:      in.LocalReference,
 		ReferenceName:       in.ReferenceName,
-		GlobalAccess:        internal.NewAccessSpecRef(in.GlobalAccess),
+		GlobalAccess:        cpi.NewAccessSpecRef(in.GlobalAccess),
 		MediaType:           in.MediaType,
 	}, nil
 }

--- a/pkg/contexts/ocm/cpi/interface.go
+++ b/pkg/contexts/ocm/cpi/interface.go
@@ -138,6 +138,10 @@ func MustRegisterDigester(digester BlobDigester, arttypes ...string) {
 	internal.MustRegisterDigester(digester, arttypes...)
 }
 
+func SetDefaultDigester(d BlobDigester) {
+	internal.SetDefaultDigester(d)
+}
+
 func RegisterRepositoryType(name string, atype RepositoryType) {
 	internal.DefaultRepositoryTypeScheme.Register(name, atype)
 }

--- a/pkg/contexts/ocm/digester/digesters/blob/digester.go
+++ b/pkg/contexts/ocm/digester/digesters/blob/digester.go
@@ -9,7 +9,6 @@ import (
 	"io"
 
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/internal"
 	"github.com/open-component-model/ocm/pkg/signing"
 )
 
@@ -17,15 +16,15 @@ const GenericBlobDigestV1 = "genericBlobDigest/v1"
 
 func init() {
 	cpi.MustRegisterDigester(&defaultDigester{})
-	internal.SetDefaultDigester(&defaultDigester{})
+	cpi.SetDefaultDigester(&defaultDigester{})
 }
 
 type defaultDigester struct{}
 
 var _ cpi.BlobDigester = (*defaultDigester)(nil)
 
-func (d defaultDigester) GetType() internal.DigesterType {
-	return internal.DigesterType{
+func (d defaultDigester) GetType() cpi.DigesterType {
+	return cpi.DigesterType{
 		HashAlgorithm:          "",
 		NormalizationAlgorithm: GenericBlobDigestV1,
 	}

--- a/pkg/contexts/ocm/registration/downloader.go
+++ b/pkg/contexts/ocm/registration/downloader.go
@@ -5,14 +5,13 @@
 package registration
 
 import (
-	ocmcpi "github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/download"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/internal"
 	"github.com/open-component-model/ocm/pkg/errors"
 )
 
-func RegisterDownloadHandler(ctx internal.Context, hdlr download.Handler, olist ...BlobHandlerOption) error {
-	opts := ocmcpi.NewBlobHandlerOptions(olist...)
+func RegisterDownloadHandler(ctx cpi.Context, hdlr download.Handler, olist ...cpi.BlobHandlerOption) error {
+	opts := cpi.NewBlobHandlerOptions(olist...)
 	if opts.Priority > 0 {
 		return errors.ErrInvalid("option", "priority")
 	}

--- a/pkg/contexts/ocm/registration/uploader.go
+++ b/pkg/contexts/ocm/registration/uploader.go
@@ -8,20 +8,26 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 )
 
-func RegisterBlobHandlerByName(ctx cpi.Context, name string, config cpi.BlobHandlerConfig, opts ...cpi.BlobHandlerOption) error {
+type (
+	BlobHandlerOption  = cpi.BlobHandlerOption
+	BlobHandlerConfig  = cpi.BlobHandlerConfig
+	BlobHandlerOptions = cpi.BlobHandlerOptions
+)
+
+func RegisterBlobHandlerByName(ctx cpi.Context, name string, config BlobHandlerConfig, opts ...BlobHandlerOption) error {
 	hdlrs := ctx.BlobHandlers()
 	_, err := hdlrs.RegisterByName(name, ctx, config, opts...)
 	return err
 }
 
-func WithPrio(prio int) cpi.BlobHandlerOption {
+func WithPrio(prio int) BlobHandlerOption {
 	return cpi.WithPrio(prio)
 }
 
-func ForArtifactType(t string) cpi.BlobHandlerOption {
+func ForArtifactType(t string) BlobHandlerOption {
 	return cpi.ForArtifactType(t)
 }
 
-func ForMimeType(t string) cpi.BlobHandlerOption {
+func ForMimeType(t string) BlobHandlerOption {
 	return cpi.ForMimeType(t)
 }

--- a/pkg/contexts/ocm/registration/uploader.go
+++ b/pkg/contexts/ocm/registration/uploader.go
@@ -5,29 +5,23 @@
 package registration
 
 import (
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/internal"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 )
 
-type (
-	BlobHandlerOption  = internal.BlobHandlerOption
-	BlobHandlerConfig  = internal.BlobHandlerConfig
-	BlobHandlerOptions = internal.BlobHandlerOptions
-)
-
-func RegisterBlobHandlerByName(ctx internal.Context, name string, config BlobHandlerConfig, opts ...BlobHandlerOption) error {
+func RegisterBlobHandlerByName(ctx cpi.Context, name string, config cpi.BlobHandlerConfig, opts ...cpi.BlobHandlerOption) error {
 	hdlrs := ctx.BlobHandlers()
 	_, err := hdlrs.RegisterByName(name, ctx, config, opts...)
 	return err
 }
 
-func WithPrio(prio int) BlobHandlerOption {
-	return internal.WithPrio(prio)
+func WithPrio(prio int) cpi.BlobHandlerOption {
+	return cpi.WithPrio(prio)
 }
 
-func ForArtifactType(t string) BlobHandlerOption {
-	return internal.ForArtifactType(t)
+func ForArtifactType(t string) cpi.BlobHandlerOption {
+	return cpi.ForArtifactType(t)
 }
 
-func ForMimeType(t string) BlobHandlerOption {
-	return internal.ForMimeType(t)
+func ForMimeType(t string) cpi.BlobHandlerOption {
+	return cpi.ForMimeType(t)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The internal packages primary purpose is to prevent cyclic dependencies between its respective context package and its cpi (context programming interface) package. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The pkg/contexts/registration package is also adjusted. But as this is not exactly an extension point, one could argue whether this should in fact use the internal package. 

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
