### PR TITLE
add get inexpensive content version identity functionality

### DIFF
--- a/pkg/contexts/ocm/accessmethods/github/method.go
+++ b/pkg/contexts/ocm/accessmethods/github/method.go
@@ -124,6 +124,10 @@ func (a *AccessSpec) AccessMethod(c cpi.ComponentVersionAccess) (cpi.AccessMetho
 	return newMethod(c, a)
 }
 
+func (a *AccessSpec) GetInexpensiveContentVersionIdentity(access cpi.ComponentVersionAccess) string {
+	return a.Commit
+}
+
 func (a *AccessSpec) createHTTPClient(token string) *http.Client {
 	if token != "" {
 		ts := oauth2.StaticTokenSource(

--- a/pkg/contexts/ocm/accessmethods/helm/method.go
+++ b/pkg/contexts/ocm/accessmethods/helm/method.go
@@ -82,6 +82,11 @@ func (s *AccessSpec) AccessMethod(access cpi.ComponentVersionAccess) (cpi.Access
 	return &accessMethod{comp: access, spec: s}, nil
 }
 
+func (a *AccessSpec) GetInexpensiveContentVersionIdentity(access cpi.ComponentVersionAccess) string {
+	return ""
+	// TODO: research possibilities with provenance file
+}
+
 ///////////////////
 
 func (s *AccessSpec) GetVersion() string {

--- a/pkg/contexts/ocm/accessmethods/localblob/method.go
+++ b/pkg/contexts/ocm/accessmethods/localblob/method.go
@@ -141,6 +141,10 @@ func (a *AccessSpec) AccessMethod(cv cpi.ComponentVersionAccess) (cpi.AccessMeth
 	return cv.AccessMethod(a)
 }
 
+func (a *AccessSpec) GetInexpensiveContentVersionIdentity(cv cpi.ComponentVersionAccess) string {
+	return cv.GetInexpensiveContentVersionIdentity(a)
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 type AccessSpecV1 struct {

--- a/pkg/contexts/ocm/accessmethods/localblob/method_test.go
+++ b/pkg/contexts/ocm/accessmethods/localblob/method_test.go
@@ -6,6 +6,11 @@ package localblob_test
 
 import (
 	"encoding/json"
+	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/common/accessobj"
+	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/resourcetypes"
+	tenv "github.com/open-component-model/ocm/pkg/env"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -13,6 +18,8 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/ociblob"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/ctf"
+	. "github.com/open-component-model/ocm/pkg/env/builder"
 	"github.com/open-component-model/ocm/pkg/mime"
 	"github.com/open-component-model/ocm/pkg/runtime"
 	. "github.com/open-component-model/ocm/pkg/testutils"
@@ -22,6 +29,12 @@ const OCIPATH = "/tmp/oci"
 const OCINAMESPACE = "ocm/test"
 const OCIVERSION = "v2.0"
 const OCIHOST = "alias"
+
+const CTF = "ctf"
+const COMPONENT = "fabianburth.org/component"
+const VERSION = "v1.0"
+const ARTIFACT_NAME = "artifact"
+const ARTIFACT_VERSION = "v1.0"
 
 var _ = Describe("Method", func() {
 
@@ -64,4 +77,27 @@ type: localBlob
 		Expect(string(r)).To(Equal(data))
 	})
 
+	It("check get inexpensive content version identity method", func() {
+		var env *Builder
+
+		env = NewBuilder(tenv.NewEnvironment())
+		defer env.Cleanup()
+
+		env.OCMCommonTransport(CTF, accessio.FormatDirectory, func() {
+			env.ComponentVersion(COMPONENT, VERSION, func() {
+				env.Resource(ARTIFACT_NAME, ARTIFACT_VERSION, resourcetypes.BLOB, metav1.LocalRelation, func() {
+					env.BlobData(mime.MIME_TEXT, []byte("testdata"))
+				})
+			})
+		})
+
+		repo := Must(ctf.Open(env.OCMContext(), accessobj.ACC_READONLY, CTF, 0, env))
+		defer Close(repo)
+		cv := Must(repo.LookupComponentVersion(COMPONENT, VERSION))
+		defer Close(cv)
+		access := cv.GetDescriptor().Resources[0].Access
+		spec := Must(env.OCMContext().AccessSpecForSpec(access))
+		id := spec.GetInexpensiveContentVersionIdentity(cv)
+		Expect(id).To(Equal("sha256:810ff2fb242a5dee4220f2cb0e6a519891fb67f2f828a6cab4ef8894633b1f50"))
+	})
 })

--- a/pkg/contexts/ocm/accessmethods/none/method.go
+++ b/pkg/contexts/ocm/accessmethods/none/method.go
@@ -61,6 +61,10 @@ func (s *AccessSpec) AccessMethod(access cpi.ComponentVersionAccess) (cpi.Access
 	return &accessMethod{spec: s}, nil
 }
 
+func (s *AccessSpec) GetInexpensiveContentVersionIdentity(access cpi.ComponentVersionAccess) string {
+	return ""
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 type accessMethod struct {

--- a/pkg/contexts/ocm/accessmethods/ociartifact/method.go
+++ b/pkg/contexts/ocm/accessmethods/ociartifact/method.go
@@ -108,6 +108,18 @@ func (a *AccessSpec) AccessMethod(c cpi.ComponentVersionAccess) (cpi.AccessMetho
 	return NewMethod(c.GetContext(), a, a.ImageReference)
 }
 
+func (a *AccessSpec) GetInexpensiveContentVersionIdentity(cv cpi.ComponentVersionAccess) string {
+	ref, err := oci.ParseRef(a.ImageReference)
+	if err != nil {
+		return ""
+	}
+	if ref.Digest != nil {
+		return ref.Digest.String()
+	}
+	// TODO: optimize for oci registries
+	return ""
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 type AccessMethod = *accessMethod

--- a/pkg/contexts/ocm/accessmethods/ociblob/method.go
+++ b/pkg/contexts/ocm/accessmethods/ociblob/method.go
@@ -80,6 +80,10 @@ func (s *AccessSpec) AccessMethod(access cpi.ComponentVersionAccess) (cpi.Access
 	return &accessMethod{comp: access, spec: s}, nil
 }
 
+func (s *AccessSpec) GetInexpensiveContentVersionIdentity(access cpi.ComponentVersionAccess) string {
+	return s.Digest.String()
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 // TODO add cache

--- a/pkg/contexts/ocm/accessmethods/plugin/doc.go
+++ b/pkg/contexts/ocm/accessmethods/plugin/doc.go
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package plugin is an adapter implementation that provides a generic handling of all AccessMethods provided by
+// plugins.
+// It includes a generic AccessType object (responsible for un-/marshaling AccessSpec objects), AccessSpec object and
+// AccessMethod implementation mapping the AccessMethod interface to the plugin interface.
+package plugin

--- a/pkg/contexts/ocm/accessmethods/plugin/method.go
+++ b/pkg/contexts/ocm/accessmethods/plugin/method.go
@@ -33,6 +33,10 @@ func (s *AccessSpec) AccessMethod(cv cpi.ComponentVersionAccess) (cpi.AccessMeth
 	return s.handler.AccessMethod(s, cv)
 }
 
+func (s *AccessSpec) GetInexpensiveContentVersionIdentity(cv cpi.ComponentVersionAccess) string {
+	return s.handler.GetInexpensiveContentVersionIdentity(s, cv)
+}
+
 func (s *AccessSpec) Describe(ctx cpi.Context) string {
 	return s.handler.Describe(s, ctx)
 }

--- a/pkg/contexts/ocm/accessmethods/plugin/plugin.go
+++ b/pkg/contexts/ocm/accessmethods/plugin/plugin.go
@@ -19,6 +19,8 @@ import (
 
 type plug = plugin.Plugin
 
+// PluginHandler is a shared object between the AccessMethod implementation and the AccessSpec implementation. The
+// object knows the actual plugin and can therefore forward the method calls to corresponding cli commands.
 type PluginHandler struct {
 	plug
 
@@ -72,6 +74,47 @@ func (p *PluginHandler) AccessMethod(spec *AccessSpec, cv cpi.ComponentVersionAc
 		}
 	}
 	return newMethod(p, spec, cv.GetContext(), info, creddata), nil
+}
+
+func (p *PluginHandler) GetInexpensiveContentVersionIdentity(spec *AccessSpec, cv cpi.ComponentVersionAccess) string {
+	mspec := p.GetAccessMethodDescriptor(spec.GetKind(), spec.GetVersion())
+	if mspec == nil {
+		return "unknown type " + spec.GetType()
+	}
+
+	if !mspec.SupportContentIdentity {
+		return ""
+	}
+
+	info, err := p.Info(spec)
+	if err != nil {
+		return ""
+	}
+
+	var creds credentials.Credentials
+	if len(info.ConsumerId) > 0 {
+		creds, err = credentials.CredentialsForConsumer(cv.GetContext(), info.ConsumerId, hostpath.IdentityMatcher(info.ConsumerId.Type()))
+		if err != nil {
+			return ""
+		}
+	}
+
+	var creddata json.RawMessage
+	if creds != nil {
+		creddata, err = json.Marshal(creds)
+		if err != nil {
+			return "cannot marshal creds"
+		}
+	}
+	specdata, err := spec.GetRaw()
+	if err != nil {
+		return ""
+	}
+	id, err := p.plug.Identity(creddata, specdata)
+	if err != nil {
+		return ""
+	}
+	return id
 }
 
 func (p *PluginHandler) Describe(spec *AccessSpec, ctx cpi.Context) string {

--- a/pkg/contexts/ocm/accessmethods/relativeociref/method.go
+++ b/pkg/contexts/ocm/accessmethods/relativeociref/method.go
@@ -7,6 +7,7 @@ package relativeociref
 import (
 	"fmt"
 
+	"github.com/open-component-model/ocm/pkg/contexts/oci"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/internal"
 	"github.com/open-component-model/ocm/pkg/runtime"
@@ -56,6 +57,25 @@ func (a *AccessSpec) GlobalAccessSpec(context cpi.Context) cpi.AccessSpec {
 
 func (a *AccessSpec) AccessMethod(access cpi.ComponentVersionAccess) (cpi.AccessMethod, error) {
 	return access.AccessMethod(a)
+}
+
+func (a *AccessSpec) GetDigest() (string, bool) {
+	ref, err := oci.ParseRef(a.Reference)
+	if err != nil {
+		return "", true
+	}
+	if ref.Digest != nil {
+		return ref.Digest.String(), true
+	}
+	return "", false
+}
+
+func (a *AccessSpec) GetInexpensiveContentVersionIdentity(cv cpi.ComponentVersionAccess) string {
+	d, ok := a.GetDigest()
+	if ok {
+		return d
+	}
+	return cv.GetInexpensiveContentVersionIdentity(a)
 }
 
 func (a *AccessSpec) GetReferenceHint(cv internal.ComponentVersionAccess) string {

--- a/pkg/contexts/ocm/accessmethods/s3/method.go
+++ b/pkg/contexts/ocm/accessmethods/s3/method.go
@@ -102,6 +102,10 @@ func (a *AccessSpec) AccessMethod(c cpi.ComponentVersionAccess) (cpi.AccessMetho
 	return newMethod(c, a)
 }
 
+func (a *AccessSpec) GetInexpensiveContentVersionIdentity(c cpi.ComponentVersionAccess) string {
+	return a.Version
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 type accessMethod struct {

--- a/pkg/contexts/ocm/cpi/dummy.go
+++ b/pkg/contexts/ocm/cpi/dummy.go
@@ -95,6 +95,10 @@ func (d *DummyComponentVersionAccess) AccessMethod(spec AccessSpec) (AccessMetho
 	panic("implement me")
 }
 
+func (d *DummyComponentVersionAccess) GetInexpensiveContentVersionIdentity(spec AccessSpec) string {
+	panic("implement me")
+}
+
 func (d *DummyComponentVersionAccess) AddBlob(blob BlobAccess, arttype, refName string, global AccessSpec) (AccessSpec, error) {
 	panic("implement me")
 }

--- a/pkg/contexts/ocm/cpi/support/compversaccess.go
+++ b/pkg/contexts/ocm/cpi/support/compversaccess.go
@@ -75,10 +75,14 @@ func (a *componentVersionAccessImpl) IsReadOnly() bool {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// with access to actualk view
+// with access to actual view
 
 func (a *componentVersionAccessImpl) AccessMethod(cv cpi.ComponentVersionAccess, acc cpi.AccessSpec) (cpi.AccessMethod, error) {
 	return a.base.AccessMethod(acc)
+}
+
+func (a *componentVersionAccessImpl) GetInexpensiveContentVersionIdentity(cv cpi.ComponentVersionAccess, acc cpi.AccessSpec) string {
+	return a.base.GetInexpensiveContentVersionIdentity(acc)
 }
 
 func (a *componentVersionAccessImpl) GetDescriptor() *compdesc.ComponentDescriptor {

--- a/pkg/contexts/ocm/cpi/support/container.go
+++ b/pkg/contexts/ocm/cpi/support/container.go
@@ -45,6 +45,7 @@ type ComponentVersionContainer interface {
 	GetDescriptor() *compdesc.ComponentDescriptor
 	BlobContainer
 	AccessMethod(a cpi.AccessSpec) (cpi.AccessMethod, error)
+	GetInexpensiveContentVersionIdentity(a cpi.AccessSpec) string
 
 	io.Closer
 }

--- a/pkg/contexts/ocm/internal/accessspecref.go
+++ b/pkg/contexts/ocm/internal/accessspecref.go
@@ -110,6 +110,13 @@ func (a *AccessSpecRef) AccessMethod(access ComponentVersionAccess) (AccessMetho
 	return a.evaluated.AccessMethod(access)
 }
 
+func (a *AccessSpecRef) GetInexpensiveContentVersionIdentity(access ComponentVersionAccess) string {
+	if err := a.assure(access.GetContext()); err != nil {
+		return ""
+	}
+	return a.evaluated.GetInexpensiveContentVersionIdentity(access)
+}
+
 func (a *AccessSpecRef) Evaluate(ctx Context) (AccessSpec, error) {
 	err := a.assure(ctx)
 	if err != nil {

--- a/pkg/contexts/ocm/internal/accesstypes.go
+++ b/pkg/contexts/ocm/internal/accesstypes.go
@@ -42,7 +42,20 @@ type AccessSpec interface {
 	Describe(Context) string
 	IsLocal(Context) bool
 	GlobalAccessSpec(Context) AccessSpec
+	// AccessMethod provides an access method implementation for
+	// an access spec. This might be a repository local implementation
+	// or a global one. It might be implemented directly by the AccessSpec
+	// for global AccessMethods or forwarded to the ComponentVersion for
+	// local access methods. It may only be forwarded for AccessSpecs stating
+	// to be local (IsLocal()==true).
+	// This forwarding is necessary because the concrete implementation of
+	// the currently used OCM Repository is not known to the AccessSpec.
 	AccessMethod(access ComponentVersionAccess) (AccessMethod, error)
+	// GetInexpensiveContentVersionIdentity implements a method that attempts to provide an inexpensive identity.
+	// Therefore, an identity that can be provided without requiring the entire object (e.g. calculating the digest from
+	// the bytes), which would defeat the purpose of caching.
+	// It follows the same contract as AccessMethod.
+	GetInexpensiveContentVersionIdentity(access ComponentVersionAccess) string
 }
 
 type (
@@ -154,6 +167,10 @@ func (s *UnknownAccessSpec) AccessMethod(ComponentVersionAccess) (AccessMethod, 
 	return nil, errors.ErrUnknown(errors.KIND_ACCESSMETHOD, s.GetType())
 }
 
+func (s *UnknownAccessSpec) GetInexpensiveContentVersionIdentity(ComponentVersionAccess) string {
+	return ""
+}
+
 func (s *UnknownAccessSpec) Describe(ctx Context) string {
 	return fmt.Sprintf("unknown access method type %q", s.GetType())
 }
@@ -236,6 +253,17 @@ func (s *GenericAccessSpec) AccessMethod(acc ComponentVersionAccess) (AccessMeth
 		return nil, errors.ErrUnknown(errors.KIND_ACCESSMETHOD, s.GetType())
 	}
 	return spec.AccessMethod(acc)
+}
+
+func (s *GenericAccessSpec) GetInexpensiveContentVersionIdentity(acc ComponentVersionAccess) string {
+	spec, err := s.Evaluate(acc.GetContext())
+	if err != nil {
+		return ""
+	}
+	if _, ok := spec.(*GenericAccessSpec); ok {
+		return ""
+	}
+	return spec.GetInexpensiveContentVersionIdentity(acc)
 }
 
 func (s *GenericAccessSpec) IsLocal(ctx Context) bool {

--- a/pkg/contexts/ocm/internal/repository.go
+++ b/pkg/contexts/ocm/internal/repository.go
@@ -151,6 +151,12 @@ type ComponentVersionAccess interface {
 	// providing a local implementation or return nil if this is
 	// not supported by the actual repository type.
 	AccessMethod(AccessSpec) (AccessMethod, error)
+
+	// GetInexpensiveContentVersionIdentity implements a method that attempts to provide an inexpensive identity for
+	// the specified artifact. Therefore, an identity that can be provided without requiring the entire object (e.g.
+	// calculating the digest from the bytes), which would defeat the purpose of caching.
+	// It follows the same contract as AccessMethod.
+	GetInexpensiveContentVersionIdentity(spec AccessSpec) string
 }
 
 // ComponentLister provides the optional repository list functionality of

--- a/pkg/contexts/ocm/plugin/cache/doc.go
+++ b/pkg/contexts/ocm/plugin/cache/doc.go
@@ -3,5 +3,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package cache implements the plugin cache that contains all loaded plugins. It keeps the metadata for the various
-// found plugins and provides a Go abstraction to call the appropriate commands.
+// discovered plugins and provides a Go abstraction to call the appropriate commands.
 package cache

--- a/pkg/contexts/ocm/plugin/cache/doc.go
+++ b/pkg/contexts/ocm/plugin/cache/doc.go
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cache implements the plugin cache that contains all loaded plugins. It keeps the metadata for the various
+// found plugins and provides a Go abstraction to call the appropriate commands.
+package cache

--- a/pkg/contexts/ocm/plugin/descriptor/descriptor.go
+++ b/pkg/contexts/ocm/plugin/descriptor/descriptor.go
@@ -72,11 +72,12 @@ func (d UploaderDescriptor) GetConstraints() []UploaderKey {
 }
 
 type AccessMethodDescriptor struct {
-	Name        string      `json:"name"`
-	Version     string      `json:"version,omitempty"`
-	Description string      `json:"description"`
-	Format      string      `json:"format"`
-	CLIOptions  []CLIOption `json:"options,omitempty"`
+	Name                   string      `json:"name"`
+	Version                string      `json:"version,omitempty"`
+	Description            string      `json:"description"`
+	Format                 string      `json:"format"`
+	SupportContentIdentity bool        `json:"supportContentIdentity,omitempty"`
+	CLIOptions             []CLIOption `json:"options,omitempty"`
 }
 
 type ActionDescriptor struct {

--- a/pkg/contexts/ocm/plugin/descriptor/doc.go
+++ b/pkg/contexts/ocm/plugin/descriptor/doc.go
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package descriptor declares several structs that describe the information that formally describes the capabilities
+// provided by each plugin. The plugin implementation has to provide this information and the plugin user has to
+// evaluate this information.
+package descriptor

--- a/pkg/contexts/ocm/plugin/doc.go
+++ b/pkg/contexts/ocm/plugin/doc.go
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package plugin maps a Go plugin interface to a technical command line interface. Thereby, it allows to embed plugins
+// and their provided functionality into the library. It is the basis for adapter implementations for accessmethods,
+// downloaders, uploaders and blob handlers.
+// Those adapters can be found in the subpackage "plugin" of their dedicated functional area packages (e.g.
+// pkg/contexts/ocm/accessmethods/plugin).
+package plugin

--- a/pkg/contexts/ocm/plugin/plugin.go
+++ b/pkg/contexts/ocm/plugin/plugin.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 
 	"github.com/open-component-model/ocm/pkg/cobrautils/flagsets"
@@ -20,6 +21,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/ppi/cmds/accessmethod"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/ppi/cmds/accessmethod/compose"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/ppi/cmds/accessmethod/get"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/ppi/cmds/accessmethod/identity"
 	accval "github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/ppi/cmds/accessmethod/validate"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/ppi/cmds/action"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/ppi/cmds/action/execute"
@@ -168,6 +170,19 @@ func (p *pluginImpl) ValidateUploadTarget(name string, spec []byte) (*ppi.Upload
 		return nil, errors.Wrapf(err, "plugin uploader %s/%s: cannot unmarshal upload target info", p.Name(), name)
 	}
 	return &info, nil
+}
+
+func (p *pluginImpl) Identity(creds, spec json.RawMessage) (string, error) {
+	args := []string{accessmethod.Name, identity.Name, string(spec)}
+	if creds != nil {
+		args = append(args, "--"+identity.OptCreds, string(creds))
+	}
+	result, err := p.Exec(nil, nil, args...)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.Trim(string(result), "\n"), nil
 }
 
 func (p *pluginImpl) Get(w io.Writer, creds, spec json.RawMessage) error {

--- a/pkg/contexts/ocm/plugin/plugin_test.go
+++ b/pkg/contexts/ocm/plugin/plugin_test.go
@@ -9,6 +9,7 @@ package plugin_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/actions/oci-repository-prepare"
@@ -88,5 +89,37 @@ someattr: value
 				"hostname": "localhost",
 			},
 		}))
+	})
+
+	It("inexpensive identity method compatibility test", func() {
+		cv := &cpi.DummyComponentVersionAccess{Context: ctx}
+		p := registry.Get("test")
+		Expect(p).NotTo(BeNil())
+		Expect(len(p.GetDescriptor().AccessMethods)).To(Equal(2))
+		Expect(registration.RegisterExtensions(registry.GetContext())).To(Succeed())
+		t := ctx.AccessMethods().GetType("test")
+		Expect(t).NotTo(BeNil())
+
+		raw := `type: test`
+		s, err := ctx.AccessSpecForConfig([]byte(raw), nil)
+		Expect(err).To(Succeed())
+		spec := s.(*access.AccessSpec)
+		Expect(spec.GetInexpensiveContentVersionIdentity(cv)).To(Equal(""))
+	})
+
+	It("check inexpensive identity method", func() {
+		cv := &cpi.DummyComponentVersionAccess{Context: ctx}
+		p := registry.Get("identity")
+		Expect(p).NotTo(BeNil())
+		Expect(len(p.GetDescriptor().AccessMethods)).To(Equal(1))
+		Expect(registration.RegisterExtensions(registry.GetContext())).To(Succeed())
+		t := ctx.AccessMethods().GetType("identity")
+		Expect(t).NotTo(BeNil())
+
+		raw := `type: identity`
+		s, err := ctx.AccessSpecForConfig([]byte(raw), nil)
+		Expect(err).To(Succeed())
+		spec := s.(*access.AccessSpec)
+		Expect(spec.GetInexpensiveContentVersionIdentity(cv)).To(Equal("testidentity"))
 	})
 })

--- a/pkg/contexts/ocm/plugin/ppi/cmds/accessmethod/cmd.go
+++ b/pkg/contexts/ocm/plugin/ppi/cmds/accessmethod/cmd.go
@@ -10,6 +10,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/ppi"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/ppi/cmds/accessmethod/compose"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/ppi/cmds/accessmethod/get"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/ppi/cmds/accessmethod/identity"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/ppi/cmds/accessmethod/validate"
 )
 
@@ -25,6 +26,7 @@ described by an access method descriptor (<CMD>` + p.Name() + ` descriptor</CMD>
 
 	cmd.AddCommand(validate.New(p))
 	cmd.AddCommand(get.New(p))
+	cmd.AddCommand(identity.New(p))
 	cmd.AddCommand(compose.New(p))
 	return cmd
 }

--- a/pkg/contexts/ocm/plugin/ppi/doc.go
+++ b/pkg/contexts/ocm/plugin/ppi/doc.go
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// ppi provides the plugin programming interface.
-// It contains everything requirted to implement an OCM plugin
+// Package ppi provides the plugin programming interface.
+// The ppi can be used by plugin developers as support. It reduces the command line interface to a corresponding Go
+// interface. In other words, if the developer implements this Go plugin interface, the ppi automatically provides a
+// corresponding command line interface.
 package ppi

--- a/pkg/contexts/ocm/plugin/ppi/interface.go
+++ b/pkg/contexts/ocm/plugin/ppi/interface.go
@@ -84,6 +84,13 @@ type AccessMethod interface {
 	ComposeAccessSpecification(p Plugin, opts Config, config Config) error
 }
 
+// ContentVersionIdentityProvider is an optional interface an AccessMethod may additionally implement to provide an
+// inexpensive content version identity which might be derived from the access specification with cheap operations on
+// the storage backend.
+type ContentVersionIdentityProvider interface {
+	GetInexpensiveContentVersionIdentity(p Plugin, spec AccessSpec, creds credentials.Credentials) (string, error)
+}
+
 type AccessSpec = runtime.TypedObject
 
 type AccessSpecProvider func() AccessSpec

--- a/pkg/contexts/ocm/plugin/ppi/plugin.go
+++ b/pkg/contexts/ocm/plugin/ppi/plugin.go
@@ -261,12 +261,14 @@ func (p *plugin) RegisterAccessMethod(m AccessMethod) error {
 			})
 		}
 	}
+	_, idp := m.(ContentVersionIdentityProvider)
 	vers := m.Version()
 	if vers == "" {
 		meth := descriptor.AccessMethodDescriptor{
-			Name:        m.Name(),
-			Description: m.Description(),
-			Format:      m.Format(),
+			Name:                   m.Name(),
+			Description:            m.Description(),
+			Format:                 m.Format(),
+			SupportContentIdentity: idp,
 		}
 		p.descriptor.AccessMethods = append(p.descriptor.AccessMethods, meth)
 		p.accessScheme.RegisterByDecoder(m.Name(), m)
@@ -274,11 +276,12 @@ func (p *plugin) RegisterAccessMethod(m AccessMethod) error {
 		vers = "v1"
 	}
 	meth := descriptor.AccessMethodDescriptor{
-		Name:        m.Name(),
-		Version:     vers,
-		Description: m.Description(),
-		Format:      m.Format(),
-		CLIOptions:  optlist,
+		Name:                   m.Name(),
+		Version:                vers,
+		Description:            m.Description(),
+		Format:                 m.Format(),
+		SupportContentIdentity: idp,
+		CLIOptions:             optlist,
 	}
 	p.descriptor.AccessMethods = append(p.descriptor.AccessMethods, meth)
 	p.accessScheme.RegisterByDecoder(m.Name()+"/"+vers, m)

--- a/pkg/contexts/ocm/plugin/testdata/identity
+++ b/pkg/contexts/ocm/plugin/testdata/identity
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+NAME="$(basename "$0")"
+
+Error() {
+  echo '{ "error": "'$1'" }' >&2
+  exit 1
+}
+
+Info() {
+  echo '{"version":"v1","pluginName":"'$NAME'","pluginVersion":"v1","shortDescription":"a test plugin","description":"a test plugin with access method test","accessMethods":[{"name":"identity","shortDescription":"test access","description":"","supportContentIdentity":true}]}
+'
+}
+
+Get() {
+  echo "test content"
+}
+
+Validate() {
+  echo '{"short":"a test","mediaType":"plain/text","description":"","hint":"testfile","consumerId":{"hostname":"localhost","type":"identity"}}'
+}
+
+AccessMethod() {
+  case "$1" in
+    get) Get "${@:2}";;
+    validate) Validate "${@:2}";;
+    identity) Identity;;
+    *) Error "invalid accessmethod command $1";;
+  esac
+}
+
+Identity() {
+  echo "testidentity"
+}
+
+case "$1" in
+  info) Info;;
+  accessmethod) AccessMethod "${@:2}";;
+  *) Error "invalid command $1";;
+esac

--- a/pkg/contexts/ocm/repositories/comparch/accessmethod_localfs.go
+++ b/pkg/contexts/ocm/repositories/comparch/accessmethod_localfs.go
@@ -23,11 +23,11 @@ type localFilesystemBlobAccessMethod struct {
 
 var _ cpi.AccessMethod = (*localFilesystemBlobAccessMethod)(nil)
 
-func newLocalFilesystemBlobAccessMethod(a *localblob.AccessSpec, base support.ComponentVersionContainer) (cpi.AccessMethod, error) {
+func newLocalFilesystemBlobAccessMethod(a *localblob.AccessSpec, base support.ComponentVersionContainer) cpi.AccessMethod {
 	return &localFilesystemBlobAccessMethod{
 		spec: a,
 		base: base,
-	}, nil
+	}
 }
 
 func (m *localFilesystemBlobAccessMethod) AccessSpec() cpi.AccessSpec {

--- a/pkg/contexts/ocm/repositories/comparch/componentarchive.go
+++ b/pkg/contexts/ocm/repositories/comparch/componentarchive.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mandelsoft/vfs/pkg/vfs"
 
 	"github.com/open-component-model/ocm/pkg/common"
+	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/common/accessobj"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localfsblob"
@@ -157,7 +158,19 @@ func (c *componentArchiveContainer) AccessMethod(a cpi.AccessSpec) (cpi.AccessMe
 		if err != nil {
 			return nil, err
 		}
-		return newLocalFilesystemBlobAccessMethod(accessSpec.(*localblob.AccessSpec), c)
+		return newLocalFilesystemBlobAccessMethod(accessSpec.(*localblob.AccessSpec), c), nil
 	}
 	return nil, errors.ErrNotSupported(errors.KIND_ACCESSMETHOD, a.GetType(), "component archive")
+}
+
+func (c *componentArchiveContainer) GetInexpensiveContentVersionIdentity(a cpi.AccessSpec) string {
+	if a.GetKind() == localblob.Type || a.GetKind() == localfsblob.Type {
+		accessSpec, err := c.GetContext().AccessSpecForSpec(a)
+		if err != nil {
+			return ""
+		}
+		digest, _ := accessio.Digest(newLocalFilesystemBlobAccessMethod(accessSpec.(*localblob.AccessSpec), c))
+		return digest.String()
+	}
+	return ""
 }

--- a/pkg/contexts/ocm/repositories/genericocireg/componentversion.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/componentversion.go
@@ -138,6 +138,25 @@ func (c *ComponentVersionContainer) AccessMethod(a cpi.AccessSpec) (cpi.AccessMe
 	return nil, errors.ErrNotSupported(errors.KIND_ACCESSMETHOD, a.GetType(), "oci registry")
 }
 
+func (c *ComponentVersionContainer) GetInexpensiveContentVersionIdentity(a cpi.AccessSpec) string {
+	accessSpec, err := c.comp.GetContext().AccessSpecForSpec(a)
+	if err != nil {
+		return ""
+	}
+
+	switch a.GetKind() {
+	case localblob.Type:
+		return accessSpec.(*localblob.AccessSpec).LocalReference
+	case localociblob.Type:
+		return accessSpec.(*localblob.AccessSpec).LocalReference
+	case relativeociref.Type:
+		d, _ := accessSpec.(*relativeociref.AccessSpec).GetDigest()
+		return d
+	}
+
+	return ""
+}
+
 func (c *ComponentVersionContainer) Update() error {
 	logger := Logger(c.GetContext()).WithValues("cv", common.NewNameVersion(c.comp.name, c.version))
 	err := c.Check()


### PR DESCRIPTION
**What this PR does / why we need it**:
The primary use case for this functionality is the caching of resources. Efficient caching requires a possibility to uniquely identify the content of a resource (so, an identity that changes if the content of the resource changes). Whether or not such an identity can be provided for a resource depends on the storage technology, or rather the access method (for oci artifacts within a oci registry, the manifest digest can be used, for blobs within an s3 storage a certain version attribute can be used, ...). This method provides a uniform interface to retrieve such an identity **if possible**. 


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user
add inexpensive content version identity functionality to enable caching
```
