### PR TITLE
fix and extend label access functions

### DIFF
--- a/pkg/contexts/ocm/compdesc/meta/v1/labels.go
+++ b/pkg/contexts/ocm/compdesc/meta/v1/labels.go
@@ -79,6 +79,27 @@ func (l Labels) Get(name string) ([]byte, bool) {
 	return nil, false
 }
 
+// GetIndex returns the index of the label with the given name,
+// or -1 if not found.
+func (l Labels) GetIndex(name string) int {
+	for i, label := range l {
+		if label.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// GetDef returns the label object with the given name.
+func (l Labels) GetDef(name string) *Label {
+	for _, label := range l {
+		if label.Name == name {
+			return &label
+		}
+	}
+	return nil
+}
+
 // GetValue returns the label value with the given name as parsed object.
 func (l Labels) GetValue(name string, dest interface{}) (bool, error) {
 	for _, label := range l {
@@ -89,14 +110,32 @@ func (l Labels) GetValue(name string, dest interface{}) (bool, error) {
 	return false, nil
 }
 
+// Set sets or modifies a label including its meta data.
 func (l *Labels) Set(name string, value interface{}, opts ...LabelOption) error {
 	newLabel, err := NewLabel(name, value, opts...)
 	if err != nil {
 		return err
 	}
-	for _, label := range *l {
+	for i, label := range *l {
 		if label.Name == name {
-			label.Value = newLabel.Value
+			(*l)[i] = *newLabel
+			return nil
+		}
+	}
+	*l = append(*l, *newLabel)
+	return nil
+}
+
+// SetValue sets or modifies the value of a label, the label meta data
+// is not touched.
+func (l *Labels) SetValue(name string, value interface{}) error {
+	newLabel, err := NewLabel(name, value)
+	if err != nil {
+		return err
+	}
+	for i, label := range *l {
+		if label.Name == name {
+			(*l)[i].Value = newLabel.Value
 			return nil
 		}
 	}

--- a/pkg/contexts/ocm/compdesc/meta/v1/labels_test.go
+++ b/pkg/contexts/ocm/compdesc/meta/v1/labels_test.go
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
+	. "github.com/open-component-model/ocm/pkg/testutils"
+)
+
+var _ = Describe("labels", func() {
+	Context("access", func() {
+		It("modififies label set", func() {
+			labels := v1.Labels{}
+
+			MustBeSuccessful(labels.Set("l1", "v1"))
+			MustBeSuccessful(labels.Set("l2", "v2", v1.WithSigning()))
+			MustBeSuccessful(labels.Set("l3", "v3", v1.WithSigning(), v1.WithVersion("v10")))
+			MustBeSuccessful(labels.Set("l4", "v4", v1.WithVersion("v11")))
+
+			Expect(labels).To(ConsistOf(
+				v1.Label{
+					Name:  "l1",
+					Value: []byte(`"v1"`),
+				},
+				v1.Label{
+					Name:    "l2",
+					Value:   []byte(`"v2"`),
+					Signing: true,
+				},
+				v1.Label{
+					Name:    "l3",
+					Value:   []byte(`"v3"`),
+					Signing: true,
+					Version: "v10",
+				},
+				v1.Label{
+					Name:    "l4",
+					Value:   []byte(`"v4"`),
+					Version: "v11",
+				},
+			))
+
+			Expect(labels.GetDef("l3")).To(Equal(&v1.Label{
+				Name:    "l3",
+				Value:   []byte(`"v3"`),
+				Signing: true,
+				Version: "v10",
+			}))
+
+			Expect(labels.GetIndex("l3")).To(Equal(2))
+			Expect(labels.GetIndex("lx")).To(Equal(-1))
+			data, ok := labels.Get("l3")
+			Expect(ok).To(BeTrue())
+			Expect(data).To(Equal([]byte(`"v3"`)))
+			var str string
+			Expect(labels.GetValue("l3", &str)).To(BeTrue())
+			Expect(str).To(Equal("v3"))
+
+			// Modify
+
+			labels.Set("l4", "modl4", v1.WithVersion("v100"))
+			Expect(labels).To(ConsistOf(
+				v1.Label{
+					Name:  "l1",
+					Value: []byte(`"v1"`),
+				},
+				v1.Label{
+					Name:    "l2",
+					Value:   []byte(`"v2"`),
+					Signing: true,
+				},
+				v1.Label{
+					Name:    "l3",
+					Value:   []byte(`"v3"`),
+					Signing: true,
+					Version: "v10",
+				},
+				v1.Label{
+					Name:    "l4",
+					Value:   []byte(`"modl4"`),
+					Version: "v100",
+				},
+			))
+			Expect(labels.GetDef("l4")).To(Equal(&v1.Label{
+				Name:    "l4",
+				Value:   []byte(`"modl4"`),
+				Version: "v100",
+			}))
+		})
+
+		It("handles complex values", func() {
+			var labels v1.Labels
+
+			var nested v1.Labels
+			nested.Set("label", "value", v1.WithSigning())
+			meta := &v1.ObjectMeta{
+				Name:    "value",
+				Version: "v1.0.0",
+				Labels:  nested,
+				Provider: v1.Provider{
+					Name:   "acme.org",
+					Labels: nested,
+				},
+				CreationTime: nil,
+			}
+
+			labels.Set("l1", meta)
+			Expect(labels).To(ConsistOf(
+				v1.Label{
+					Name:  "l1",
+					Value: []byte(`{"name":"value","version":"v1.0.0","labels":[{"name":"label","value":"value","signing":true}],"provider":{"name":"acme.org","labels":[{"name":"label","value":"value","signing":true}]}}`),
+				},
+			))
+			var get v1.ObjectMeta
+			Expect(labels.GetValue("l1", &get)).To(BeTrue())
+			Expect(&get).To(Equal(meta))
+		})
+	})
+})

--- a/pkg/contexts/ocm/compdesc/meta/v1/suite_test.go
+++ b/pkg/contexts/ocm/compdesc/meta/v1/suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Component Descriptor Meta Test Suite")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The `Set` for the label set cannot modify existing labels correctly. This is fixed.
 Additionally, some useful access methods for labels and tests are added.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
