### PR TITLE
generic object validation

### DIFF
--- a/cmds/ocm/app/app.go
+++ b/cmds/ocm/app/app.go
@@ -13,6 +13,7 @@ import (
 
 	_ "github.com/open-component-model/ocm/pkg/contexts/clictx/config"
 	_ "github.com/open-component-model/ocm/pkg/contexts/ocm/attrs"
+	"github.com/open-component-model/ocm/pkg/runtime"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -78,6 +79,7 @@ type CLIOptions struct {
 	Verbose     bool
 	LogOpts     logopts.Options
 	Version     bool
+	Sloppy      bool
 }
 
 var desc = `
@@ -255,7 +257,8 @@ func (o *CLIOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVarP(&o.Credentials, "cred", "C", nil, "credential setting")
 	fs.StringArrayVarP(&o.Settings, "attribute", "X", nil, "attribute setting")
 	fs.BoolVarP(&o.Verbose, "verbose", "v", false, "deprecated: enable logrus verbose logging")
-	fs.BoolVarP(&o.Version, "version", "", false, "show version") // otherwise it is implicitly added by cobra
+	fs.BoolVarP(&o.Version, "version", "", false, "show version")                                                       // otherwise it is implicitly added by cobra
+	fs.BoolVarP(&o.Sloppy, "sloppy", "", false, "silently ignore unknown fields in dynamic component descriptor parts") // otherwise it is implicitly added by cobra
 
 	o.LogOpts.AddFlags(fs)
 }
@@ -269,6 +272,8 @@ func (o *CLIOptions) Complete() error {
 		return nil
 	}
 	o.Completed = true
+
+	runtime.StrictMode = !o.Sloppy
 
 	if o.Verbose {
 		logrus.SetLevel(logrus.DebugLevel)

--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/utils.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/utils.go
@@ -199,7 +199,7 @@ func DecodeInput(data []byte, ctx clictx.Context) (*ResourceInput, error) {
 	}
 	_, err = input.Input.Evaluate(inputs.For(ctx))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "input")
 	}
 
 	var plainOrig map[string]interface{}
@@ -207,9 +207,8 @@ func DecodeInput(data []byte, ctx clictx.Context) (*ResourceInput, error) {
 	if err != nil {
 		return nil, err
 	}
-	var fldPath *field.Path
-	err = CheckForUnknown(fldPath.Child("input"), plainOrig["input"], input.Input)
-	return &input, err
+	err = CheckForUnknown(nil, plainOrig["input"], input.Input)
+	return &input, errors.Wrapf(err, "input")
 }
 
 func CheckForUnknownForData(fldPath *field.Path, orig []byte, accepted interface{}) error {

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/directory/inputtype_test.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/directory/inputtype_test.go
@@ -6,6 +6,7 @@ package directory
 
 import (
 	. "github.com/onsi/ginkgo/v2"
+
 	. "github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs/testutils"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs/cpi"
@@ -44,5 +45,4 @@ var _ = Describe("Input Type", func() {
 			FollowSymlinks: &True,
 		})
 	})
-
 })

--- a/cmds/ocm/commands/ocmcmds/common/resources_test.go
+++ b/cmds/ocm/commands/ocmcmds/common/resources_test.go
@@ -45,7 +45,7 @@ input:
   bla: blub
 `
 		_, err := addhdlrs.DecodeInput([]byte(in), nil)
-		Expect(err.Error()).To(Equal("input.bla: Forbidden: unknown field"))
+		Expect(err.Error()).To(Equal("input: bla: Forbidden: unknown field"))
 	})
 
 	It("does not complains about additional dir field", func() {
@@ -76,6 +76,6 @@ input:
 `
 		_, err := addhdlrs.DecodeInput([]byte(in), nil)
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(Equal("input.excludeFiles: Forbidden: unknown field"))
+		Expect(err.Error()).To(Equal("input: excludeFiles: Forbidden: unknown field"))
 	})
 })

--- a/pkg/contexts/credentials/internal/cred_test.go
+++ b/pkg/contexts/credentials/internal/cred_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/internal"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/repositories/memory"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 )
 
 var DefaultContext = credentials.New()
@@ -41,9 +42,10 @@ var _ = Describe("generic credentials", func() {
 		err = json.Unmarshal(data, credspec)
 		Expect(err).To(Succeed())
 		s := credspec.(*internal.DefaultCredentialsSpec)
-		Expect(reflect.TypeOf(s.RepositorySpec).String()).To(Equal("*memory.RepositorySpec"))
+		rspec := Must(s.GetRepositorySpec(DefaultContext))
+		Expect(reflect.TypeOf(rspec).String()).To(Equal("*memory.RepositorySpec"))
 		Expect(s.CredentialsName).To(Equal("cred"))
-		Expect(s.RepositorySpec.(*memory.RepositorySpec).RepositoryName).To(Equal("test"))
+		Expect(rspec.(*memory.RepositorySpec).RepositoryName).To(Equal("test"))
 	})
 
 	It("de/serializes generic credentials spec", func() {

--- a/pkg/contexts/credentials/internal/credentialsspec.go
+++ b/pkg/contexts/credentials/internal/credentialsspec.go
@@ -17,13 +17,15 @@ import (
 type CredentialsSpec interface {
 	CredentialsSource
 	GetCredentialsName() string
-	GetRepositorySpec(Context) RepositorySpec
+	GetRepositorySpec(Context) (RepositorySpec, error)
 }
 
 type DefaultCredentialsSpec struct {
 	RepositorySpec  RepositorySpec
 	CredentialsName string
 }
+
+const CREDNAME_ATTRIBUTE = "credentialsName"
 
 func NewCredentialsSpec(name string, repospec RepositorySpec) CredentialsSpec {
 	return &DefaultCredentialsSpec{
@@ -36,8 +38,8 @@ func (s *DefaultCredentialsSpec) GetCredentialsName() string {
 	return s.CredentialsName
 }
 
-func (s *DefaultCredentialsSpec) GetRepositorySpec(Context) RepositorySpec {
-	return s.RepositorySpec
+func (s *DefaultCredentialsSpec) GetRepositorySpec(ctx Context) (RepositorySpec, error) {
+	return ctx.RepositorySpecForSpec(s.RepositorySpec)
 }
 
 func (s *DefaultCredentialsSpec) Credentials(ctx Context, creds ...CredentialsSource) (Credentials, error) {
@@ -46,37 +48,34 @@ func (s *DefaultCredentialsSpec) Credentials(ctx Context, creds ...CredentialsSo
 
 // MarshalJSON implements a custom json unmarshal method.
 func (s DefaultCredentialsSpec) MarshalJSON() ([]byte, error) {
-	ocispec, err := runtime.ToUnstructuredTypedObject(s.RepositorySpec)
+	specdata, err := runtime.ToUnstructuredTypedObject(s.RepositorySpec)
 	if err != nil {
 		return nil, err
 	}
-	specdata, err := runtime.ToUnstructuredObject(struct {
-		Name string `json:"credentialsName,omitempty"`
-	}{Name: s.CredentialsName})
-	if err != nil {
-		return nil, err
-	}
-	return json.Marshal(specdata.FlatMerge(ocispec.Object))
+	specdata.Object[CREDNAME_ATTRIBUTE] = s.CredentialsName
+	return json.Marshal(specdata)
 }
 
 // UnmarshalJSON implements a custom default json unmarshal method.
 // It should not be used because it always used the default context.
 func (s *DefaultCredentialsSpec) UnmarshalJSON(data []byte) error {
-	repo, err := DefaultContext.RepositoryTypes().Decode(data, runtime.DefaultJSONEncoding)
+	spec := &GenericRepositorySpec{}
+	err := json.Unmarshal(data, spec)
 	if err != nil {
-		return fmt.Errorf("failed to decode data: %w", err)
+		return err
 	}
 
-	specdata := &struct {
-		Name string `json:"credentialsName,omitempty"`
-	}{}
-	err = json.Unmarshal(data, specdata)
-	if err != nil {
-		return fmt.Errorf("failed ot unmarshal spec data: %w", err)
+	// check for additional property of a credentials spec.
+	s.CredentialsName = ""
+	if name, ok := spec.Object[CREDNAME_ATTRIBUTE]; ok {
+		if n, ok := name.(string); ok {
+			s.CredentialsName = n
+		}
 	}
+	// remove additional property from generic repository spec.
+	delete(spec.Object, CREDNAME_ATTRIBUTE)
 
-	s.RepositorySpec = repo
-	s.CredentialsName = specdata.Name
+	s.RepositorySpec = spec
 	return nil
 }
 
@@ -124,8 +123,8 @@ func (s *GenericCredentialsSpec) GetCredentialsName() string {
 	return s.CredentialsName
 }
 
-func (s *GenericCredentialsSpec) GetRepositorySpec(context Context) RepositorySpec {
-	return s.RepositorySpec
+func (s *GenericCredentialsSpec) GetRepositorySpec(ctx Context) (RepositorySpec, error) {
+	return ctx.RepositorySpecForSpec(s.RepositorySpec)
 }
 
 func (s *GenericCredentialsSpec) Credentials(ctx Context, creds ...CredentialsSource) (Credentials, error) {
@@ -153,14 +152,13 @@ func (s *GenericCredentialsSpec) UnmarshalJSON(data []byte) error {
 	}
 
 	s.CredentialsName = ""
-
 	if name, ok := spec.Object["credentialsName"]; ok {
 		if n, ok := name.(string); ok {
 			s.CredentialsName = n
 		}
 	}
+	delete(spec.Object, "credentialsName")
 
-	delete(spec.Object, "credentialName")
 	s.RepositorySpec = spec
 	return nil
 }

--- a/pkg/contexts/credentials/repositories/directcreds/type.go
+++ b/pkg/contexts/credentials/repositories/directcreds/type.go
@@ -55,6 +55,6 @@ func (a *RepositorySpec) GetCredentialsName() string {
 	return ""
 }
 
-func (a *RepositorySpec) GetRepositorySpec(context cpi.Context) cpi.RepositorySpec {
-	return a
+func (a *RepositorySpec) GetRepositorySpec(context cpi.Context) (cpi.RepositorySpec, error) {
+	return a, nil
 }

--- a/pkg/contexts/ocm/accessmethods/localfsblob/method.go
+++ b/pkg/contexts/ocm/accessmethods/localfsblob/method.go
@@ -54,7 +54,7 @@ func Decode(data []byte) (*localblob.AccessSpec, error) {
 type AccessSpec struct {
 	runtime.ObjectVersionedType `json:",inline"`
 	// FileName is the
-	Filename string `json:"fileName"`
+	Filename string `json:"filename"`
 	// MediaType is the media type of the object represented by the blob
 	MediaType string `json:"mediaType"`
 }

--- a/pkg/contexts/ocm/accessmethods/localfsblob/method_test.go
+++ b/pkg/contexts/ocm/accessmethods/localfsblob/method_test.go
@@ -15,29 +15,11 @@ import (
 	. "github.com/open-component-model/ocm/pkg/testutils"
 )
 
-const OCIPATH = "/tmp/oci"
-const OCINAMESPACE = "ocm/test"
-const OCIVERSION = "v2.0"
-const OCIHOST = "alias"
-
 var _ = Describe("Method", func() {
-
-	var data = `globalAccess:
-  digest: sha256:1bf729fa00e355199e711933ccfa27467ee3d2de1343aef2a7c1ecbdf885e63a
-  mediaType: application/tar+gzip
-  ref: ghcr.io/vasu1124/ocm/component-descriptors/github.com/vasu1124/introspect-delivery
-  size: 11287
-  type: ociBlob
-localReference: sha256:1bf729fa00e355199e711933ccfa27467ee3d2de1343aef2a7c1ecbdf885e63a
-mediaType: application/tar+gzip
-type: localBlob
-`
-	_ = data
-
 	It("marshal/unmarshal simple", func() {
 		spec := localfsblob.New("path", mime.MIME_TEXT)
 		data := Must(json.Marshal(spec))
-		Expect(string(data)).To(Equal("{\"type\":\"localFilesystemBlob\",\"fileName\":\"path\",\"mediaType\":\"text/plain\"}"))
+		Expect(string(data)).To(Equal("{\"type\":\"localFilesystemBlob\",\"filename\":\"path\",\"mediaType\":\"text/plain\"}"))
 		r := Must(localfsblob.Decode(data))
 		Expect(r).To(Equal(spec))
 	})

--- a/pkg/contexts/ocm/repositories/comparch/accessmethod_test.go
+++ b/pkg/contexts/ocm/repositories/comparch/accessmethod_test.go
@@ -26,7 +26,7 @@ var DefaultContext = ocm.New()
 
 var _ = Describe("access method", func() {
 
-	legacy := "{\"type\":\"localFilesystemBlob\",\"fileName\":\"anydigest\",\"mediaType\":\"application/json\"}"
+	legacy := "{\"type\":\"localFilesystemBlob\",\"filename\":\"anydigest\",\"mediaType\":\"application/json\"}"
 
 	Context("local access method", func() {
 		It("decodes legacy methood", func() {

--- a/pkg/runtime/encoding.go
+++ b/pkg/runtime/encoding.go
@@ -4,21 +4,15 @@
 
 package runtime
 
-// github.com/ghodss/yaml
-
 import (
-	"encoding/json"
-
-	"sigs.k8s.io/yaml"
+	"github.com/open-component-model/ocm/pkg/runtime/encoding"
 )
 
-type Marshaler interface {
-	Marshal(obj interface{}) ([]byte, error)
-}
+// github.com/ghodss/yaml
 
-type Unmarshaler interface {
-	Unmarshal(data []byte, obj interface{}) error
-}
+type Marshaler = encoding.Marshaler
+
+type Unmarshaler encoding.Unmarshaler
 
 type MarshalFunction func(obj interface{}) ([]byte, error)
 
@@ -28,22 +22,10 @@ type UnmarshalFunction func(data []byte, obj interface{}) error
 
 func (f UnmarshalFunction) Unmarshal(data []byte, obj interface{}) error { return f(data, obj) }
 
-type Encoding interface {
-	Unmarshaler
-	Marshaler
-}
+type Encoding = encoding.Encoding
 
-type EncodingWrapper struct {
-	Unmarshaler
-	Marshaler
-}
+type EncodingWrapper = encoding.EncodingWrapper
 
-var DefaultJSONEncoding = &EncodingWrapper{
-	Marshaler:   MarshalFunction(json.Marshal),
-	Unmarshaler: UnmarshalFunction(json.Unmarshal),
-}
+var DefaultJSONEncoding = encoding.DefaultJSONEncoding
 
-var DefaultYAMLEncoding = &EncodingWrapper{
-	Marshaler:   MarshalFunction(yaml.Marshal),
-	Unmarshaler: UnmarshalFunction(func(data []byte, obj interface{}) error { return yaml.Unmarshal(data, obj) }),
-}
+var DefaultYAMLEncoding = encoding.DefaultYAMLEncoding

--- a/pkg/runtime/encoding/encoding.go
+++ b/pkg/runtime/encoding/encoding.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package encoding
+
+// github.com/ghodss/yaml
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"sigs.k8s.io/yaml"
+)
+
+type Marshaler interface {
+	Marshal(obj interface{}) ([]byte, error)
+}
+
+type Unmarshaler interface {
+	Unmarshal(data []byte, obj interface{}) error
+}
+
+type MarshalFunction func(obj interface{}) ([]byte, error)
+
+func (f MarshalFunction) Marshal(obj interface{}) ([]byte, error) { return f(obj) }
+
+type UnmarshalFunction func(data []byte, obj interface{}) error
+
+func (f UnmarshalFunction) Unmarshal(data []byte, obj interface{}) error { return f(data, obj) }
+
+type Encoding interface {
+	Unmarshaler
+	Marshaler
+}
+
+type EncodingWrapper struct {
+	Unmarshaler
+	Marshaler
+}
+
+// Cannot use Strict basic encoding, because
+// all places using an incremental field parsing will not work anymore.
+var (
+	DefaultYAMLEncoding = StandardYAMLEncoding
+	DefaultJSONEncoding = StandardJSONEncoding
+)
+
+var (
+	StandardJSONEncoding = &EncodingWrapper{
+		Marshaler:   MarshalFunction(json.Marshal),
+		Unmarshaler: UnmarshalFunction(json.Unmarshal),
+	}
+	StandardYAMLEncoding = &EncodingWrapper{
+		Marshaler:   MarshalFunction(yaml.Marshal),
+		Unmarshaler: UnmarshalFunction(func(data []byte, obj interface{}) error { return yaml.Unmarshal(data, obj) }),
+	}
+)
+
+var (
+	StrictJSONEncoding = &EncodingWrapper{
+		Marshaler: MarshalFunction(json.Marshal),
+		Unmarshaler: UnmarshalFunction(func(data []byte, obj interface{}) error {
+			d := json.NewDecoder(bytes.NewReader(data))
+			d.DisallowUnknownFields()
+			return d.Decode(obj)
+		}),
+	}
+	StrictYAMLEncoding = &EncodingWrapper{
+		Marshaler:   MarshalFunction(yaml.Marshal),
+		Unmarshaler: UnmarshalFunction(func(data []byte, obj interface{}) error { return yaml.Unmarshal(data, obj, yaml.DisallowUnknownFields) }),
+	}
+)

--- a/pkg/runtime/remove.go
+++ b/pkg/runtime/remove.go
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package runtime
+
+import (
+	"encoding/json"
+)
+
+// Remove removes additional top level attributes from a generic
+// object specification based on an object covering the additional
+// attributes.
+func Remove(data UnstructuredMap, obj interface{}) error {
+	var m UnstructuredMap
+	bytes, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	err = json.Unmarshal(bytes, &m)
+	if err != nil {
+		return err
+	}
+	for k := range m {
+		delete(data, k)
+	}
+	return nil
+}
+
+// RemoveFromData removes additional top level attributes from an
+// object specification based on an object covering the additional
+// attributes.
+func RemoveFromData(data []byte, obj interface{}, unmarshaler Unmarshaler) ([]byte, error) {
+	var m UnstructuredMap
+	bytes, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(bytes, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	if unmarshaler == nil {
+		unmarshaler = DefaultJSONEncoding
+	}
+
+	var d UnstructuredMap
+	err = unmarshaler.Unmarshal(data, &d)
+	if err != nil {
+		return nil, err
+	}
+
+	for k := range m {
+		delete(d, k)
+	}
+	return json.Marshal(d)
+}
+
+// UnmarshalAdditional unmarshalls an object serialization by a given
+// unmarshaler by separating independent top-level property sets defined
+// by a main object and several addenda given by a list of deserializable objects.
+// The main object then gets all the properties not covered by the addenda,
+// while the additional aspects are fed into the given objects.
+func UnmarshalAdditional(data []byte, result Unstructured, unmarshaler Unmarshaler, additional ...interface{}) error {
+	if unmarshaler == nil {
+		unmarshaler = DefaultJSONEncoding
+	}
+
+	err := unmarshaler.Unmarshal(data, result)
+	if err != nil {
+		return err
+	}
+
+	for _, a := range additional {
+		err := unmarshaler.Unmarshal(data, a)
+		if err != nil {
+			return err
+		}
+		err = Remove(result.GetObject(), a)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/runtime/scheme.go
+++ b/pkg/runtime/scheme.go
@@ -15,17 +15,18 @@ import (
 
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/generics"
+	"github.com/open-component-model/ocm/pkg/runtime/validation"
 	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 var (
-	typeTypedObject = reflect.TypeOf((*TypedObject)(nil)).Elem()
 	typeUnknown     = reflect.TypeOf((*Unknown)(nil)).Elem()
+	typeTypedObject = reflect.TypeOf((*TypedObject)(nil)).Elem()
 )
 
 type (
 	// TypedObjectDecoder is able to provide an effective typed object for some
-	// serilaized form. The technical deserialization is done by an Unmarshaler.
+	// serialized form. The technical deserialization is done by an Unmarshaler.
 	TypedObjectDecoder[T TypedObject] interface {
 		Decode(data []byte, unmarshaler Unmarshaler) (T, error)
 	}
@@ -33,6 +34,9 @@ type (
 		TypedObjectDecoder[T]
 	}
 )
+
+// StrictMode enables the checking for unexpected fields in object unmarshalling.
+var StrictMode = true
 
 // TypedObjectEncoder is able to provide a versioned representation of
 // an effective TypedObject.
@@ -74,7 +78,13 @@ func (d *DirectDecoder[T]) CreateInstance() T {
 func (d *DirectDecoder[T]) Decode(data []byte, unmarshaler Unmarshaler) (T, error) {
 	var zero T
 	inst := d.CreateInstance()
-	err := unmarshaler.Unmarshal(data, inst)
+
+	var err error
+	if StrictMode {
+		err = validation.UnmarshalProtoWithValidation(data, inst, unmarshaler)
+	} else {
+		err = unmarshaler.Unmarshal(data, inst)
+	}
 	if err != nil {
 		return zero, err
 	}

--- a/pkg/runtime/scheme_test.go
+++ b/pkg/runtime/scheme_test.go
@@ -23,12 +23,12 @@ type T interface {
 
 type T1 struct {
 	runtime.ObjectTypedObject
-	T1 string
+	T1 string `json:"t1,omitempty"`
 }
 
 type T2 struct {
 	runtime.ObjectTypedObject
-	T2 string
+	T2 string `json:"t2,omitempty"`
 }
 
 func (t *T1) TFunc() {}

--- a/pkg/runtime/unstructured.go
+++ b/pkg/runtime/unstructured.go
@@ -38,6 +38,7 @@ const ATTR_TYPE = "type"
 type Unstructured interface {
 	TypeGetter
 	GetRaw() ([]byte, error)
+	GetObject() UnstructuredMap
 }
 
 type Object interface{}
@@ -171,6 +172,10 @@ func (u *UnstructuredTypedObject) DeepCopy() *UnstructuredTypedObject {
 
 func (u UnstructuredTypedObject) GetRaw() ([]byte, error) {
 	return json.Marshal(u.Object)
+}
+
+func (u UnstructuredTypedObject) GetObject() UnstructuredMap {
+	return u.Object
 }
 
 func (u *UnstructuredTypedObject) setRaw(data []byte) error {

--- a/pkg/runtime/validation/suite_test.go
+++ b/pkg/runtime/validation/suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Validation Test Suite")
+}

--- a/pkg/runtime/validation/validate.go
+++ b/pkg/runtime/validation/validate.go
@@ -1,0 +1,239 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"fmt"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/runtime/encoding"
+	"github.com/open-component-model/ocm/pkg/utils"
+)
+
+// Validater is an object interface which may be implemented
+// to validate its property settings.
+type Validater interface {
+	Validate() error
+}
+
+// UnmarshalWithValidation unmarshalls an object serialization by a given
+// unmarshaler into an object according to the type parameter (it must not
+// be a pointer). Optionally a set of validation rules may be given used
+// to complain about additional (not used by the object) properties.
+func UnmarshalWithValidation[T any](data []byte, unmarshaler encoding.Unmarshaler, additional ...AdditionalProperties) (*T, error) {
+	var obj T
+	err := UnmarshalProtoWithValidation(data, &obj, unmarshaler, additional...)
+	if err != nil {
+		return nil, err
+	}
+	return &obj, nil
+}
+
+func UnmarshalProtoWithValidation(data []byte, proto interface{}, unmarshaler encoding.Unmarshaler, additional ...AdditionalProperties) error {
+	err := unmarshaler.Unmarshal(data, proto)
+	if err != nil {
+		return err
+	}
+
+	var fields interface{}
+	err = unmarshaler.Unmarshal(data, &fields)
+	if err != nil {
+		return errors.Wrapf(err, "cannot unmarshal data")
+	}
+
+	data, err = encoding.DefaultJSONEncoding.Marshal(proto)
+	if err != nil {
+		return errors.Wrapf(err, "cannot marshal object")
+	}
+
+	var found interface{}
+	err = encoding.DefaultJSONEncoding.Unmarshal(data, &found)
+	if err != nil {
+		return errors.Wrapf(err, "cannot unmarshal accepted data")
+	}
+	err = checkFields(nil, fields, found, Next(true, Composition(additional))).ToAggregate()
+	if err != nil {
+		return err
+	}
+	if v, ok := proto.(Validater); ok {
+		return v.Validate()
+	}
+	return nil
+}
+
+func checkFields(fldPath *field.Path, data, accepted interface{}, elem ElementInfo) field.ErrorList {
+	if data == nil {
+		return nil
+	}
+
+	allErrs := field.ErrorList{}
+
+	switch a := accepted.(type) {
+	case map[string]interface{}:
+		if d, ok := data.(map[string]interface{}); ok {
+			return checkMap(fldPath, d, a, elem.Next())
+		}
+		return append(allErrs, field.TypeInvalid(fldPath, field.OmitValueType{}, "field must be a map/struct"))
+	case []interface{}:
+		if d, ok := data.([]interface{}); ok {
+			return checkList(fldPath, d, a, elem.Next())
+		}
+		return append(allErrs, field.TypeInvalid(fldPath, field.OmitValueType{}, "field must be a list"))
+	default:
+		if accepted == nil {
+			if elem.IsEnabled() {
+				return allErrs
+			}
+			return append(allErrs, field.Forbidden(fldPath, "unknown field"))
+		}
+		if !reflect.DeepEqual(accepted, data) {
+			return append(allErrs, field.Invalid(fldPath, data, "value is invalid"))
+		}
+	}
+	return nil
+}
+
+func checkMap(fldPath *field.Path, data, accepted map[string]interface{}, additional ...AdditionalProperties) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for _, k := range utils.StringMapKeys(data) {
+		f := fldPath.Child(k)
+		allErrs = append(allErrs, checkFields(f, data[k], accepted[k], Composition(additional).ForMapField(k, f))...)
+	}
+	return allErrs
+}
+
+func checkList(fldPath *field.Path, data, accepted []interface{}, additional ...AdditionalProperties) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if len(data) != len(accepted) {
+		return append(allErrs, field.InternalError(fldPath, fmt.Errorf("non matching list size")))
+	}
+	for i, v := range data {
+		f := fldPath.Index(i)
+		allErrs = append(allErrs, checkFields(f, v, accepted[i], Composition(additional).ForListEntry(i, v))...)
+	}
+	return allErrs
+}
+
+type ElementInfo interface {
+	IsEnabled() bool
+	Next() AdditionalProperties
+}
+
+// AdditionalProperties is the interface for rules
+// deciding to accept unknown properties or not.
+type AdditionalProperties interface {
+	ForMapField(name string, elem interface{}) ElementInfo
+	ForListEntry(index int, elem interface{}) ElementInfo
+}
+
+type elementInfo struct {
+	flag bool
+	next AdditionalProperties
+}
+
+func (e *elementInfo) IsEnabled() bool {
+	return e.flag
+}
+
+func (e *elementInfo) Next() AdditionalProperties {
+	return e.next
+}
+
+func Next(flag bool, next AdditionalProperties) ElementInfo {
+	return &elementInfo{flag, next}
+}
+
+func NoAdditionalProperties() AdditionalProperties {
+	a := &additionalProperties{}
+	a.elem = Next(false, a)
+	return a
+}
+
+func AdditionalRootProperties() AdditionalProperties {
+	return &additionalProperties{Next(true, NoAdditionalProperties())}
+}
+
+type additionalProperties struct {
+	elem ElementInfo
+}
+
+func (n *additionalProperties) ForMapField(name string, elem interface{}) ElementInfo {
+	return n.elem
+}
+
+func (n *additionalProperties) ForListEntry(index int, elem interface{}) ElementInfo {
+	return n.elem
+}
+
+type Composition []AdditionalProperties
+
+func (c Composition) ForMapField(name string, elem interface{}) ElementInfo {
+	for _, a := range c {
+		e := a.ForMapField(name, elem)
+		if e != nil {
+			return e
+		}
+	}
+	return Next(false, NoAdditionalProperties())
+}
+
+func (c Composition) ForListEntry(index int, elem interface{}) ElementInfo {
+	for _, a := range c {
+		e := a.ForListEntry(index, elem)
+		if e != nil {
+			return e
+		}
+	}
+	return Next(false, NoAdditionalProperties())
+}
+
+type additionalMapField struct {
+	name     string
+	optional bool
+	nested   AdditionalProperties
+}
+
+func (a *additionalMapField) ForMapField(name string, elem interface{}) ElementInfo {
+	if name == a.name || a.name == "" {
+		return Next(a.optional, a.nested)
+	}
+	return nil
+}
+
+func (a additionalMapField) ForListEntry(index int, elem interface{}) ElementInfo {
+	return nil
+}
+
+func AdditionalMapField(name string, nested ...AdditionalProperties) AdditionalProperties {
+	return &additionalMapField{name, true, Composition(nested)}
+}
+
+func MapField(name string, nested ...AdditionalProperties) AdditionalProperties {
+	return &additionalMapField{name, false, Composition(nested)}
+}
+
+type additionalListField struct {
+	index    int
+	optional bool
+	nested   AdditionalProperties
+}
+
+func (a *additionalListField) ForMapField(name string, elem interface{}) ElementInfo {
+	return nil
+}
+
+func (a *additionalListField) ForListEntry(index int, elem interface{}) ElementInfo {
+	if a.index == index || a.index < 0 {
+		return Next(a.optional, a.nested)
+	}
+	return nil
+}
+
+func ListField(index int, nested ...AdditionalProperties) AdditionalProperties {
+	return &additionalListField{index, false, Composition(nested)}
+}

--- a/pkg/runtime/validation/validate_test.go
+++ b/pkg/runtime/validation/validate_test.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package validation_test
+
+import (
+	"reflect"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/open-component-model/ocm/pkg/runtime"
+	"github.com/open-component-model/ocm/pkg/runtime/validation"
+	. "github.com/open-component-model/ocm/pkg/testutils"
+)
+
+type TestType struct {
+	Field1 string `json:"field1,omitempty"`
+	Field2 string `json:"field2,omitempty"`
+
+	Struct1 StructType `json:"struct1,omitempty"`
+	Struct2 StructType `json:"struct2,omitempty"`
+
+	List1 []StructType `json:"list1,omitempty"`
+	List2 []StructType `json:"list2,omitempty"`
+}
+
+type StructType struct {
+	Field1 string `json:"structField1,omitempty"`
+	Field2 string `json:"structField2,omitempty"`
+}
+
+var _ = Describe("validation", func() {
+
+	It("validates correct data", func() {
+		data := `
+field1: value1
+struct1:
+  structField1: value2
+list1:
+- structField1: value3
+`
+		o := Must(validation.UnmarshalWithValidation[TestType]([]byte(data), runtime.DefaultYAMLEncoding, validation.NoAdditionalProperties()))
+
+		Expect(reflect.TypeOf(o)).To(Equal(reflect.TypeOf(&TestType{})))
+	})
+
+	It("complains about unused fields", func() {
+		data := `
+any: value1
+struct1:
+  other: value2
+list1:
+- value: value3
+`
+		_, err := validation.UnmarshalWithValidation[TestType]([]byte(data), runtime.DefaultYAMLEncoding, validation.NoAdditionalProperties())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("[any: Forbidden: unknown field, list1[0].value: Forbidden: unknown field, struct1.other: Forbidden: unknown field]"))
+	})
+
+	It("complains about wrong structure (struct)", func() {
+		data := `
+struct1:
+- structField1: value1
+`
+		_, err := validation.UnmarshalWithValidation[TestType]([]byte(data), runtime.DefaultYAMLEncoding, validation.NoAdditionalProperties())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go struct field TestType.struct1 of type validation_test.StructType"))
+	})
+
+	It("complains about wrong structure (list)", func() {
+		data := `
+list1:
+  structField1: value1
+`
+		_, err := validation.UnmarshalWithValidation[TestType]([]byte(data), runtime.DefaultYAMLEncoding, validation.NoAdditionalProperties())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("error unmarshaling JSON: while decoding JSON: json: cannot unmarshal object into Go struct field TestType.list1 of type []validation_test.StructType"))
+	})
+
+	It("complains about unused fields, but not top level", func() {
+		data := `
+any: value1
+struct1:
+  other: value2
+list1:
+- value: value3
+`
+		_, err := validation.UnmarshalWithValidation[TestType]([]byte(data), runtime.DefaultYAMLEncoding, validation.AdditionalRootProperties())
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("[list1[0].value: Forbidden: unknown field, struct1.other: Forbidden: unknown field]"))
+	})
+
+	It("complains about unused fields, but not struct1 level", func() {
+		data := `
+any: value1
+struct1:
+  other: value2
+list1:
+- value: value3
+`
+		_, err := validation.UnmarshalWithValidation[TestType]([]byte(data), runtime.DefaultYAMLEncoding, validation.MapField("struct1", validation.AdditionalMapField("other")))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("[any: Forbidden: unknown field, list1[0].value: Forbidden: unknown field]"))
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a `StrictMode`for the library to improve the object deserialization 
to validate the decoded objects against the initial data to check for
unexpected fields.

Add support to parse a set of object parts separately.

Fix all the the places where an object unmarshalling is delegated to 
unmarshal enriched object types using embedded fields. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
