### PR TITLE
extend utf8 input type to accept and generate YAML/JSON content

### DIFF
--- a/cmds/ocm/commands/ocmcmds/common/inputs/options/standard.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/options/standard.go
@@ -41,4 +41,10 @@ var DataOption = flagsets.NewBytesOptionType("inputData", "data (string, !!strin
 
 var TextOption = flagsets.NewStringOptionType("inputText", "utf8 text")
 
+var YAMLOption = flagsets.NewYAMLOptionType("inputYaml", "YAML formatted text")
+
+var JSONOption = flagsets.NewYAMLOptionType("inputJson", "JSON formatted text")
+
+var FormattedJSONOption = flagsets.NewYAMLOptionType("inputFormattedJson", "JSON formatted text")
+
 var HelmRepositoryOption = flagsets.NewStringOptionType("inputHelmRepository", "helm repository base URL")

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/utf8/cli.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/utf8/cli.go
@@ -11,12 +11,16 @@ import (
 )
 
 func ConfigHandler() flagsets.ConfigOptionTypeSetHandler {
-	set := flagsets.NewConfigOptionTypeSetHandler(TYPE, AddConfig, options.TextOption)
+	set := flagsets.NewConfigOptionTypeSetHandler(TYPE, AddConfig,
+		options.TextOption, options.JSONOption, options.FormattedJSONOption, options.YAMLOption)
 	cpi.AddProcessSpecOptionTypes(set)
 	return set
 }
 
 func AddConfig(opts flagsets.ConfigOptions, config flagsets.Config) error {
 	flagsets.AddFieldByOptionP(opts, options.TextOption, config, "text")
+	flagsets.AddFieldByOptionP(opts, options.JSONOption, config, "json")
+	flagsets.AddFieldByOptionP(opts, options.FormattedJSONOption, config, "formattedJson")
+	flagsets.AddFieldByOptionP(opts, options.YAMLOption, config, "yaml")
 	return cpi.AddProcessSpecConfig(opts, config)
 }

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/utf8/inputtype_test.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/utf8/inputtype_test.go
@@ -6,26 +6,131 @@ package utf8
 
 import (
 	. "github.com/onsi/ginkgo/v2"
-	. "github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs/testutils"
-
+	. "github.com/onsi/gomega"
+	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs/cpi"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs/options"
+	. "github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs/testutils"
+	"github.com/open-component-model/ocm/pkg/contexts/clictx"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 )
 
 var _ = Describe("Input Type", func() {
-	var env *InputTest
+	Context("options", func() {
+		var env *InputTest
 
-	BeforeEach(func() {
-		env = NewInputTest(TYPE)
+		BeforeEach(func() {
+			env = NewInputTest(TYPE)
+		})
+
+		It("simple string decode", func() {
+			env.Set(options.CompressOption, "true")
+			env.Set(options.MediaTypeOption, "media")
+			env.Set(options.TextOption, "stringdata")
+			env.Check(&Spec{
+				Text:        "stringdata",
+				ProcessSpec: cpi.NewProcessSpec("media", true),
+			})
+		})
+
+		It("simple json decode", func() {
+			env.Set(options.CompressOption, "true")
+			env.Set(options.MediaTypeOption, "media")
+			env.Set(options.JSONOption, `field: value`)
+			env.Check(&Spec{
+				Json:        []byte(`{"field":"value"}`),
+				ProcessSpec: cpi.NewProcessSpec("media", true),
+			})
+		})
+
+		It("simple formatted json decode", func() {
+			env.Set(options.CompressOption, "true")
+			env.Set(options.MediaTypeOption, "media")
+			env.Set(options.FormattedJSONOption, `field: value`)
+			env.Check(&Spec{
+				FormattedJson: []byte(`{"field":"value"}`),
+				ProcessSpec:   cpi.NewProcessSpec("media", true),
+			})
+		})
+
+		It("simple yaml decode", func() {
+			env.Set(options.CompressOption, "true")
+			env.Set(options.MediaTypeOption, "media")
+			env.Set(options.YAMLOption, `field: value`)
+			env.Check(&Spec{
+				Yaml:        []byte(`{"field":"value"}`),
+				ProcessSpec: cpi.NewProcessSpec("media", true),
+			})
+		})
 	})
 
-	It("simple string decode", func() {
-		env.Set(options.CompressOption, "true")
-		env.Set(options.MediaTypeOption, "media")
-		env.Set(options.TextOption, "stringdata")
-		env.Check(&Spec{
-			Text:        "stringdata",
-			ProcessSpec: cpi.NewProcessSpec("media", true),
+	Context("blob", func() {
+		ctx := inputs.NewContext(clictx.DefaultContext(), nil, nil)
+
+		It("handles text", func() {
+			inp := New("stringdata", "media", false)
+
+			a, info := Must2(inp.GetBlob(ctx, inputs.InputResourceInfo{}))
+			Expect(a.MimeType()).To(Equal("media"))
+			Expect(a.Get()).To(Equal([]byte("stringdata")))
+			Expect(info).To(Equal(""))
+		})
+
+		It("handles json from string", func() {
+			inp := Must(NewJson("field: value", "media", false))
+
+			a, info := Must2(inp.GetBlob(ctx, inputs.InputResourceInfo{}))
+			Expect(a.MimeType()).To(Equal("media"))
+			Expect(a.Get()).To(Equal([]byte(`{"field":"value"}`)))
+			Expect(info).To(Equal(""))
+		})
+		It("handles json", func() {
+			inp := Must(NewJson(map[string]interface{}{"field": "value"}, "media", false))
+
+			a, info := Must2(inp.GetBlob(ctx, inputs.InputResourceInfo{}))
+			Expect(a.MimeType()).To(Equal("media"))
+			Expect(a.Get()).To(Equal([]byte(`{"field":"value"}`)))
+			Expect(info).To(Equal(""))
+		})
+
+		It("handles formatted json from string", func() {
+			inp := Must(NewFormattedJson("field: value", "media", false))
+
+			a, info := Must2(inp.GetBlob(ctx, inputs.InputResourceInfo{}))
+			Expect(a.MimeType()).To(Equal("media"))
+			Expect(a.Get()).To(Equal([]byte(`{
+  "field": "value"
+}`)))
+			Expect(info).To(Equal(""))
+		})
+		It("handles formatted json", func() {
+			inp := Must(NewFormattedJson(map[string]interface{}{"field": "value"}, "media", false))
+
+			a, info := Must2(inp.GetBlob(ctx, inputs.InputResourceInfo{}))
+			Expect(a.MimeType()).To(Equal("media"))
+			Expect(a.Get()).To(Equal([]byte(`{
+  "field": "value"
+}`)))
+			Expect(info).To(Equal(""))
+		})
+
+		It("handles yaml from string", func() {
+			inp := Must(NewYaml("field: value", "media", false))
+
+			a, info := Must2(inp.GetBlob(ctx, inputs.InputResourceInfo{}))
+			Expect(a.MimeType()).To(Equal("media"))
+			Expect(a.Get()).To(Equal([]byte(`field: value
+`)))
+			Expect(info).To(Equal(""))
+		})
+		It("handles yaml", func() {
+			inp := Must(NewYaml(map[string]interface{}{"field": "value"}, "media", false))
+
+			a, info := Must2(inp.GetBlob(ctx, inputs.InputResourceInfo{}))
+			Expect(a.MimeType()).To(Equal("media"))
+			Expect(a.Get()).To(Equal([]byte(`field: value
+`)))
+			Expect(info).To(Equal(""))
 		})
 	})
 })

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/utf8/spec.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/utf8/spec.go
@@ -5,6 +5,8 @@
 package utf8
 
 import (
+	"encoding/json"
+
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs"
@@ -18,7 +20,10 @@ type Spec struct {
 	cpi.ProcessSpec      `json:",inline"`
 
 	// Text is an utf8 string
-	Text string `json:"text,omitempty"`
+	Text          string          `json:"text,omitempty"`
+	Json          json.RawMessage `json:"json,omitempty"`
+	FormattedJson json.RawMessage `json:"formattedJson,omitempty"`
+	Yaml          json.RawMessage `json:"yaml,omitempty"`
 }
 
 var _ inputs.InputSpec = (*Spec)(nil)
@@ -35,10 +40,136 @@ func New(text string, mediatype string, compress bool) *Spec {
 	}
 }
 
+func NewJson(data interface{}, mediatype string, compress bool) (*Spec, error) {
+	raw, err := runtime.DefaultJSONEncoding.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	return &Spec{
+		InputSpecBase: inputs.InputSpecBase{
+			ObjectVersionedType: runtime.ObjectVersionedType{
+				Type: TYPE,
+			},
+		},
+		ProcessSpec: cpi.NewProcessSpec(mediatype, compress),
+		Json:        json.RawMessage(raw),
+	}, nil
+}
+
+func NewFormattedJson(data interface{}, mediatype string, compress bool) (*Spec, error) {
+	raw, err := runtime.DefaultJSONEncoding.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	return &Spec{
+		InputSpecBase: inputs.InputSpecBase{
+			ObjectVersionedType: runtime.ObjectVersionedType{
+				Type: TYPE,
+			},
+		},
+		ProcessSpec:   cpi.NewProcessSpec(mediatype, compress),
+		FormattedJson: json.RawMessage(raw),
+	}, nil
+}
+
+func NewYaml(data interface{}, mediatype string, compress bool) (*Spec, error) {
+	raw, err := runtime.DefaultJSONEncoding.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	return &Spec{
+		InputSpecBase: inputs.InputSpecBase{
+			ObjectVersionedType: runtime.ObjectVersionedType{
+				Type: TYPE,
+			},
+		},
+		ProcessSpec: cpi.NewProcessSpec(mediatype, compress),
+		Yaml:        json.RawMessage(raw),
+	}, nil
+}
+
 func (s *Spec) Validate(fldPath *field.Path, ctx inputs.Context, inputFilePath string) field.ErrorList {
+	cnt := 0
+	if s.Text != "" {
+		cnt++
+	}
+	if s.Json != nil {
+		cnt++
+	}
+	if s.FormattedJson != nil {
+		cnt++
+	}
+	if s.Yaml != nil {
+		cnt++
+	}
+	if cnt > 1 {
+		allErrs := field.ErrorList{}
+		allErrs = append(allErrs, field.Forbidden(fldPath, "only one of the fields text, json, formattedJson or yaml can be set"))
+		return allErrs
+	}
 	return nil
 }
 
 func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.TemporaryBlobAccess, string, error) {
-	return s.ProcessBlob(ctx, accessio.DataAccessForBytes([]byte(s.Text)), ctx.FileSystem())
+	data, err := Plain([]byte(s.Text))
+
+	if s.Json != nil {
+		data, err = Json(s.Json)
+	}
+	if s.FormattedJson != nil {
+		data, err = FormattedJson(s.FormattedJson)
+	}
+	if s.Yaml != nil {
+		data, err = Yaml(s.Yaml)
+	}
+	if err != nil {
+		return nil, "", err
+	}
+	return s.ProcessBlob(ctx, accessio.DataAccessForBytes(data), ctx.FileSystem())
+}
+
+func Prepare(raw []byte) (interface{}, error) {
+	var v interface{}
+	err := runtime.DefaultJSONEncoding.Unmarshal(raw, &v)
+	if err != nil {
+		return nil, err
+	}
+	if s, ok := v.(string); ok {
+		v = nil
+		err := runtime.DefaultYAMLEncoding.Unmarshal([]byte(s), &v)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return v, nil
+}
+
+type OutputFormat func(data []byte) ([]byte, error)
+
+func Plain(data []byte) ([]byte, error) {
+	return data, nil
+}
+
+func Json(raw []byte) ([]byte, error) {
+	v, err := Prepare(raw)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(v)
+}
+
+func FormattedJson(raw []byte) ([]byte, error) {
+	v, err := Prepare(raw)
+	if err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(v, "", "  ")
+}
+
+func Yaml(raw []byte) ([]byte, error) {
+	v, err := Prepare(raw)
+	if err != nil {
+		return nil, err
+	}
+	return runtime.DefaultYAMLEncoding.Marshal(v)
 }

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/utf8/type.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/utf8/type.go
@@ -22,4 +22,16 @@ specification supports the following fields:
 - **<code>text</code>** *string*
 
   The utf8 string content to provide.
+
+- **<code>json</code>** *JSON or JSON string interpreted as JSON*
+
+  The content emitted as JSON.
+
+- **<code>formattedJson</code>** *YAML/JSON or JSON/YAML string interpreted as JSON*
+
+  The content emitted as formatted JSON.
+
+- **<code>yaml</code>** *AML/JSON or JSON/YAML string interpreted as YAML*
+
+  The content emitted as YAML.
 ` + cpi.ProcessSpecUsage

--- a/docs/reference/ocm_add_resource-configuration.md
+++ b/docs/reference/ocm_add_resource-configuration.md
@@ -51,8 +51,10 @@ resource-configuration, resourceconfig, rsccfg, rcfg
       --inputData !bytesBase64       data (string, !!string or !<base64>
       --inputExcludes stringArray    excludes (path) for inputs
       --inputFollowSymlinks          follow symbolic links during archive creation for inputs
+      --inputFormattedJson YAML      JSON formatted text
       --inputHelmRepository string   helm repository base URL
       --inputIncludes stringArray    includes (path) for inputs
+      --inputJson YAML               JSON formatted text
       --inputLibraries stringArray   library path for inputs
       --inputPath string             path field for input
       --inputPreserveDir             preserve directory in archive for inputs
@@ -61,6 +63,7 @@ resource-configuration, resourceconfig, rsccfg, rcfg
       --inputValues YAML             YAML based generic values for inputs
       --inputVariants stringArray    (platform) variants for inputs
       --inputVersion stringArray     version info for inputs
+      --inputYaml YAML               YAML formatted text
       --mediaType string             media type for artifact blob representation
 ```
 
@@ -410,6 +413,18 @@ with the field <code>type</code> in the <code>input</code> field:
   
     The utf8 string content to provide.
   
+  - **<code>json</code>** *JSON or JSON string interpreted as JSON*
+  
+    The content emitted as JSON.
+  
+  - **<code>formattedJson</code>** *YAML/JSON or JSON/YAML string interpreted as JSON*
+  
+    The content emitted as formatted JSON.
+  
+  - **<code>yaml</code>** *AML/JSON or JSON/YAML string interpreted as YAML*
+  
+    The content emitted as YAML.
+  
   - **<code>mediaType</code>** *string*
   
     This OPTIONAL property describes the media type to store with the local blob.
@@ -421,7 +436,7 @@ with the field <code>type</code> in the <code>input</code> field:
     This OPTIONAL property describes whether the content should be stored
     compressed or not.
   
-  Options used to configure fields: <code>--inputCompress</code>, <code>--inputText</code>, <code>--mediaType</code>
+  Options used to configure fields: <code>--inputCompress</code>, <code>--inputFormattedJson</code>, <code>--inputJson</code>, <code>--inputText</code>, <code>--inputYaml</code>, <code>--mediaType</code>
 
 The following list describes the supported access methods, their versions
 and specification formats.

--- a/docs/reference/ocm_add_resources.md
+++ b/docs/reference/ocm_add_resources.md
@@ -56,8 +56,10 @@ resources, resource, res, r
       --inputData !bytesBase64       data (string, !!string or !<base64>
       --inputExcludes stringArray    excludes (path) for inputs
       --inputFollowSymlinks          follow symbolic links during archive creation for inputs
+      --inputFormattedJson YAML      JSON formatted text
       --inputHelmRepository string   helm repository base URL
       --inputIncludes stringArray    includes (path) for inputs
+      --inputJson YAML               JSON formatted text
       --inputLibraries stringArray   library path for inputs
       --inputPath string             path field for input
       --inputPreserveDir             preserve directory in archive for inputs
@@ -66,6 +68,7 @@ resources, resource, res, r
       --inputValues YAML             YAML based generic values for inputs
       --inputVariants stringArray    (platform) variants for inputs
       --inputVersion stringArray     version info for inputs
+      --inputYaml YAML               YAML formatted text
       --mediaType string             media type for artifact blob representation
 ```
 
@@ -419,6 +422,18 @@ with the field <code>type</code> in the <code>input</code> field:
   
     The utf8 string content to provide.
   
+  - **<code>json</code>** *JSON or JSON string interpreted as JSON*
+  
+    The content emitted as JSON.
+  
+  - **<code>formattedJson</code>** *YAML/JSON or JSON/YAML string interpreted as JSON*
+  
+    The content emitted as formatted JSON.
+  
+  - **<code>yaml</code>** *AML/JSON or JSON/YAML string interpreted as YAML*
+  
+    The content emitted as YAML.
+  
   - **<code>mediaType</code>** *string*
   
     This OPTIONAL property describes the media type to store with the local blob.
@@ -430,7 +445,7 @@ with the field <code>type</code> in the <code>input</code> field:
     This OPTIONAL property describes whether the content should be stored
     compressed or not.
   
-  Options used to configure fields: <code>--inputCompress</code>, <code>--inputText</code>, <code>--mediaType</code>
+  Options used to configure fields: <code>--inputCompress</code>, <code>--inputFormattedJson</code>, <code>--inputJson</code>, <code>--inputText</code>, <code>--inputYaml</code>, <code>--mediaType</code>
 
 The following list describes the supported access methods, their versions
 and specification formats.

--- a/docs/reference/ocm_add_source-configuration.md
+++ b/docs/reference/ocm_add_source-configuration.md
@@ -51,8 +51,10 @@ source-configuration, sourceconfig, srccfg, scfg
       --inputData !bytesBase64       data (string, !!string or !<base64>
       --inputExcludes stringArray    excludes (path) for inputs
       --inputFollowSymlinks          follow symbolic links during archive creation for inputs
+      --inputFormattedJson YAML      JSON formatted text
       --inputHelmRepository string   helm repository base URL
       --inputIncludes stringArray    includes (path) for inputs
+      --inputJson YAML               JSON formatted text
       --inputLibraries stringArray   library path for inputs
       --inputPath string             path field for input
       --inputPreserveDir             preserve directory in archive for inputs
@@ -61,6 +63,7 @@ source-configuration, sourceconfig, srccfg, scfg
       --inputValues YAML             YAML based generic values for inputs
       --inputVariants stringArray    (platform) variants for inputs
       --inputVersion stringArray     version info for inputs
+      --inputYaml YAML               YAML formatted text
       --mediaType string             media type for artifact blob representation
 ```
 
@@ -410,6 +413,18 @@ with the field <code>type</code> in the <code>input</code> field:
   
     The utf8 string content to provide.
   
+  - **<code>json</code>** *JSON or JSON string interpreted as JSON*
+  
+    The content emitted as JSON.
+  
+  - **<code>formattedJson</code>** *YAML/JSON or JSON/YAML string interpreted as JSON*
+  
+    The content emitted as formatted JSON.
+  
+  - **<code>yaml</code>** *AML/JSON or JSON/YAML string interpreted as YAML*
+  
+    The content emitted as YAML.
+  
   - **<code>mediaType</code>** *string*
   
     This OPTIONAL property describes the media type to store with the local blob.
@@ -421,7 +436,7 @@ with the field <code>type</code> in the <code>input</code> field:
     This OPTIONAL property describes whether the content should be stored
     compressed or not.
   
-  Options used to configure fields: <code>--inputCompress</code>, <code>--inputText</code>, <code>--mediaType</code>
+  Options used to configure fields: <code>--inputCompress</code>, <code>--inputFormattedJson</code>, <code>--inputJson</code>, <code>--inputText</code>, <code>--inputYaml</code>, <code>--mediaType</code>
 
 The following list describes the supported access methods, their versions
 and specification formats.

--- a/docs/reference/ocm_add_sources.md
+++ b/docs/reference/ocm_add_sources.md
@@ -56,8 +56,10 @@ sources, source, src, s
       --inputData !bytesBase64       data (string, !!string or !<base64>
       --inputExcludes stringArray    excludes (path) for inputs
       --inputFollowSymlinks          follow symbolic links during archive creation for inputs
+      --inputFormattedJson YAML      JSON formatted text
       --inputHelmRepository string   helm repository base URL
       --inputIncludes stringArray    includes (path) for inputs
+      --inputJson YAML               JSON formatted text
       --inputLibraries stringArray   library path for inputs
       --inputPath string             path field for input
       --inputPreserveDir             preserve directory in archive for inputs
@@ -66,6 +68,7 @@ sources, source, src, s
       --inputValues YAML             YAML based generic values for inputs
       --inputVariants stringArray    (platform) variants for inputs
       --inputVersion stringArray     version info for inputs
+      --inputYaml YAML               YAML formatted text
       --mediaType string             media type for artifact blob representation
 ```
 
@@ -417,6 +420,18 @@ with the field <code>type</code> in the <code>input</code> field:
   
     The utf8 string content to provide.
   
+  - **<code>json</code>** *JSON or JSON string interpreted as JSON*
+  
+    The content emitted as JSON.
+  
+  - **<code>formattedJson</code>** *YAML/JSON or JSON/YAML string interpreted as JSON*
+  
+    The content emitted as formatted JSON.
+  
+  - **<code>yaml</code>** *AML/JSON or JSON/YAML string interpreted as YAML*
+  
+    The content emitted as YAML.
+  
   - **<code>mediaType</code>** *string*
   
     This OPTIONAL property describes the media type to store with the local blob.
@@ -428,7 +443,7 @@ with the field <code>type</code> in the <code>input</code> field:
     This OPTIONAL property describes whether the content should be stored
     compressed or not.
   
-  Options used to configure fields: <code>--inputCompress</code>, <code>--inputText</code>, <code>--mediaType</code>
+  Options used to configure fields: <code>--inputCompress</code>, <code>--inputFormattedJson</code>, <code>--inputJson</code>, <code>--inputText</code>, <code>--inputYaml</code>, <code>--mediaType</code>
 
 The following list describes the supported access methods, their versions
 and specification formats.


### PR DESCRIPTION
**What this PR does / why we need it**:

The input type `utf8` now supports additional modes:
- (field `text`: utf8 text)
- field `json`: output JSON, input inline json/yaml or json/yaml string
- field `formattedJson`: output formatted JSON, input inline json/yaml or json/yaml string
- field `yaml`: output YAML, input inline json/yaml or json/yaml string


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
