### PR TITLE
fix evaluation of docker config file

### DIFF
--- a/pkg/contexts/credentials/repositories/dockerconfig/provider.go
+++ b/pkg/contexts/credentials/repositories/dockerconfig/provider.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/identity"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 const PROVIDER = "ocm.software/credentialprovider/" + Type
@@ -44,11 +45,15 @@ func (p *ConsumerProvider) get(req cpi.ConsumerIdentity, cur cpi.ConsumerIdentit
 	var creds cpi.CredentialsSource
 
 	for h, a := range all {
-		hostname := dockercred.ConvertToHostname(h)
+		hostname, port, _ := utils.SplitLocator(dockercred.ConvertToHostname(h))
 		if hostname == "index.docker.io" {
 			hostname = "docker.io"
 		}
-		id := cpi.NewConsumerIdentity(identity.CONSUMER_TYPE, identity.ID_HOSTNAME, hostname)
+		attrs := []string{identity.ID_HOSTNAME, hostname}
+		if port != "" {
+			attrs = append(attrs, identity.ID_PORT, port)
+		}
+		id := cpi.NewConsumerIdentity(identity.CONSUMER_TYPE, attrs...)
 		if m(req, cur, id) {
 			if IsEmptyAuthConfig(a) {
 				store := store


### PR DESCRIPTION
**What this PR does / why we need it**:

In the docker config file the auth map may contain host:port pairs as keys. This is not correctly handled
in the credentials repository implementation for dockerconfig.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
