### PR TITLE
check for existing transfer target not matching the source

### DIFF
--- a/pkg/contexts/ocm/compdesc/componentdescriptor.go
+++ b/pkg/contexts/ocm/compdesc/componentdescriptor.go
@@ -286,6 +286,7 @@ type ObjectMetaAccessor interface {
 // ElementMetaAccessor provides generic access an elements meta information.
 type ElementMetaAccessor interface {
 	GetMeta() *ElementMeta
+	IsEquivalent(ElementMetaAccessor) bool
 }
 
 // ElementAccessor provides generic access to list of elements.
@@ -369,6 +370,20 @@ type Source struct {
 
 func (s *Source) GetMeta() *ElementMeta {
 	return &s.ElementMeta
+}
+
+func (r *Source) IsEquivalent(e ElementMetaAccessor) bool {
+	if o, ok := e.(*Source); !ok {
+		return false
+	} else {
+		if !reflect.DeepEqual(&r.ElementMeta, &o.ElementMeta) {
+			return false
+		}
+		if !reflect.DeepEqual(&r.Access, &o.Access) {
+			return false
+		}
+		return r.Type == o.Type
+	}
 }
 
 func (s *Source) GetAccess() AccessSpec {
@@ -494,6 +509,22 @@ type Resource struct {
 
 func (r *Resource) GetMeta() *ElementMeta {
 	return &r.ElementMeta
+}
+
+func (r *Resource) IsEquivalent(e ElementMetaAccessor) bool {
+	if o, ok := e.(*Resource); !ok {
+		return false
+	} else {
+		if !reflect.DeepEqual(&r.ElementMeta, &o.ElementMeta) {
+			return false
+		}
+		if !reflect.DeepEqual(&r.Access, &o.Access) {
+			return false
+		}
+		return r.Type == o.Type &&
+			r.Relation == o.Relation &&
+			reflect.DeepEqual(r.SourceRef, o.SourceRef)
+	}
 }
 
 func (r *Resource) GetAccess() AccessSpec {
@@ -649,6 +680,17 @@ func (r ComponentReference) String() string {
 
 func (r *ComponentReference) GetMeta() *ElementMeta {
 	return &r.ElementMeta
+}
+
+func (r *ComponentReference) IsEquivalent(e ElementMetaAccessor) bool {
+	if o, ok := e.(*ComponentReference); !ok {
+		return false
+	} else {
+		if !reflect.DeepEqual(&r.ElementMeta, &o.ElementMeta) {
+			return false
+		}
+		return r.ComponentName == o.ComponentName
+	}
 }
 
 func (r *ComponentReference) GetComponentName() string {

--- a/pkg/contexts/ocm/compdesc/equal.go
+++ b/pkg/contexts/ocm/compdesc/equal.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package compdesc
+
+import (
+	"reflect"
+)
+
+func (cd *ComponentDescriptor) Equal(o *ComponentDescriptor) bool {
+	o = o.Copy()
+	o.Metadata.ConfiguredVersion = cd.Metadata.ConfiguredVersion
+	o.RepositoryContexts = cd.RepositoryContexts
+
+	return reflect.DeepEqual(cd, o)
+}
+
+func (cd *ComponentDescriptor) Equivalent(o *ComponentDescriptor) bool {
+	if !reflect.DeepEqual(&cd.ObjectMeta, &o.ObjectMeta) {
+		return false
+	}
+
+	if !equivalentElems(cd.Resources, o.Resources) {
+		return false
+	}
+	if !equivalentElems(cd.Sources, o.Sources) {
+		return false
+	}
+	if !equivalentElems(cd.References, o.References) {
+		return false
+	}
+	return true
+}
+
+func equivalentElems(a ElementAccessor, b ElementAccessor) bool {
+	if a.Len() != b.Len() {
+		return false
+	}
+
+	for i := 0; i < a.Len(); i++ {
+		if !a.Get(i).IsEquivalent(b.Get(i)) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/contexts/ocm/transfer/transfer.go
+++ b/pkg/contexts/ocm/transfer/transfer.go
@@ -66,11 +66,15 @@ func transferVersion(printer common.Printer, log logging.Logger, state WalkingSt
 			defer accessio.Close(t)
 		}
 	} else {
-		var ok bool
-		ok, err = handler.OverwriteVersion(src, t)
-		if !ok {
+		if d.Equal(t.GetDescriptor()) {
 			printer.Printf("  version %q already present -> skip transport\n", nv)
-			return nil
+		} else {
+			var ok bool
+			ok, err = handler.OverwriteVersion(src, t)
+			if !ok {
+				printer.Printf("  version %q already present, but differs\n", nv)
+				return errors.ErrAlreadyExists(ocm.KIND_COMPONENTVERSION, nv.String())
+			}
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

During a transfer a potentially already existing target version is checked to be equal to the source version before just omitting
the transport. If it is not equal an error is provided.

**Which issue(s) this PR fixes**:
Fixes #387

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
