### PR TITLE
time based cache cleanup

### DIFF
--- a/docs/reference/ocm_clean_cache.md
+++ b/docs/reference/ocm_clean_cache.md
@@ -9,7 +9,9 @@ ocm clean cache [<options>]
 ### Options
 
 ```
-  -h, --help   help for cache
+  -b, --before string   time since last usage
+  -s, --dry-run         show size to be removed
+  -h, --help            help for cache
 ```
 
 ### Description

--- a/pkg/common/accessio/cache.go
+++ b/pkg/common/accessio/cache.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/mandelsoft/vfs/pkg/osfs"
 	"github.com/mandelsoft/vfs/pkg/projectionfs"
@@ -132,6 +134,15 @@ type RootedCache interface {
 	Root() (string, vfs.FileSystem)
 }
 
+type CleanupCache interface {
+	// Cleanup can be implemented to offer a cache reorg.
+	// It returns the number and size of
+	//	- handled entries (cnt, size)
+	//	- not handled entries (ncnt, nsize)
+	//	- failing entries (fcnt, fsize)
+	Cleanup(p common.Printer, before *time.Time, dryrun bool) (cnt int, ncnt int, fcnt int, size int64, nsize int64, fsize int64, err error)
+}
+
 type BlobCache interface {
 	BlobSource
 	BlobSink
@@ -190,6 +201,61 @@ func (c *blobCache) Unlock() {
 	c.lock.Unlock()
 }
 
+func (c *blobCache) Cleanup(p common.Printer, before *time.Time, dryrun bool) (cnt int, ncnt int, fcnt int, size int64, nsize int64, fsize int64, err error) {
+	c.Lock()
+	defer c.Unlock()
+
+	if p == nil {
+		p = common.NewPrinter(nil)
+	}
+	path, fs := c.Root()
+
+	entries, err := vfs.ReadDir(fs, path)
+	if err != nil {
+		return 0, 0, 0, 0, 0, 0, err
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".acc") {
+			continue
+		}
+		base := vfs.Join(fs, path, e.Name())
+		if before != nil && !before.IsZero() {
+			fi, err := fs.Stat(base + ".acc")
+			if err != nil {
+				if !vfs.IsErrNotExist(err) {
+					if p != nil {
+						p.Printf("cannot stat %q: %s", e.Name(), err)
+					}
+					fcnt++
+					fsize += e.Size()
+					continue
+				}
+			} else {
+				if fi.ModTime().After(*before) {
+					ncnt++
+					nsize += e.Size()
+					continue
+				}
+			}
+		}
+		if !dryrun {
+			err := fs.RemoveAll(base)
+			if err != nil {
+				if p != nil {
+					p.Printf("cannot delete %q: %s", e.Name(), err)
+				}
+				fcnt++
+				fsize += e.Size()
+				continue
+			}
+			fs.RemoveAll(base + ".acc")
+		}
+		cnt++
+		size += e.Size()
+	}
+	return cnt, ncnt, fcnt, size, nsize, fsize, nil
+}
+
 func (c *blobCache) cleanup() error {
 	return vfs.Cleanup(c.cache)
 }
@@ -204,6 +270,9 @@ func (c *blobCache) GetBlobData(digest digest.Digest) (int64, DataAccess, error)
 		path := common.DigestToFileName(digest)
 		fi, err := c.cache.Stat(path)
 		if err == nil {
+			vfs.WriteFile(c.cache, path+".acc", []byte{}, 0o600)
+			// now := time.Now()
+			// c.cache.Chtimes(path+".acc", now, now)
 			return fi.Size(), DataAccessForFile(c.cache, path), nil
 		}
 		if os.IsNotExist(err) {
@@ -272,6 +341,7 @@ func (c *blobCache) AddBlob(blob BlobAccess) (int64, digest.Digest, error) {
 		err = c.cache.Rename(tmp, target)
 	}
 	c.cache.Remove(tmp)
+	vfs.WriteFile(c.cache, target+".acc", []byte{}, 0o600)
 	return size, digest, err
 }
 

--- a/pkg/errors/list.go
+++ b/pkg/errors/list.go
@@ -60,6 +60,10 @@ func (l *ErrorList) Len() int {
 	return len(l.errors)
 }
 
+func (l *ErrorList) Entries() []error {
+	return l.errors
+}
+
 func (l *ErrorList) Result() error {
 	if l == nil || len(l.errors) == 0 {
 		return nil

--- a/pkg/utils/time.go
+++ b/pkg/utils/time.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/generics"
+)
+
+func ParseDeltaTime(s string, past bool) (time.Time, error) {
+	var t time.Time
+
+	f := int64(generics.Conditional(past, -1, 1))
+
+	if len(s) < 2 {
+		return t, errors.Newf("invalid time diff %q", s)
+	}
+	i, err := strconv.ParseInt(s[:len(s)-1], 10, 64)
+	if err != nil {
+		return t, errors.Wrapf(err, "invalid time diff %q", s)
+	}
+
+	d := scale[s[len(s)-1:]]
+	if d == nil {
+		return t, errors.Newf("invalid time diff %q", s)
+	}
+	return d(i*f, time.Now()), nil
+}
+
+type timeModifier func(d int64, t time.Time) time.Time
+
+var scale = map[string]timeModifier{
+	"s": func(d int64, t time.Time) time.Time { return t.Add(time.Duration(d) * time.Second) },
+	"m": func(d int64, t time.Time) time.Time { return t.Add(time.Duration(d) * time.Minute) },
+	"h": func(d int64, t time.Time) time.Time { return t.Add(time.Duration(d) * time.Hour) },
+	"d": func(d int64, t time.Time) time.Time { return t.AddDate(0, 0, int(d)) },
+	"M": func(d int64, t time.Time) time.Time { return t.AddDate(0, int(d), 0) },
+	"y": func(d int64, t time.Time) time.Time { return t.AddDate(int(d), 0, 0) },
+}

--- a/pkg/utils/time.go
+++ b/pkg/utils/time.go
@@ -12,6 +12,8 @@ import (
 	"github.com/open-component-model/ocm/pkg/generics"
 )
 
+// ParseDeltaTime parses a time diff relative to the actual
+// time and returns the resulting time.
 func ParseDeltaTime(s string, past bool) (time.Time, error) {
 	var t time.Time
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The filesystem cache for blobs now supports an API for a cache cleanup.
It supports a dry-run mode and a time based mode.

It is accessible using an option interface `CacheCleanup`.

This way it can programatically be used from a library without the command line interface.,

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
