### PR TITLE
handle scheme based URL in OCM repo spec

### DIFF
--- a/pkg/contexts/oci/ref_test.go
+++ b/pkg/contexts/oci/ref_test.go
@@ -78,6 +78,19 @@ var _ = Describe("ref parsing", func() {
 				Digest:     &digest,
 			},
 		})
+		CheckRef("http://127.0.0.1:443/repo/repo:v1@"+digest.String(), &oci.RefSpec{
+			UniformRepositorySpec: oci.UniformRepositorySpec{
+				Type:   "",
+				Scheme: "http",
+				Host:   "127.0.0.1:443",
+				Info:   "",
+			},
+			ArtSpec: oci.ArtSpec{
+				Repository: "repo/repo",
+				Tag:        &tag,
+				Digest:     &digest,
+			},
+		})
 		CheckRef("directory::a/b", &oci.RefSpec{
 			UniformRepositorySpec: oci.UniformRepositorySpec{
 				Type:   "directory",

--- a/pkg/contexts/oci/repositories/ocireg/namespace.go
+++ b/pkg/contexts/oci/repositories/ocireg/namespace.go
@@ -36,7 +36,7 @@ type NamespaceContainer struct {
 var _ support.NamespaceContainer = (*NamespaceContainer)(nil)
 
 func NewNamespace(repo *RepositoryImpl, name string) (cpi.NamespaceAccess, error) {
-	ref := repo.getRef(name, "")
+	ref := repo.GetRef(name, "")
 	resolver, err := repo.getResolver(name)
 	if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (n *NamespaceContainer) getPusher(vers string) (resolve.Pusher, error) {
 		return nil, err
 	}
 
-	ref := n.repo.getRef(n.impl.GetNamespace(), vers)
+	ref := n.repo.GetRef(n.impl.GetNamespace(), vers)
 	resolver := n.resolver
 
 	n.repo.GetContext().Logger().Trace("get pusher", "ref", ref)
@@ -147,7 +147,7 @@ func (n *NamespaceContainer) ListTags() ([]string, error) {
 }
 
 func (n *NamespaceContainer) GetArtifact(i support.NamespaceAccessImpl, vers string) (cpi.ArtifactAccess, error) {
-	ref := n.repo.getRef(n.impl.GetNamespace(), vers)
+	ref := n.repo.GetRef(n.impl.GetNamespace(), vers)
 	n.repo.GetContext().Logger().Debug("get artifact", "ref", ref)
 	_, desc, err := n.resolver.Resolve(context.Background(), ref)
 	n.repo.GetContext().Logger().Debug("done", "digest", desc.Digest, "size", desc.Size, "mimetype", desc.MediaType, "error", logging.ErrorMessage(err))
@@ -169,7 +169,7 @@ func (n *NamespaceContainer) GetArtifact(i support.NamespaceAccessImpl, vers str
 }
 
 func (n *NamespaceContainer) HasArtifact(vers string) (bool, error) {
-	ref := n.repo.getRef(n.impl.GetNamespace(), vers)
+	ref := n.repo.GetRef(n.impl.GetNamespace(), vers)
 	n.repo.GetContext().Logger().Debug("check artifact", "ref", ref)
 	_, desc, err := n.resolver.Resolve(context.Background(), ref)
 	n.repo.GetContext().Logger().Debug("done", "digest", desc.Digest, "size", desc.Size, "mimetype", desc.MediaType, "error", logging.ErrorMessage(err))
@@ -234,7 +234,7 @@ func (n *NamespaceContainer) AddArtifact(artifact cpi.Artifact, tags ...string) 
 }
 
 func (n *NamespaceContainer) AddTags(digest digest.Digest, tags ...string) error {
-	_, desc, err := n.resolver.Resolve(context.Background(), n.repo.getRef(n.impl.GetNamespace(), digest.String()))
+	_, desc, err := n.resolver.Resolve(context.Background(), n.repo.GetRef(n.impl.GetNamespace(), digest.String()))
 	if err != nil {
 		return fmt.Errorf("unable to resolve: %w", err)
 	}

--- a/pkg/contexts/oci/repositories/ocireg/repository.go
+++ b/pkg/contexts/oci/repositories/ocireg/repository.go
@@ -147,7 +147,7 @@ func (r *RepositoryImpl) getResolver(comp string) (resolve.Resolver, error) {
 	return docker.NewResolver(opts), nil
 }
 
-func (r *RepositoryImpl) getRef(comp, vers string) string {
+func (r *RepositoryImpl) GetRef(comp, vers string) string {
 	base := path.Join(r.info.Locator, comp)
 	if vers == "" {
 		return base
@@ -167,7 +167,7 @@ func (r *RepositoryImpl) ExistsArtifact(name string, version string) (bool, erro
 	if err != nil {
 		return false, err
 	}
-	ref := r.getRef(name, version)
+	ref := r.GetRef(name, version)
 	_, _, err = res.Resolve(context.Background(), ref)
 
 	if err != nil {

--- a/pkg/contexts/ocm/repositories/genericocireg/spec_test.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/spec_test.go
@@ -66,4 +66,14 @@ var _ = Describe("access method", func() {
 		Expect(effoci.BaseURL).To(Equal("X"))
 	})
 
+	It("creates spec", func() {
+		spec := ocmreg.NewRepositorySpec("http://127.0.0.1:5000/ocm")
+		Expect(spec).To(Equal(&ocmreg.RepositorySpec{
+			RepositorySpec: ocireg.NewRepositorySpec("http://127.0.0.1:5000"),
+			ComponentRepositoryMeta: genericocireg.ComponentRepositoryMeta{
+				SubPath:              "ocm",
+				ComponentNameMapping: genericocireg.OCIRegistryURLPathMapping,
+			},
+		}))
+	})
 })

--- a/pkg/contexts/ocm/repositories/ocireg/type.go
+++ b/pkg/contexts/ocm/repositories/ocireg/type.go
@@ -37,9 +37,14 @@ type RepositorySpec = genericocireg.RepositorySpec
 func NewRepositorySpec(baseURL string, metas ...*ComponentRepositoryMeta) *RepositorySpec {
 	meta := utils.Optional(metas...)
 	if meta == nil {
+		scheme := ""
+		if idx := strings.Index(baseURL, "://"); idx > 0 {
+			scheme = baseURL[:idx+3]
+			baseURL = baseURL[idx+3:]
+		}
 		if idx := strings.Index(baseURL, "/"); idx > 0 {
 			meta = NewComponentRepositoryMeta(baseURL[idx+1:])
-			baseURL = baseURL[:idx]
+			baseURL = scheme + baseURL[:idx]
 		}
 	}
 

--- a/pkg/testutils/utils.go
+++ b/pkg/testutils/utils.go
@@ -17,7 +17,7 @@ import (
 )
 
 func Close(c io.Closer, msg ...interface{}) {
-	Defer(c.Close)
+	Defer(c.Close, msg...)
 }
 
 func Defer(f func() error, msg ...interface{}) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Creating an oci based OCM repository spec with NewRepositorySpec creates corrupted
specification objects when passing a scheme based URL with a port part.

This PR now parses the scheme part separately and created an appropropriate wrapped
OCI repository spec for the OCM repository spec. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
