### PR TITLE
Provide default implementation to support implementations of simple virtual/simulated OCM repositories,

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/klauspost/compress v1.16.5
 	github.com/klauspost/pgzip v1.2.5
 	github.com/mandelsoft/logging v0.0.0-20230331123830-36542ef18f6f
-	github.com/mandelsoft/vfs v0.0.0-20230506183150-975954b82357
+	github.com/mandelsoft/vfs v0.0.0-20230713123140-269aa4fb1338
 	github.com/marstr/guid v1.1.0
 	github.com/mitchellh/copystructure v1.2.0
 	github.com/mittwald/go-helm-client v0.11.3

--- a/go.sum
+++ b/go.sum
@@ -1128,8 +1128,8 @@ github.com/mandelsoft/logging v0.0.0-20230331123830-36542ef18f6f h1:ZoqAURpfhE54
 github.com/mandelsoft/logging v0.0.0-20230331123830-36542ef18f6f/go.mod h1:HjtBPH5tsJygvyYEu2r/ZwOOBGcu+oR2sKH73VEnHtg=
 github.com/mandelsoft/spiff v1.7.0-beta-5 h1:3kC10nTviDQhL8diSxp7i4IC2iSiDg6KPbH1CAq7Lfw=
 github.com/mandelsoft/spiff v1.7.0-beta-5/go.mod h1:TwEeOPuRZxlzQBCLEyVTlHmBSruSGGNdiQ2fovVJ8ao=
-github.com/mandelsoft/vfs v0.0.0-20230506183150-975954b82357 h1:BJKXJKeVAn9Z1Ke6N1p3G20SjMwOuJNBeSxT9two2FA=
-github.com/mandelsoft/vfs v0.0.0-20230506183150-975954b82357/go.mod h1:Z6caUgivS+P837kxRUaYPuzLKxNpOly4WlInNhrcWyc=
+github.com/mandelsoft/vfs v0.0.0-20230713123140-269aa4fb1338 h1:06XAA8Z3qNQLdq8eUtxGRDgJ3dSzJuqt82y3E3siO6s=
+github.com/mandelsoft/vfs v0.0.0-20230713123140-269aa4fb1338/go.mod h1:Z6caUgivS+P837kxRUaYPuzLKxNpOly4WlInNhrcWyc=
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/markbates/errx v1.1.0 h1:QDFeR+UP95dO12JgW+tgi2UVfo0V8YBHiUIOaeBPiEI=
 github.com/markbates/errx v1.1.0/go.mod h1:PLa46Oex9KNbVDZhKel8v1OT7hD5JZ2eI7AHhA0wswc=

--- a/pkg/contexts/ocm/repositories/virtual/access.go
+++ b/pkg/contexts/ocm/repositories/virtual/access.go
@@ -30,3 +30,7 @@ type Access interface {
 
 	Close() error
 }
+
+type RepositorySpecProvider interface {
+	GetSpecification() cpi.RepositorySpec
+}

--- a/pkg/contexts/ocm/repositories/virtual/access.go
+++ b/pkg/contexts/ocm/repositories/virtual/access.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package virtual
+
+import (
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
+)
+
+type VersionAccess interface {
+	GetDescriptor() *compdesc.ComponentDescriptor
+	GetBlob(name string) (cpi.DataAccess, error)
+	AddBlob(blob cpi.BlobAccess) (string, error)
+	Update() error
+	Close() error
+
+	IsReadOnly() bool
+	GetInexpensiveContentVersionIdentity(a cpi.AccessSpec) string
+}
+
+type Access interface {
+	ComponentLister() cpi.ComponentLister
+
+	ExistsComponentVersion(name string, version string) (bool, error)
+	ListVersions(comp string) ([]string, error)
+
+	GetComponentVersion(comp, version string) (VersionAccess, error)
+
+	Close() error
+}

--- a/pkg/contexts/ocm/repositories/virtual/accessmethod_localblob.go
+++ b/pkg/contexts/ocm/repositories/virtual/accessmethod_localblob.go
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package virtual
+
+import (
+	"io"
+	"sync"
+
+	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
+)
+
+type localBlobAccessMethod struct {
+	lock   sync.Mutex
+	data   accessio.DataAccess
+	spec   *localblob.AccessSpec
+	access VersionAccess
+}
+
+var _ cpi.AccessMethod = (*localBlobAccessMethod)(nil)
+
+func newLocalBlobAccessMethod(a *localblob.AccessSpec, acc VersionAccess) *localBlobAccessMethod {
+	return &localBlobAccessMethod{
+		spec:   a,
+		access: acc,
+	}
+}
+
+func (m *localBlobAccessMethod) GetKind() string {
+	return m.spec.GetKind()
+}
+
+func (m *localBlobAccessMethod) AccessSpec() cpi.AccessSpec {
+	return m.spec
+}
+
+func (m *localBlobAccessMethod) Close() error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if m.data != nil {
+		tmp := m.data
+		m.data = nil
+		return tmp.Close()
+	}
+	return nil
+}
+
+func (m *localBlobAccessMethod) getBlob() (cpi.DataAccess, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if m.data != nil {
+		return m.data, nil
+	}
+	data, err := m.access.GetBlob(m.spec.LocalReference)
+	if err != nil {
+		return nil, err
+	}
+	m.data = data
+	return m.data, err
+}
+
+func (m *localBlobAccessMethod) Reader() (io.ReadCloser, error) {
+	blob, err := m.getBlob()
+	if err != nil {
+		return nil, err
+	}
+	return blob.Reader()
+}
+
+func (m *localBlobAccessMethod) Get() ([]byte, error) {
+	return accessio.BlobData(m.getBlob())
+}
+
+func (m *localBlobAccessMethod) MimeType() string {
+	return m.spec.MediaType
+}

--- a/pkg/contexts/ocm/repositories/virtual/component.go
+++ b/pkg/contexts/ocm/repositories/virtual/component.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package virtual
+
+import (
+	"fmt"
+
+	"github.com/open-component-model/ocm/pkg/contexts/oci"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi/support"
+	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/utils"
+)
+
+type _ComponentAccessImplBase = cpi.ComponentAccessImplBase
+
+type componentAccessImpl struct {
+	_ComponentAccessImplBase
+	repo *RepositoryImpl
+	name string
+}
+
+func newComponentAccess(repo *RepositoryImpl, name string, main bool) (cpi.ComponentAccess, error) {
+	base, err := cpi.NewComponentAccessImplBase(repo.GetContext(), name, repo)
+	if err != nil {
+		return nil, err
+	}
+	impl := &componentAccessImpl{
+		_ComponentAccessImplBase: *base,
+		repo:                     repo,
+		name:                     name,
+	}
+	return cpi.NewComponentAccess(impl, "OCM component[Simple]"), nil
+}
+
+func (c *componentAccessImpl) ListVersions() ([]string, error) {
+	return c.repo.access.ListVersions(c.name)
+}
+
+func (c *componentAccessImpl) HasVersion(vers string) (bool, error) {
+	return c.repo.ExistsComponentVersion(c.name, vers)
+}
+
+func (c *componentAccessImpl) LookupVersion(version string) (cpi.ComponentVersionAccess, error) {
+	ok, err := c.HasVersion(version)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, cpi.ErrComponentVersionNotFoundWrap(err, c.name, version)
+	}
+	v, err := c._ComponentAccessImplBase.View()
+	if err != nil {
+		return nil, err
+	}
+	defer v.Close()
+
+	return newComponentVersionAccess(c, version, true)
+}
+
+func (c *componentAccessImpl) AddVersion(access cpi.ComponentVersionAccess) error {
+	if access.GetName() != c.GetName() {
+		return errors.ErrInvalid("component name", access.GetName())
+	}
+	cont, err := support.GetComponentVersionContainer(access)
+	if err != nil {
+		return fmt.Errorf("cannot add component version: component version access %s not created for target", access.GetName()+":"+access.GetVersion())
+	}
+	mine, ok := cont.(*ComponentVersionContainer)
+	if !ok || mine.comp != c {
+		return fmt.Errorf("cannot add component version: component version access %s not created for target", access.GetName()+":"+access.GetVersion())
+	}
+	mine.impl.EnablePersistence()
+	return mine.impl.Update(false)
+}
+
+func (c *componentAccessImpl) NewVersion(version string, overrides ...bool) (cpi.ComponentVersionAccess, error) {
+	v, err := c.View(false)
+	if err != nil {
+		return nil, err
+	}
+	defer v.Close()
+
+	override := utils.Optional(overrides...)
+	_, err = c.HasVersion(version)
+	if err == nil {
+		if override {
+			return newComponentVersionAccess(c, version, false)
+		}
+		return nil, errors.ErrAlreadyExists(cpi.KIND_COMPONENTVERSION, c.name+"/"+version)
+	}
+	if !errors.IsErrNotFoundKind(err, oci.KIND_OCIARTIFACT) {
+		return nil, err
+	}
+	return newComponentVersionAccess(c, version, false)
+}

--- a/pkg/contexts/ocm/repositories/virtual/component.go
+++ b/pkg/contexts/ocm/repositories/virtual/component.go
@@ -7,7 +7,6 @@ package virtual
 import (
 	"fmt"
 
-	"github.com/open-component-model/ocm/pkg/contexts/oci"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi/support"
 	"github.com/open-component-model/ocm/pkg/errors"
@@ -84,14 +83,14 @@ func (c *componentAccessImpl) NewVersion(version string, overrides ...bool) (cpi
 	defer v.Close()
 
 	override := utils.Optional(overrides...)
-	_, err = c.HasVersion(version)
-	if err == nil {
+	ok, err := c.HasVersion(version)
+	if err == nil && ok {
 		if override {
 			return newComponentVersionAccess(c, version, false)
 		}
 		return nil, errors.ErrAlreadyExists(cpi.KIND_COMPONENTVERSION, c.name+"/"+version)
 	}
-	if !errors.IsErrNotFoundKind(err, oci.KIND_OCIARTIFACT) {
+	if err != nil && !errors.IsErrNotFoundKind(err, cpi.KIND_COMPONENTVERSION) {
 		return nil, err
 	}
 	return newComponentVersionAccess(c, version, false)

--- a/pkg/contexts/ocm/repositories/virtual/componentversion.go
+++ b/pkg/contexts/ocm/repositories/virtual/componentversion.go
@@ -64,8 +64,9 @@ func (c *ComponentVersionContainer) Close() error {
 	if c.access == nil {
 		return accessio.ErrClosed
 	}
+	a := c.access
 	c.access = nil
-	return nil
+	return a.Close()
 }
 
 func (c *ComponentVersionContainer) Check() error {

--- a/pkg/contexts/ocm/repositories/virtual/componentversion.go
+++ b/pkg/contexts/ocm/repositories/virtual/componentversion.go
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package virtual
+
+import (
+	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"
+	ocmhdlr "github.com/open-component-model/ocm/pkg/contexts/ocm/blobhandler/handlers/ocm"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi/support"
+	"github.com/open-component-model/ocm/pkg/errors"
+)
+
+// newComponentVersionAccess creates a component access for the artifact access, if this fails the artifact acess is closed.
+func newComponentVersionAccess(comp *componentAccessImpl, version string, persistent bool) (cpi.ComponentVersionAccess, error) {
+	access, err := comp.repo.access.GetComponentVersion(comp.GetName(), version)
+	if err != nil {
+		return nil, err
+	}
+	c, err := newComponentVersionContainer(comp, version, access)
+	if err != nil {
+		return nil, err
+	}
+	impl, err := support.NewComponentVersionAccessImpl(comp.GetName(), version, c, true, persistent)
+	if err != nil {
+		c.Close()
+		return nil, err
+	}
+	return cpi.NewComponentVersionAccess(impl), nil
+}
+
+// //////////////////////////////////////////////////////////////////////////////
+
+type ComponentVersionContainer struct {
+	impl support.ComponentVersionAccessImpl
+
+	comp    *componentAccessImpl
+	version string
+	access  VersionAccess
+}
+
+var _ support.ComponentVersionContainer = (*ComponentVersionContainer)(nil)
+
+func newComponentVersionContainer(comp *componentAccessImpl, version string, access VersionAccess) (*ComponentVersionContainer, error) {
+	return &ComponentVersionContainer{
+		comp:    comp,
+		version: version,
+		access:  access,
+	}, nil
+}
+
+func (c *ComponentVersionContainer) SetImplementation(impl support.ComponentVersionAccessImpl) {
+	c.impl = impl
+}
+
+func (c *ComponentVersionContainer) GetParentViewManager() cpi.ComponentAccessViewManager {
+	return c.comp
+}
+
+func (c *ComponentVersionContainer) Close() error {
+	if c.access == nil {
+		return accessio.ErrClosed
+	}
+	c.access = nil
+	return nil
+}
+
+func (c *ComponentVersionContainer) Check() error {
+	if c.version != c.GetDescriptor().Version {
+		return errors.ErrInvalid("component version", c.GetDescriptor().Version)
+	}
+	if c.comp.name != c.GetDescriptor().Name {
+		return errors.ErrInvalid("component name", c.GetDescriptor().Name)
+	}
+	return nil
+}
+
+func (c *ComponentVersionContainer) Repository() cpi.Repository {
+	return c.comp.repo.nonref
+}
+
+func (c *ComponentVersionContainer) GetContext() cpi.Context {
+	return c.comp.GetContext()
+}
+
+func (c *ComponentVersionContainer) IsReadOnly() bool {
+	return c.access.IsReadOnly()
+}
+
+func (c *ComponentVersionContainer) IsClosed() bool {
+	return c.access == nil
+}
+
+func (c *ComponentVersionContainer) AccessMethod(a cpi.AccessSpec) (cpi.AccessMethod, error) {
+	accessSpec, err := c.comp.GetContext().AccessSpecForSpec(a)
+	if err != nil {
+		return nil, err
+	}
+
+	switch a.GetKind() { //nolint:gocritic // to be extended
+	case localblob.Type:
+		return newLocalBlobAccessMethod(accessSpec.(*localblob.AccessSpec), c.access), nil
+	}
+
+	return nil, errors.ErrNotSupported(errors.KIND_ACCESSMETHOD, a.GetType(), "virtual registry")
+}
+
+func (c *ComponentVersionContainer) GetInexpensiveContentVersionIdentity(a cpi.AccessSpec) string {
+	accessSpec, err := c.comp.GetContext().AccessSpecForSpec(a)
+	if err != nil {
+		return ""
+	}
+
+	switch a.GetKind() { //nolint:gocritic // to be extended
+	case localblob.Type:
+		return c.access.GetInexpensiveContentVersionIdentity(accessSpec)
+	}
+
+	return ""
+}
+
+func (c *ComponentVersionContainer) Update() error {
+	return c.access.Update()
+}
+
+func (c *ComponentVersionContainer) GetDescriptor() *compdesc.ComponentDescriptor {
+	return c.access.GetDescriptor()
+}
+
+func (c *ComponentVersionContainer) GetBlobData(name string) (cpi.DataAccess, error) {
+	return c.access.GetBlob(name)
+}
+
+func (c *ComponentVersionContainer) GetStorageContext(cv cpi.ComponentVersionAccess) cpi.StorageContext {
+	return ocmhdlr.New(c.Repository(), cv, c.access, Type, c.access)
+}
+
+func (c *ComponentVersionContainer) AddBlobFor(storagectx cpi.StorageContext, blob cpi.BlobAccess, refName string, global cpi.AccessSpec) (cpi.AccessSpec, error) {
+	if c.IsReadOnly() {
+		return nil, accessio.ErrReadOnly
+	}
+	if blob == nil {
+		return nil, errors.New("a resource has to be defined")
+	}
+
+	ref, err := c.access.AddBlob(blob)
+	if err != nil {
+		return nil, err
+	}
+	return localblob.New(ref, refName, blob.MimeType(), global), nil
+}

--- a/pkg/contexts/ocm/repositories/virtual/componentversion.go
+++ b/pkg/contexts/ocm/repositories/virtual/componentversion.go
@@ -8,7 +8,6 @@ import (
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localfsblob"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localociblob"
 	ocmhdlr "github.com/open-component-model/ocm/pkg/contexts/ocm/blobhandler/handlers/ocm"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
@@ -106,8 +105,6 @@ func (c *ComponentVersionContainer) AccessMethod(a cpi.AccessSpec) (cpi.AccessMe
 	switch a.GetKind() { //nolint:gocritic // to be extended
 	case localfsblob.Type:
 		fallthrough
-	case localociblob.Type:
-		fallthrough
 	case localblob.Type:
 		return newLocalBlobAccessMethod(accessSpec.(*localblob.AccessSpec), c.access), nil
 	}
@@ -122,6 +119,8 @@ func (c *ComponentVersionContainer) GetInexpensiveContentVersionIdentity(a cpi.A
 	}
 
 	switch a.GetKind() { //nolint:gocritic // to be extended
+	case localfsblob.Type:
+		fallthrough
 	case localblob.Type:
 		return c.access.GetInexpensiveContentVersionIdentity(accessSpec)
 	}

--- a/pkg/contexts/ocm/repositories/virtual/componentversion.go
+++ b/pkg/contexts/ocm/repositories/virtual/componentversion.go
@@ -102,7 +102,7 @@ func (c *ComponentVersionContainer) AccessMethod(a cpi.AccessSpec) (cpi.AccessMe
 		return nil, err
 	}
 
-	switch a.GetKind() { //nolint:gocritic // to be extended
+	switch a.GetKind() { // to be extended
 	case localfsblob.Type:
 		fallthrough
 	case localblob.Type:
@@ -118,7 +118,7 @@ func (c *ComponentVersionContainer) GetInexpensiveContentVersionIdentity(a cpi.A
 		return ""
 	}
 
-	switch a.GetKind() { //nolint:gocritic // to be extended
+	switch a.GetKind() { // to be extended
 	case localfsblob.Type:
 		fallthrough
 	case localblob.Type:

--- a/pkg/contexts/ocm/repositories/virtual/componentversion.go
+++ b/pkg/contexts/ocm/repositories/virtual/componentversion.go
@@ -7,6 +7,8 @@ package virtual
 import (
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localfsblob"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localociblob"
 	ocmhdlr "github.com/open-component-model/ocm/pkg/contexts/ocm/blobhandler/handlers/ocm"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
@@ -102,6 +104,10 @@ func (c *ComponentVersionContainer) AccessMethod(a cpi.AccessSpec) (cpi.AccessMe
 	}
 
 	switch a.GetKind() { //nolint:gocritic // to be extended
+	case localfsblob.Type:
+		fallthrough
+	case localociblob.Type:
+		fallthrough
 	case localblob.Type:
 		return newLocalBlobAccessMethod(accessSpec.(*localblob.AccessSpec), c.access), nil
 	}

--- a/pkg/contexts/ocm/repositories/virtual/example/doc.go
+++ b/pkg/contexts/ocm/repositories/virtual/example/doc.go
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package example contains a simple implementation providing
+// a virtual OCM repository based on some opinionated
+// filesystem structure.
+// It uses the virtual package by providing a dedicated
+// implementation of the virtual.Access interface working
+// on a virtual filesystem.
+package example

--- a/pkg/contexts/ocm/repositories/virtual/example/example.go
+++ b/pkg/contexts/ocm/repositories/virtual/example/example.go
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package example
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"path"
+	"reflect"
+	"sync"
+
+	"github.com/mandelsoft/vfs/pkg/projectionfs"
+	"github.com/mandelsoft/vfs/pkg/vfs"
+
+	"github.com/open-component-model/ocm/pkg/common"
+	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/virtual"
+	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/utils"
+)
+
+////////////////////////////////////////////////////////////////////////////////
+
+func NewRepository(ctx cpi.ContextProvider, fs vfs.FileSystem, readonly bool, path ...string) (cpi.Repository, error) {
+	var err error
+
+	p := utils.Optional(path...)
+	if p != "" && p != "/" {
+		fs, err = projectionfs.New(fs, p)
+		if err != nil {
+			return nil, err
+		}
+	}
+	acc, err := NewAccess(fs, readonly)
+	if err != nil {
+		return nil, err
+	}
+	return virtual.NewRepository(ctx.OCMContext(), acc), nil
+}
+
+type Index = virtual.Index[string]
+
+type Access struct {
+	lock     sync.Mutex
+	readonly bool
+	fs       vfs.FileSystem
+	index    *Index
+}
+
+func NewAccess(fs vfs.FileSystem, readonly bool) (*Access, error) {
+	a := &Access{
+		readonly: readonly,
+		fs:       fs,
+	}
+	err := a.Reset()
+	if err != nil {
+		return nil, err
+	}
+	return a, nil
+}
+
+func (a *Access) Reset() error {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	a.index = virtual.NewIndex[string]()
+
+	list, err := vfs.ReadDir(a.fs, "descriptors")
+	if err != nil {
+		return err
+	}
+	for _, e := range list {
+		p := path.Join("descriptors", e.Name())
+		data, err := vfs.ReadFile(a.fs, p)
+		if err != nil {
+			return err
+		}
+		cd, err := compdesc.Decode(data)
+		if err != nil {
+			return err
+		}
+		err = a.index.Add(cd, p)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (a *Access) ComponentLister() cpi.ComponentLister {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	return a.index
+}
+
+func (a *Access) ExistsComponentVersion(name string, version string) (bool, error) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	e := a.index.Get(name, version)
+	return e != nil, nil
+}
+
+func (a *Access) ListVersions(comp string) ([]string, error) {
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	return a.index.GetVersions(comp), nil
+}
+
+func (a *Access) GetComponentVersion(comp, version string) (virtual.VersionAccess, error) {
+	var cd *compdesc.ComponentDescriptor
+
+	a.lock.Lock()
+	defer a.lock.Unlock()
+
+	i := a.index.Get(comp, version)
+	if i == nil {
+		if a.readonly {
+			return nil, errors.ErrNotFound(cpi.KIND_COMPONENTVERSION, common.NewNameVersion(comp, version).String())
+		}
+		cd = compdesc.New(comp, version)
+		hash := sha256.Sum256([]byte(comp + ":" + version))
+		err := a.index.Add(cd, path.Join("descriptors", hex.EncodeToString(hash[:])))
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		cd = i.CD()
+	}
+	return &VersionAccess{a, cd.GetName(), cd.GetVersion(), cd.Copy()}, nil
+}
+
+func (a *Access) Close() error {
+	return nil
+}
+
+var _ virtual.Access = (*Access)(nil)
+
+type VersionAccess struct {
+	access *Access
+	comp   string
+	vers   string
+	desc   *compdesc.ComponentDescriptor
+}
+
+func (v *VersionAccess) GetDescriptor() *compdesc.ComponentDescriptor {
+	return v.desc
+}
+
+func (v *VersionAccess) GetBlob(name string) (cpi.DataAccess, error) {
+	p := path.Join("blobs", name)
+
+	if ok, err := vfs.FileExists(v.access.fs, p); !ok || err != nil {
+		return nil, vfs.ErrNotExist
+	}
+	return accessio.DataAccessForFile(v.access.fs, p), nil
+}
+
+func (v *VersionAccess) AddBlob(blob cpi.BlobAccess) (string, error) {
+	if v.IsReadOnly() {
+		return "", accessio.ErrReadOnly
+	}
+	d := blob.Digest()
+	p := path.Join("blobs", d.Encoded())
+	r, err := blob.Reader()
+	if err != nil {
+		return "", err
+	}
+	defer r.Close()
+	w, err := v.access.fs.OpenFile(p, vfs.O_CREATE|vfs.O_RDWR, 0o600)
+	if err != nil {
+		return "", err
+	}
+	defer w.Close()
+	_, err = io.Copy(w, r)
+	if err != nil {
+		return "", err
+	}
+	return d.Encoded(), nil
+}
+
+func (v *VersionAccess) Update() error {
+	v.access.lock.Lock()
+	defer v.access.lock.Unlock()
+
+	if v.desc.GetName() != v.comp || v.desc.GetVersion() != v.vers {
+		return errors.ErrInvalid(cpi.KIND_COMPONENTVERSION, common.VersionedElementKey(v.desc).String())
+	}
+	i := v.access.index.Get(v.comp, v.vers)
+	if !reflect.DeepEqual(v.desc, i.CD()) {
+		if v.IsReadOnly() {
+			return accessio.ErrReadOnly
+		}
+		data, err := compdesc.Encode(v.desc)
+		if err != nil {
+			return err
+		}
+		v.access.index.Set(v.desc, i.Info())
+		return vfs.WriteFile(v.access.fs, i.Info(), data, 0o600)
+	}
+	return nil
+}
+
+func (v *VersionAccess) Close() error {
+	return v.Update()
+}
+
+func (v *VersionAccess) IsReadOnly() bool {
+	return v.access.readonly
+}
+
+func (v *VersionAccess) GetInexpensiveContentVersionIdentity(a cpi.AccessSpec) string {
+	switch a.GetKind() { //nolint:gocritic // to be extended
+	case localblob.Type:
+		blob, err := v.GetBlob(a.(*localblob.AccessSpec).LocalReference)
+		if err != nil {
+			return ""
+		}
+		defer blob.Close()
+		dig, err := accessio.Digest(blob)
+		if err != nil {
+			return ""
+		}
+		return dig.String()
+	}
+	return ""
+}
+
+var _ virtual.VersionAccess = (*VersionAccess)(nil)

--- a/pkg/contexts/ocm/repositories/virtual/index.go
+++ b/pkg/contexts/ocm/repositories/virtual/index.go
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package virtual
+
+import (
+	"sync"
+
+	"github.com/open-component-model/ocm/pkg/common"
+	ocicpi "github.com/open-component-model/ocm/pkg/contexts/oci/cpi"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
+	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/utils"
+)
+
+type IndexEntry[I interface{}] struct {
+	cd   *compdesc.ComponentDescriptor
+	info I
+}
+
+func (i *IndexEntry[I]) CD() *compdesc.ComponentDescriptor {
+	if i == nil {
+		return nil
+	}
+	return i.cd
+}
+
+func (i *IndexEntry[I]) Info() I {
+	var zero I
+	if i == nil {
+		return zero
+	}
+	return i.info
+}
+
+type Index[I interface{}] struct {
+	lock        sync.Mutex
+	descriptors map[string]map[string]*IndexEntry[I]
+}
+
+func NewIndex[I interface{}]() *Index[I] {
+	return &Index[I]{descriptors: map[string]map[string]*IndexEntry[I]{}}
+}
+
+func (i *Index[I]) NumComponents(prefix string) (int, error) {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	list := ocicpi.FilterByNamespacePrefix(prefix, utils.StringMapKeys(i.descriptors))
+	return len(list), nil
+}
+
+func (i *Index[I]) GetComponents(prefix string, closure bool) ([]string, error) {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	return ocicpi.FilterChildren(closure, prefix, utils.StringMapKeys(i.descriptors)), nil
+}
+
+func (i *Index[I]) GetVersions(comp string) []string {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	vers := i.descriptors[comp]
+	if len(vers) == 0 {
+		return []string{}
+	}
+	return utils.StringMapKeys(vers)
+}
+
+func (i *Index[I]) Get(comp, vers string) *IndexEntry[I] {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	var e *IndexEntry[I]
+	set := i.descriptors[comp]
+	if len(vers) != 0 {
+		e = set[vers]
+	}
+	return e
+}
+
+func (i *Index[I]) Add(cd *compdesc.ComponentDescriptor, info I) error {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	set := i.descriptors[cd.Name]
+	if set == nil {
+		set = map[string]*IndexEntry[I]{}
+		i.descriptors[cd.Name] = set
+	}
+	if set[cd.Version] != nil {
+		return errors.ErrAlreadyExists(cpi.KIND_COMPONENTVERSION, common.VersionedElementKey(cd).String())
+	}
+	set[cd.Version] = &IndexEntry[I]{cd, info}
+	return nil
+}
+
+func (i *Index[I]) Set(cd *compdesc.ComponentDescriptor, info I) {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	set := i.descriptors[cd.Name]
+	if set == nil {
+		set = map[string]*IndexEntry[I]{}
+		i.descriptors[cd.Name] = set
+	}
+	set[cd.Version] = &IndexEntry[I]{cd, info}
+}

--- a/pkg/contexts/ocm/repositories/virtual/repo_test.go
+++ b/pkg/contexts/ocm/repositories/virtual/repo_test.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/virtual/example"
 	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/mandelsoft/vfs/pkg/layerfs"
@@ -21,6 +20,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/virtual"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/virtual/example"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/resourcetypes"
 	ocmutils "github.com/open-component-model/ocm/pkg/contexts/ocm/utils"
 	"github.com/open-component-model/ocm/pkg/finalizer"

--- a/pkg/contexts/ocm/repositories/virtual/repo_test.go
+++ b/pkg/contexts/ocm/repositories/virtual/repo_test.go
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package virtual_test
+
+import (
+	"path"
+	"reflect"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+	. "github.com/open-component-model/ocm/pkg/testutils"
+
+	"github.com/mandelsoft/vfs/pkg/projectionfs"
+	"github.com/mandelsoft/vfs/pkg/vfs"
+
+	"github.com/open-component-model/ocm/pkg/common"
+	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/virtual"
+	ocmutils "github.com/open-component-model/ocm/pkg/contexts/ocm/utils"
+	"github.com/open-component-model/ocm/pkg/errors"
+)
+
+var _ = Describe("virtual repo", func() {
+	var env *TestEnv
+	var repo ocm.Repository
+
+	// ocmlog.Context().AddRule(logging.NewConditionRule(logging.TraceLevel, accessio.ALLOC_REALM))
+
+	BeforeEach(func() {
+		env = NewTestEnv(TestData())
+		acc := Must(NewAccess(Must(projectionfs.New(env, "testdata"))))
+		repo = virtual.NewRepository(env.OCMContext(), acc)
+	})
+
+	AfterEach(func() {
+		MustBeSuccessful(repo.Close())
+		env.Cleanup()
+	})
+
+	It("handles list", func() {
+		lister := repo.ComponentLister()
+		Expect(lister).NotTo(BeNil())
+		names := Must(lister.GetComponents("", true))
+		Expect(names).To(ConsistOf([]string{"acme.org/component", "acme.org/component/ref"}))
+	})
+
+	It("handles get", func() {
+		comp := Must(repo.LookupComponent("acme.org/component"))
+		defer Close(comp, "component")
+		Expect(comp.ListVersions()).To(ConsistOf([]string{"v1.0.0"}))
+		Expect(comp.HasVersion("v1.0.0")).To(BeTrue())
+		Expect(comp.HasVersion("v1.0.1")).To(BeFalse())
+		vers := Must(comp.LookupVersion("v1.0.0"))
+		defer Close(vers, "version")
+		r := Must(vers.GetResourceByIndex(0))
+		data := Must(ocmutils.GetResourceData(r))
+		Expect(string(data)).To(Equal("my test data\n"))
+
+		a := Must(r.Access())
+		Expect(a.GetInexpensiveContentVersionIdentity(vers)).To(Equal("sha256:2fdeb101f225dad71efd2dadb92b5aa422169f1884eecb81abdd988d77b68466"))
+	})
+})
+
+////////////////////////////////////////////////////////////////////////////////
+
+type Index = virtual.Index[interface{}]
+
+type Access struct {
+	fs    vfs.FileSystem
+	index *Index
+}
+
+func NewAccess(fs vfs.FileSystem) (*Access, error) {
+	a := &Access{
+		fs:    fs,
+		index: virtual.NewIndex[interface{}](),
+	}
+
+	list, err := vfs.ReadDir(fs, "descriptors")
+	if err != nil {
+		return nil, err
+	}
+	for _, e := range list {
+		data, err := vfs.ReadFile(fs, path.Join("descriptors", e.Name()))
+		if err != nil {
+			return nil, err
+		}
+		cd, err := compdesc.Decode(data)
+		if err != nil {
+			return nil, err
+		}
+		err = a.index.Add(cd, nil)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return a, nil
+}
+
+func (a *Access) ComponentLister() cpi.ComponentLister {
+	return a.index
+}
+
+func (a *Access) ExistsComponentVersion(name string, version string) (bool, error) {
+	e := a.index.Get(name, version)
+	return e != nil, nil
+}
+
+func (a *Access) ListVersions(comp string) ([]string, error) {
+	return a.index.GetVersions(comp), nil
+}
+
+func (a *Access) GetDescriptor(comp, version string) *compdesc.ComponentDescriptor {
+	return a.index.Get(comp, version).CD()
+
+}
+func (a *Access) GetComponentVersion(comp, version string) (virtual.VersionAccess, error) {
+	cd := a.GetDescriptor(comp, version)
+	if cd == nil {
+		// test is readonly mode
+		return nil, errors.ErrNotFound(cpi.KIND_COMPONENTVERSION, common.NewNameVersion(comp, version).String())
+	}
+	return &VersionAccess{a, cd.GetName(), cd.GetVersion(), cd.Copy()}, nil
+}
+
+func (a *Access) Close() error {
+	return nil
+}
+
+var _ virtual.Access = (*Access)(nil)
+
+type VersionAccess struct {
+	access *Access
+	comp   string
+	vers   string
+	desc   *compdesc.ComponentDescriptor
+}
+
+func (v *VersionAccess) GetDescriptor() *compdesc.ComponentDescriptor {
+	return v.desc
+}
+
+func (v *VersionAccess) GetBlob(name string) (cpi.DataAccess, error) {
+	p := path.Join("blobs", name)
+
+	if ok, err := vfs.FileExists(v.access.fs, p); !ok || err != nil {
+		return nil, vfs.ErrNotExist
+	}
+	return accessio.DataAccessForFile(v.access.fs, p), nil
+}
+
+func (v *VersionAccess) AddBlob(blob cpi.BlobAccess) (string, error) {
+	return "", accessio.ErrReadOnly
+}
+
+func (v *VersionAccess) Update() error {
+	if v.desc.GetName() != v.comp || v.desc.GetVersion() != v.vers {
+		return errors.ErrInvalid(cpi.KIND_COMPONENTVERSION, common.VersionedElementKey(v.desc).String())
+	}
+	if !reflect.DeepEqual(v.desc, v.access.GetDescriptor(v.comp, v.vers)) {
+		return accessio.ErrReadOnly
+	}
+	return nil
+}
+
+func (v *VersionAccess) Close() error {
+	return nil
+}
+
+func (v *VersionAccess) IsReadOnly() bool {
+	return true
+}
+
+func (v *VersionAccess) GetInexpensiveContentVersionIdentity(a cpi.AccessSpec) string {
+	switch a.GetKind() { //nolint:gocritic // to be extended
+	case localblob.Type:
+		blob, err := v.GetBlob(a.(*localblob.AccessSpec).LocalReference)
+		if err != nil {
+			return ""
+		}
+		defer blob.Close()
+		dig, err := accessio.Digest(blob)
+		if err != nil {
+			return ""
+		}
+		return dig.String()
+	}
+	return ""
+}
+
+var _ virtual.VersionAccess = (*VersionAccess)(nil)

--- a/pkg/contexts/ocm/repositories/virtual/repo_test.go
+++ b/pkg/contexts/ocm/repositories/virtual/repo_test.go
@@ -5,194 +5,119 @@
 package virtual_test
 
 import (
-	"path"
-	"reflect"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/virtual/example"
 	. "github.com/open-component-model/ocm/pkg/testutils"
 
+	"github.com/mandelsoft/vfs/pkg/layerfs"
+	"github.com/mandelsoft/vfs/pkg/memoryfs"
 	"github.com/mandelsoft/vfs/pkg/projectionfs"
-	"github.com/mandelsoft/vfs/pkg/vfs"
 
-	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
+	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/virtual"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/resourcetypes"
 	ocmutils "github.com/open-component-model/ocm/pkg/contexts/ocm/utils"
-	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/finalizer"
+	"github.com/open-component-model/ocm/pkg/mime"
 )
 
 var _ = Describe("virtual repo", func() {
 	var env *TestEnv
 	var repo ocm.Repository
+	var access *example.Access
 
 	// ocmlog.Context().AddRule(logging.NewConditionRule(logging.TraceLevel, accessio.ALLOC_REALM))
-
-	BeforeEach(func() {
-		env = NewTestEnv(TestData())
-		acc := Must(NewAccess(Must(projectionfs.New(env, "testdata"))))
-		repo = virtual.NewRepository(env.OCMContext(), acc)
-	})
 
 	AfterEach(func() {
 		MustBeSuccessful(repo.Close())
 		env.Cleanup()
 	})
 
-	It("handles list", func() {
-		lister := repo.ComponentLister()
-		Expect(lister).NotTo(BeNil())
-		names := Must(lister.GetComponents("", true))
-		Expect(names).To(ConsistOf([]string{"acme.org/component", "acme.org/component/ref"}))
+	Context("readonly", func() {
+		BeforeEach(func() {
+			env = NewTestEnv(TestData())
+			access = Must(example.NewAccess(Must(projectionfs.New(env, "testdata")), true))
+			repo = virtual.NewRepository(env.OCMContext(), access)
+		})
+
+		It("handles list", func() {
+			lister := repo.ComponentLister()
+			Expect(lister).NotTo(BeNil())
+			names := Must(lister.GetComponents("", true))
+			Expect(names).To(ConsistOf([]string{"acme.org/component", "acme.org/component/ref"}))
+		})
+
+		It("handles get", func() {
+			comp := Must(repo.LookupComponent("acme.org/component"))
+			defer Close(comp, "component")
+			Expect(comp.ListVersions()).To(ConsistOf([]string{"v1.0.0"}))
+			Expect(comp.HasVersion("v1.0.0")).To(BeTrue())
+			Expect(comp.HasVersion("v1.0.1")).To(BeFalse())
+			vers := Must(comp.LookupVersion("v1.0.0"))
+			defer Close(vers, "version")
+			r := Must(vers.GetResourceByIndex(0))
+			data := Must(ocmutils.GetResourceData(r))
+			Expect(string(data)).To(Equal("my test data\n"))
+
+			a := Must(r.Access())
+			Expect(a.GetInexpensiveContentVersionIdentity(vers)).To(Equal("sha256:2fdeb101f225dad71efd2dadb92b5aa422169f1884eecb81abdd988d77b68466"))
+		})
 	})
 
-	It("handles get", func() {
-		comp := Must(repo.LookupComponent("acme.org/component"))
-		defer Close(comp, "component")
-		Expect(comp.ListVersions()).To(ConsistOf([]string{"v1.0.0"}))
-		Expect(comp.HasVersion("v1.0.0")).To(BeTrue())
-		Expect(comp.HasVersion("v1.0.1")).To(BeFalse())
-		vers := Must(comp.LookupVersion("v1.0.0"))
-		defer Close(vers, "version")
-		r := Must(vers.GetResourceByIndex(0))
-		data := Must(ocmutils.GetResourceData(r))
-		Expect(string(data)).To(Equal("my test data\n"))
+	Context("modifiable", func() {
+		BeforeEach(func() {
+			env = NewTestEnv(TestData())
 
-		a := Must(r.Access())
-		Expect(a.GetInexpensiveContentVersionIdentity(vers)).To(Equal("sha256:2fdeb101f225dad71efd2dadb92b5aa422169f1884eecb81abdd988d77b68466"))
+			fs := Must(projectionfs.New(env, "testdata"))
+			fs = layerfs.New(memoryfs.New(), fs)
+			access = Must(example.NewAccess(fs, false))
+			repo = virtual.NewRepository(env.OCMContext(), access)
+		})
+
+		It("handles put", func() {
+			var finalize finalizer.Finalizer
+			defer Defer(finalize.Finalize)
+
+			comp := Must(repo.LookupComponent("acme.org/component/new"))
+			finalize.Close(comp, "component")
+			Expect(comp.ListVersions()).To(ConsistOf([]string{}))
+			vers := Must(comp.NewVersion("v1.0.0", false))
+			finalize.Close(vers, "version")
+
+			blob := accessio.BlobAccessForString(mime.MIME_TEXT, "new test data")
+			MustBeSuccessful(vers.SetResourceBlob(compdesc.NewResourceMeta("new", resourcetypes.PLAIN_TEXT, metav1.LocalRelation), blob, "", nil))
+
+			r := Must(vers.GetResourceByIndex(0))
+			a := Must(r.Access())
+			Expect(a.GetKind()).To(Equal(localblob.Type))
+
+			dig := "fe81d80611e39a10f1d7d12f98ce0bc6fe745d08fef007d8eebddc0a21d17827"
+			Expect(a.(*localblob.AccessSpec).LocalReference).To(Equal(dig))
+
+			MustBeSuccessful(finalize.Finalize())
+
+			MustBeSuccessful(access.Reset())
+
+			comp = Must(repo.LookupComponent("acme.org/component/new"))
+			finalize.Close(comp, "component")
+			Expect(comp.ListVersions()).To(ConsistOf([]string{"v1.0.0"}))
+			Expect(comp.HasVersion("v1.0.0")).To(BeTrue())
+			Expect(comp.HasVersion("v1.0.1")).To(BeFalse())
+			vers = Must(comp.LookupVersion("v1.0.0"))
+			finalize.Close(vers, "version")
+			r = Must(vers.GetResourceByIndex(0))
+			data := Must(ocmutils.GetResourceData(r))
+			Expect(string(data)).To(Equal("new test data"))
+
+			a = Must(r.Access())
+			Expect(a.GetInexpensiveContentVersionIdentity(vers)).To(Equal("sha256:" + dig))
+
+		})
 	})
 })
-
-////////////////////////////////////////////////////////////////////////////////
-
-type Index = virtual.Index[interface{}]
-
-type Access struct {
-	fs    vfs.FileSystem
-	index *Index
-}
-
-func NewAccess(fs vfs.FileSystem) (*Access, error) {
-	a := &Access{
-		fs:    fs,
-		index: virtual.NewIndex[interface{}](),
-	}
-
-	list, err := vfs.ReadDir(fs, "descriptors")
-	if err != nil {
-		return nil, err
-	}
-	for _, e := range list {
-		data, err := vfs.ReadFile(fs, path.Join("descriptors", e.Name()))
-		if err != nil {
-			return nil, err
-		}
-		cd, err := compdesc.Decode(data)
-		if err != nil {
-			return nil, err
-		}
-		err = a.index.Add(cd, nil)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return a, nil
-}
-
-func (a *Access) ComponentLister() cpi.ComponentLister {
-	return a.index
-}
-
-func (a *Access) ExistsComponentVersion(name string, version string) (bool, error) {
-	e := a.index.Get(name, version)
-	return e != nil, nil
-}
-
-func (a *Access) ListVersions(comp string) ([]string, error) {
-	return a.index.GetVersions(comp), nil
-}
-
-func (a *Access) GetDescriptor(comp, version string) *compdesc.ComponentDescriptor {
-	return a.index.Get(comp, version).CD()
-
-}
-func (a *Access) GetComponentVersion(comp, version string) (virtual.VersionAccess, error) {
-	cd := a.GetDescriptor(comp, version)
-	if cd == nil {
-		// test is readonly mode
-		return nil, errors.ErrNotFound(cpi.KIND_COMPONENTVERSION, common.NewNameVersion(comp, version).String())
-	}
-	return &VersionAccess{a, cd.GetName(), cd.GetVersion(), cd.Copy()}, nil
-}
-
-func (a *Access) Close() error {
-	return nil
-}
-
-var _ virtual.Access = (*Access)(nil)
-
-type VersionAccess struct {
-	access *Access
-	comp   string
-	vers   string
-	desc   *compdesc.ComponentDescriptor
-}
-
-func (v *VersionAccess) GetDescriptor() *compdesc.ComponentDescriptor {
-	return v.desc
-}
-
-func (v *VersionAccess) GetBlob(name string) (cpi.DataAccess, error) {
-	p := path.Join("blobs", name)
-
-	if ok, err := vfs.FileExists(v.access.fs, p); !ok || err != nil {
-		return nil, vfs.ErrNotExist
-	}
-	return accessio.DataAccessForFile(v.access.fs, p), nil
-}
-
-func (v *VersionAccess) AddBlob(blob cpi.BlobAccess) (string, error) {
-	return "", accessio.ErrReadOnly
-}
-
-func (v *VersionAccess) Update() error {
-	if v.desc.GetName() != v.comp || v.desc.GetVersion() != v.vers {
-		return errors.ErrInvalid(cpi.KIND_COMPONENTVERSION, common.VersionedElementKey(v.desc).String())
-	}
-	if !reflect.DeepEqual(v.desc, v.access.GetDescriptor(v.comp, v.vers)) {
-		return accessio.ErrReadOnly
-	}
-	return nil
-}
-
-func (v *VersionAccess) Close() error {
-	return nil
-}
-
-func (v *VersionAccess) IsReadOnly() bool {
-	return true
-}
-
-func (v *VersionAccess) GetInexpensiveContentVersionIdentity(a cpi.AccessSpec) string {
-	switch a.GetKind() { //nolint:gocritic // to be extended
-	case localblob.Type:
-		blob, err := v.GetBlob(a.(*localblob.AccessSpec).LocalReference)
-		if err != nil {
-			return ""
-		}
-		defer blob.Close()
-		dig, err := accessio.Digest(blob)
-		if err != nil {
-			return ""
-		}
-		return dig.String()
-	}
-	return ""
-}
-
-var _ virtual.VersionAccess = (*VersionAccess)(nil)

--- a/pkg/contexts/ocm/repositories/virtual/repository.go
+++ b/pkg/contexts/ocm/repositories/virtual/repository.go
@@ -44,6 +44,9 @@ func (r *RepositoryImpl) Close() error {
 }
 
 func (r *RepositoryImpl) GetSpecification() cpi.RepositorySpec {
+	if p, ok := r.access.(RepositorySpecProvider); ok {
+		return p.GetSpecification()
+	}
 	return NewRepositorySpec(r.access)
 }
 

--- a/pkg/contexts/ocm/repositories/virtual/repository.go
+++ b/pkg/contexts/ocm/repositories/virtual/repository.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package virtual
+
+import (
+	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
+)
+
+type _RepositoryImplBase = cpi.RepositoryImplBase
+
+type RepositoryImpl struct {
+	_RepositoryImplBase
+	access Access
+	nonref cpi.Repository
+}
+
+var _ cpi.RepositoryImpl = (*RepositoryImpl)(nil)
+
+func NewRepository(ctx cpi.Context, acc Access) cpi.Repository {
+	impl := &RepositoryImpl{
+		_RepositoryImplBase: *cpi.NewRepositoryImplBase(ctx.OCMContext()),
+		access:              acc,
+	}
+	impl.nonref = cpi.NewNoneRefRepositoryView(impl)
+	r := cpi.NewRepository(impl, "OCM repo[Simple]")
+	return r
+}
+
+/*
+func (r *RepositoryImpl) GetConsumerId(uctx ...credentials.UsageContext) credentials.ConsumerIdentity {
+	return nil
+}
+
+func (r *RepositoryImpl) GetIdentityMatcher() string {
+	return ""
+}
+*/
+
+func (r *RepositoryImpl) Close() error {
+	return r.access.Close()
+}
+
+func (r *RepositoryImpl) GetSpecification() cpi.RepositorySpec {
+	return NewRepositorySpec(r.access)
+}
+
+func (r *RepositoryImpl) ComponentLister() cpi.ComponentLister {
+	return r.access.ComponentLister()
+}
+
+func (r *RepositoryImpl) ExistsComponentVersion(name string, version string) (bool, error) {
+	return r.access.ExistsComponentVersion(name, version)
+}
+
+func (r *RepositoryImpl) LookupComponent(name string) (cpi.ComponentAccess, error) {
+	return newComponentAccess(r, name, true)
+}
+
+func (r *RepositoryImpl) LookupComponentVersion(name string, version string) (cpi.ComponentVersionAccess, error) {
+	c, err := newComponentAccess(r, name, false)
+	if err != nil {
+		return nil, err
+	}
+	defer accessio.PropagateCloseTemporary(&err, c) // temporary component object not exposed.
+	return c.LookupVersion(version)
+}

--- a/pkg/contexts/ocm/repositories/virtual/spec.go
+++ b/pkg/contexts/ocm/repositories/virtual/spec.go
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package virtual
+
+import (
+	"github.com/open-component-model/ocm/pkg/contexts/credentials"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/internal"
+	"github.com/open-component-model/ocm/pkg/runtime"
+)
+
+const (
+	Type   = "Virtual"
+	TypeV1 = Type + runtime.VersionSeparator + "v1"
+)
+
+type RepositorySpec struct {
+	runtime.ObjectVersionedTypedObject
+	Access Access `json:"-"`
+}
+
+func NewRepositorySpec(acc Access) *RepositorySpec {
+	return &RepositorySpec{
+		ObjectVersionedTypedObject: runtime.NewVersionedTypedObject(Type),
+		Access:                     acc,
+	}
+}
+
+func (r RepositorySpec) AsUniformSpec(context internal.Context) *cpi.UniformRepositorySpec {
+	return nil
+}
+
+func (r *RepositorySpec) Repository(ctx cpi.Context, credentials credentials.Credentials) (internal.Repository, error) {
+	return NewRepository(ctx, r.Access), nil
+}
+
+var _ cpi.RepositorySpec = (*RepositorySpec)(nil)

--- a/pkg/contexts/ocm/repositories/virtual/suite_test.go
+++ b/pkg/contexts/ocm/repositories/virtual/suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package virtual_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OCM Virtual Repository Suite")
+}

--- a/pkg/contexts/ocm/repositories/virtual/testdata/blobs/blob1
+++ b/pkg/contexts/ocm/repositories/virtual/testdata/blobs/blob1
@@ -1,0 +1,1 @@
+my test data

--- a/pkg/contexts/ocm/repositories/virtual/testdata/blobs/blob2
+++ b/pkg/contexts/ocm/repositories/virtual/testdata/blobs/blob2
@@ -1,0 +1,1 @@
+my second test data

--- a/pkg/contexts/ocm/repositories/virtual/testdata/descriptors/cd1.yaml
+++ b/pkg/contexts/ocm/repositories/virtual/testdata/descriptors/cd1.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+meta:
+  schemaVersion: 'v2'
+
+component:
+  name: acme.org/component
+  version: v1.0.0
+
+  provider: acme.org
+
+  sources: []
+  resources:
+    - name: text
+      version: v1.0.0
+      type: plainText
+      relation: local
+      access:
+        type: localBlob
+        localReference: blob1
+  componentReferences: []
+  repositoryContexts: []

--- a/pkg/contexts/ocm/repositories/virtual/testdata/descriptors/cd2.yaml
+++ b/pkg/contexts/ocm/repositories/virtual/testdata/descriptors/cd2.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+meta:
+  schemaVersion: 'v2'
+
+component:
+  name: acme.org/component/ref
+  version: v1.0.0
+
+  provider: acme.org
+
+  sources: []
+  componentReferences:
+    - name: ref
+      componentName: acme.org/component
+      version: v1.0.0
+
+  resources:
+    - name: other
+      version: v1.0.0
+      type: plainText
+      relation: local
+      access:
+        type: localBlob
+        localReference: blob2
+
+  repositoryContexts: []

--- a/pkg/contexts/ocm/utils/configure.go
+++ b/pkg/contexts/ocm/utils/configure.go
@@ -47,7 +47,7 @@ func Configure(ctx ocm.Context, path string, fss ...vfs.FileSystem) (ocm.Context
 			}
 		}
 	}
-	if path != "" {
+	if path != "" && path != "None" {
 		if strings.HasPrefix(path, "~"+string(os.PathSeparator)) {
 			if len(h) == 0 {
 				return nil, fmt.Errorf("no home directory found for resolving path of ocm config file %q", path)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR provides an OCM repository implementation based on two simple implementation interfaces, These interfaces 
can be implemented to provide virtual repositories based on some mapping of existing data structures.

It is intended to map OCM information provided in some context to be presented as complete OCM repository.
This will be used to map the inline OCM component descriptors optionally provided by a *Landscaper Installation*
to an OCM repository view. This enables to use those virtual environments exactly like a regular OCM repository context,
which avoids special cases for the regular installation processing coding.

An example implementation of these interfaces is based on some files in a virtual filesystem. It is used for the test cases, also.

This OCM repository wrapper based on those interface supports complete reference handling and readonly mode as well as
modifiable virtual environments.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
