### PR TITLE
CA certificate of oci registry as part of credentials

### DIFF
--- a/cmds/ocm/commands/ocmcmds/cli/download/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/cli/download/cmd.go
@@ -11,6 +11,9 @@ import (
 
 	"github.com/mandelsoft/filepath/pkg/filepath"
 	"github.com/mandelsoft/vfs/pkg/vfs"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/open-component-model/ocm/cmds/ocm/commands/common/options/destoption"
 	ocmcommon "github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/handlers/elemhdlr"
@@ -28,8 +31,6 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/consts"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/resourcetypes"
 	"github.com/open-component-model/ocm/pkg/out"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var (

--- a/cmds/ocm/commands/ocmcmds/cli/download/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/cli/download/cmd_test.go
@@ -13,7 +13,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
-	env2 "github.com/open-component-model/ocm/pkg/env"
 	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/cli/download"
@@ -21,6 +20,7 @@ import (
 	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/consts"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/resourcetypes"
+	env2 "github.com/open-component-model/ocm/pkg/env"
 	"github.com/open-component-model/ocm/pkg/mime"
 )
 

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/utf8/inputtype_test.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/utf8/inputtype_test.go
@@ -7,12 +7,13 @@ package utf8
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs/testutils"
+	. "github.com/open-component-model/ocm/pkg/testutils"
+
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs/cpi"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs/options"
-	. "github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs/testutils"
 	"github.com/open-component-model/ocm/pkg/contexts/clictx"
-	. "github.com/open-component-model/ocm/pkg/testutils"
 )
 
 var _ = Describe("Input Type", func() {

--- a/cmds/ocm/commands/ocmcmds/common/options/versionconstraintsoption/option.go
+++ b/cmds/ocm/commands/ocmcmds/common/options/versionconstraintsoption/option.go
@@ -6,11 +6,11 @@ package versionconstraintsoption
 
 import (
 	"github.com/Masterminds/semver/v3"
-	"github.com/open-component-model/ocm/pkg/utils"
 	"github.com/spf13/pflag"
 
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
 	"github.com/open-component-model/ocm/pkg/cobrautils/flag"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 func From(o options.OptionSetProvider) *Option {

--- a/cmds/ocm/commands/ocmcmds/resources/download/action.go
+++ b/cmds/ocm/commands/ocmcmds/resources/download/action.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
+
 	"github.com/open-component-model/ocm/cmds/ocm/commands/common/options/destoption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/handlers/elemhdlr"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/resources/common"

--- a/cmds/ocm/commands/ocmcmds/resources/download/options.go
+++ b/cmds/ocm/commands/ocmcmds/resources/download/options.go
@@ -5,10 +5,10 @@
 package download
 
 import (
-	"github.com/open-component-model/ocm/pkg/utils"
 	"github.com/spf13/pflag"
 
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/output"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 func From(o *output.Options) *Option {

--- a/cmds/ocm/pkg/utils/fileutils.go
+++ b/cmds/ocm/pkg/utils/fileutils.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
+
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 )
 

--- a/docs/pluginreference/plugin.md
+++ b/docs/pluginreference/plugin.md
@@ -21,11 +21,11 @@ mechanism to add further variants, like repository types, backend technologies,
 access methods, blob downloaders and uploaders.
 
 This requires Go coding, which is feasible for additional standard
-implementations. Nevertheless, it is useful to provide a more dynamic 
+implementations. Nevertheless, it is useful to provide a more dynamic
 way to enrich the functionality of the library and the OCM command line
 tool.
 
-This can be achieved by the experimental *plugin* concept. It allows 
+This can be achieved by the experimental *plugin* concept. It allows
 to implement functionality in separate executables (the plugins) and
 register them for any main program based on this library.
 
@@ -48,7 +48,7 @@ Errors have to be reported on *stderr* as JSON document with the fields:
   The error message provided by a command.
 
 Any plugin, regardless of its functionality has to provide an [plugin info](plugin_info.md),
-which prints JSON document containing a plugin descriptor that describes the 
+which prints JSON document containing a plugin descriptor that describes the
 apabilities of the plugin.
 
 

--- a/docs/pluginreference/plugin_accessmethod_validate.md
+++ b/docs/pluginreference/plugin_accessmethod_validate.md
@@ -19,8 +19,8 @@ This command accepts an access specification as argument. It is used to
 validate the specification and to provide some metadata for the given
 specification.
 
-This metadata has to be provided as JSON string on *stdout* and has the 
-following fields: 
+This metadata has to be provided as JSON string on *stdout* and has the
+following fields:
 
 - **<code>mediaType</code>** *string*
 

--- a/docs/pluginreference/plugin_action_execute.md
+++ b/docs/pluginreference/plugin_action_execute.md
@@ -19,8 +19,8 @@ plugin action execute <spec> [<options>]
 
 This command executes an action.
 
-This action has to provide an execution result as JSON string on *stdout*. It has the 
-following fields: 
+This action has to provide an execution result as JSON string on *stdout*. It has the
+following fields:
 
 - **<code>name</code>** *string*
 

--- a/docs/pluginreference/plugin_descriptor.md
+++ b/docs/pluginreference/plugin_descriptor.md
@@ -88,7 +88,7 @@ It uses the following fields:
 
   - **<code>name</code>** *string*
 
-    This required field describe the name of the option. THis might be 
+    This required field describe the name of the option. THis might be
     the name of a preconfigured option, or a new one.
 
   - **<code>type</code>** *string*

--- a/docs/pluginreference/plugin_download.md
+++ b/docs/pluginreference/plugin_download.md
@@ -22,7 +22,7 @@ This command accepts a target filepath as argument. It is used as base name
 to store the downloaded content. The blob content is provided on the
 *stdin*. The first argument specified the downloader to use for the operation.
 
-The task of this command is to transform the content of the provided 
+The task of this command is to transform the content of the provided
 blob into a filesystem structure applicable to the type specific tools working
 with content of the given artifact type.
 

--- a/docs/reference/ocm_credential-handling.md
+++ b/docs/reference/ocm_credential-handling.md
@@ -49,12 +49,12 @@ The following credential consumer types are used:
     the <code>hostpath</code> type.
 
     Credential consumers of the consumer type HelmChartRepository evaluate the following credential properties:
-
-    - **<code>username</code>**: basic auth user name.
-    - **<code>password</code>**: basic auth password.
-    - **<code>certificate</code>**: TLS client certificate.
-    - **<code>privateKey</code>**: TLS private key.
-
+      - <code>username</code>: the basic auth user name
+      - <code>password</code>: the basic auth password
+      - <code>certificate</code>: TLS client certificate
+      - <code>privateKey</code>: TLS private key
+      - <code>certificateAuthority</code>: TLS certificate authority
+    
   - <code>OCIRegistry</code>: OCI registry credential matcher
 
     It matches the <code>OCIRegistry</code> consumer type and additionally acts like
@@ -65,8 +65,8 @@ The following credential consumer types are used:
       - <code>username</code>: the basic auth user name
       - <code>password</code>: the basic auth password
       - <code>identityToken</code>: the bearer token used for non-basic auth authorization
-
-
+      - <code>certificateAuthority</code>: the certificate authority certificate used to verify certificates
+    
   - <code>S3</code>: S3 credential matcher
 
     This matcher is a hostpath matcher.

--- a/docs/reference/ocm_credential-handling.md
+++ b/docs/reference/ocm_credential-handling.md
@@ -49,12 +49,14 @@ The following credential consumer types are used:
     the <code>hostpath</code> type.
 
     Credential consumers of the consumer type HelmChartRepository evaluate the following credential properties:
+
       - <code>username</code>: the basic auth user name
       - <code>password</code>: the basic auth password
       - <code>certificate</code>: TLS client certificate
       - <code>privateKey</code>: TLS private key
       - <code>certificateAuthority</code>: TLS certificate authority
-    
+
+
   - <code>OCIRegistry</code>: OCI registry credential matcher
 
     It matches the <code>OCIRegistry</code> consumer type and additionally acts like
@@ -66,7 +68,8 @@ The following credential consumer types are used:
       - <code>password</code>: the basic auth password
       - <code>identityToken</code>: the bearer token used for non-basic auth authorization
       - <code>certificateAuthority</code>: the certificate authority certificate used to verify certificates
-    
+
+
   - <code>S3</code>: S3 credential matcher
 
     This matcher is a hostpath matcher.

--- a/docs/reference/ocm_download_resources.md
+++ b/docs/reference/ocm_download_resources.md
@@ -32,7 +32,7 @@ resources, resource, res, r
 
 
 Download resources of a component version. Resources are specified
-by identities. An identity consists of
+by identities. An identity consists of 
 a name argument followed by optional <code>&lt;key>=&lt;value></code>
 arguments.
 
@@ -73,7 +73,7 @@ relative to the specified repository using the syntax
     <pre>&lt;component>[:&lt;version>]</pre>
 </center>
 
-If no <code>--repo</code> option is specified the given names are interpreted
+If no <code>--repo</code> option is specified the given names are interpreted 
 as located OCM component version references:
 
 <center>
@@ -96,7 +96,7 @@ The <code>--repo</code> option takes an OCM repository specification:
 For the *Common Transport Format* the types <code>directory</code>,
 <code>tar</code> or <code>tgz</code> is possible.
 
-Using the JSON variant any repository types supported by the
+Using the JSON variant any repository types supported by the 
 linked library can be used:
 
 Dedicated OCM repository types:
@@ -122,7 +122,7 @@ are configured for the operation. It has the following format
 
 The downloader name may be a path expression with the following possibilities:
   - <code>ocm/dirtree</code>: downloading directory tree-like resources
-
+    
     The <code>dirtree</code> downloader is able to download directory-tree like
     resources as directory structure (default) or archive.
     The following artifact media types are supported:
@@ -130,55 +130,55 @@ The downloader name may be a path expression with the following possibilities:
       - <code>application/x-tgz</code>
       - <code>application/x-tar+gzip</code>
       - <code>application/x-tar</code>
-
+    
     By default, it is registered for the following resource types:
       - <code>directoryTree</code>
       - <code>filesystem</code>
-
+    
     It accepts a config with the following fields:
       - <code>asArchive</code>: flag to request an archive download
       - <code>ociConfigTypes</code>: a list of accepted OCI config archive mime types
         defaulted by <code>application/vnd.oci.image.config.v1+json</code>.
 
   - <code>oci/artifact</code>: uploading an OCI artifact to an OCI registry
-
+    
     The <code>artifact</code> downloader is able to transfer OCI artifact-like resources
     into an OCI registry given by the combination of the download target and the
     registration config.
-
+    
     If no config is given, the target must be an OCI reference with a potentially
     omitted repository. The repo part is derived from the reference hint provided
     by the resource's access specification.
-
+    
     If the config is given, the target is used as repository name prefixed with an
     optional repository prefix given by the configuration.
-
+    
     The following artifact media types are supported:
       - <code>application/vnd.oci.image.manifest.v1+tar+gzip</code>
       - <code>application/vnd.oci.image.index.v1+tar+gzip</code>
-
+    
     It accepts a config with the following fields:
       - <code>namespacePrefix</code>: a namespace prefix used for the uploaded artifacts
       - <code>ociRef</code>: an OCI repository reference
       - <code>repository</code>: an OCI repository specification for the target OCI registry
 
   - <code>plugin</code>: [downloaders provided by plugins]
-
+    
     sub namespace of the form <code>&lt;plugin name>/&lt;handler></code>
 
   - <code>landscaper/blueprint</code>: uploading an OCI artifact to an OCI registry
-
+    
     The <code>artifact</code> downloader is able to transfer OCI artifact-like resources
     into an OCI registry given by the combination of the download target and the
     registration config.
-
+    
     If no config is given, the target must be an OCI reference with a potentially
     omitted repository. The repo part is derived from the reference hint provided
     by the resource's access specification.
-
+    
     If the config is given, the target is used as repository name prefixed with an
     optional repository prefix given by the configuration.
-
+    
     The following artifact media types are supported:
       - <code>application/vnd.docker.distribution.manifest.v2+tar</code>
       - <code>application/vnd.docker.distribution.manifest.v2+tar+gzip</code>
@@ -190,14 +190,14 @@ The downloader name may be a path expression with the following possibilities:
       - <code>application/x-tar</code>
       - <code>application/x-tar+gzip</code>
       - <code>application/x-tgz</code>
-
+    
     It accepts a config with the following fields:
       - <code>ociConfigTypes</code>: a list of accepted OCI config archive mime types
         defaulted by <code>application/vnd.gardener.landscaper.blueprint.config.v1</code>.
-
-
-
-    This handler is by default registered for the following artifact types:
+    
+    
+    
+    This handler is by default registered for the following artifact types: 
     landscaper.gardener.cloud/blueprint,blueprint
 
 

--- a/docs/reference/ocm_download_resources.md
+++ b/docs/reference/ocm_download_resources.md
@@ -32,7 +32,7 @@ resources, resource, res, r
 
 
 Download resources of a component version. Resources are specified
-by identities. An identity consists of 
+by identities. An identity consists of
 a name argument followed by optional <code>&lt;key>=&lt;value></code>
 arguments.
 
@@ -73,7 +73,7 @@ relative to the specified repository using the syntax
     <pre>&lt;component>[:&lt;version>]</pre>
 </center>
 
-If no <code>--repo</code> option is specified the given names are interpreted 
+If no <code>--repo</code> option is specified the given names are interpreted
 as located OCM component version references:
 
 <center>
@@ -96,7 +96,7 @@ The <code>--repo</code> option takes an OCM repository specification:
 For the *Common Transport Format* the types <code>directory</code>,
 <code>tar</code> or <code>tgz</code> is possible.
 
-Using the JSON variant any repository types supported by the 
+Using the JSON variant any repository types supported by the
 linked library can be used:
 
 Dedicated OCM repository types:
@@ -122,7 +122,7 @@ are configured for the operation. It has the following format
 
 The downloader name may be a path expression with the following possibilities:
   - <code>ocm/dirtree</code>: downloading directory tree-like resources
-    
+
     The <code>dirtree</code> downloader is able to download directory-tree like
     resources as directory structure (default) or archive.
     The following artifact media types are supported:
@@ -130,55 +130,55 @@ The downloader name may be a path expression with the following possibilities:
       - <code>application/x-tgz</code>
       - <code>application/x-tar+gzip</code>
       - <code>application/x-tar</code>
-    
+
     By default, it is registered for the following resource types:
       - <code>directoryTree</code>
       - <code>filesystem</code>
-    
+
     It accepts a config with the following fields:
       - <code>asArchive</code>: flag to request an archive download
       - <code>ociConfigTypes</code>: a list of accepted OCI config archive mime types
         defaulted by <code>application/vnd.oci.image.config.v1+json</code>.
 
   - <code>oci/artifact</code>: uploading an OCI artifact to an OCI registry
-    
+
     The <code>artifact</code> downloader is able to transfer OCI artifact-like resources
     into an OCI registry given by the combination of the download target and the
     registration config.
-    
+
     If no config is given, the target must be an OCI reference with a potentially
     omitted repository. The repo part is derived from the reference hint provided
     by the resource's access specification.
-    
+
     If the config is given, the target is used as repository name prefixed with an
     optional repository prefix given by the configuration.
-    
+
     The following artifact media types are supported:
       - <code>application/vnd.oci.image.manifest.v1+tar+gzip</code>
       - <code>application/vnd.oci.image.index.v1+tar+gzip</code>
-    
+
     It accepts a config with the following fields:
       - <code>namespacePrefix</code>: a namespace prefix used for the uploaded artifacts
       - <code>ociRef</code>: an OCI repository reference
       - <code>repository</code>: an OCI repository specification for the target OCI registry
 
   - <code>plugin</code>: [downloaders provided by plugins]
-    
+
     sub namespace of the form <code>&lt;plugin name>/&lt;handler></code>
 
   - <code>landscaper/blueprint</code>: uploading an OCI artifact to an OCI registry
-    
+
     The <code>artifact</code> downloader is able to transfer OCI artifact-like resources
     into an OCI registry given by the combination of the download target and the
     registration config.
-    
+
     If no config is given, the target must be an OCI reference with a potentially
     omitted repository. The repo part is derived from the reference hint provided
     by the resource's access specification.
-    
+
     If the config is given, the target is used as repository name prefixed with an
     optional repository prefix given by the configuration.
-    
+
     The following artifact media types are supported:
       - <code>application/vnd.docker.distribution.manifest.v2+tar</code>
       - <code>application/vnd.docker.distribution.manifest.v2+tar+gzip</code>
@@ -190,14 +190,14 @@ The downloader name may be a path expression with the following possibilities:
       - <code>application/x-tar</code>
       - <code>application/x-tar+gzip</code>
       - <code>application/x-tgz</code>
-    
+
     It accepts a config with the following fields:
       - <code>ociConfigTypes</code>: a list of accepted OCI config archive mime types
         defaulted by <code>application/vnd.gardener.landscaper.blueprint.config.v1</code>.
-    
-    
-    
-    This handler is by default registered for the following artifact types: 
+
+
+
+    This handler is by default registered for the following artifact types:
     landscaper.gardener.cloud/blueprint,blueprint
 
 

--- a/docs/reference/ocm_get_credentials.md
+++ b/docs/reference/ocm_get_credentials.md
@@ -51,12 +51,13 @@ Matchers exist for the following usage contexts or consumer types:
     the <code>hostpath</code> type.
 
     Credential consumers of the consumer type HelmChartRepository evaluate the following credential properties:
-
-    - **<code>username</code>**: basic auth user name.
-    - **<code>password</code>**: basic auth password.
-    - **<code>certificate</code>**: TLS client certificate.
-    - **<code>privateKey</code>**: TLS private key.
-
+    
+      - <code>username</code>: the basic auth user name
+      - <code>password</code>: the basic auth password
+      - <code>certificate</code>: TLS client certificate
+      - <code>privateKey</code>: TLS private key
+      - <code>certificateAuthority</code>: TLS certificate authority
+    
   - <code>OCIRegistry</code>: OCI registry credential matcher
 
     It matches the <code>OCIRegistry</code> consumer type and additionally acts like
@@ -67,8 +68,8 @@ Matchers exist for the following usage contexts or consumer types:
       - <code>username</code>: the basic auth user name
       - <code>password</code>: the basic auth password
       - <code>identityToken</code>: the bearer token used for non-basic auth authorization
-
-
+      - <code>certificateAuthority</code>: the certificate authority certificate used to verify certificates
+    
   - <code>S3</code>: S3 credential matcher
 
     This matcher is a hostpath matcher.

--- a/docs/reference/ocm_get_credentials.md
+++ b/docs/reference/ocm_get_credentials.md
@@ -51,13 +51,14 @@ Matchers exist for the following usage contexts or consumer types:
     the <code>hostpath</code> type.
 
     Credential consumers of the consumer type HelmChartRepository evaluate the following credential properties:
-    
+
       - <code>username</code>: the basic auth user name
       - <code>password</code>: the basic auth password
       - <code>certificate</code>: TLS client certificate
       - <code>privateKey</code>: TLS private key
       - <code>certificateAuthority</code>: TLS certificate authority
-    
+
+
   - <code>OCIRegistry</code>: OCI registry credential matcher
 
     It matches the <code>OCIRegistry</code> consumer type and additionally acts like
@@ -69,7 +70,8 @@ Matchers exist for the following usage contexts or consumer types:
       - <code>password</code>: the basic auth password
       - <code>identityToken</code>: the bearer token used for non-basic auth authorization
       - <code>certificateAuthority</code>: the certificate authority certificate used to verify certificates
-    
+
+
   - <code>S3</code>: S3 credential matcher
 
     This matcher is a hostpath matcher.

--- a/docs/reference/ocm_ocm-downloadhandlers.md
+++ b/docs/reference/ocm_ocm-downloadhandlers.md
@@ -14,7 +14,7 @@ For example, a pre-registered helm download handler will store
 OCI-based helm artifacts as regular helm archives in the local
 file system.
 
-### Handler Registration 
+### Handler Registration
 
 Programmatically any kind of handlers can be registered for various
 download conditions. But this feature is available as command-line option, also.
@@ -31,7 +31,7 @@ exact behaviour of the handler for selected artifacts.
 
 The following handler names are possible:
   - <code>ocm/dirtree</code>: downloading directory tree-like resources
-    
+
     The <code>dirtree</code> downloader is able to download directory-tree like
     resources as directory structure (default) or archive.
     The following artifact media types are supported:
@@ -39,55 +39,55 @@ The following handler names are possible:
       - <code>application/x-tgz</code>
       - <code>application/x-tar+gzip</code>
       - <code>application/x-tar</code>
-    
+
     By default, it is registered for the following resource types:
       - <code>directoryTree</code>
       - <code>filesystem</code>
-    
+
     It accepts a config with the following fields:
       - <code>asArchive</code>: flag to request an archive download
       - <code>ociConfigTypes</code>: a list of accepted OCI config archive mime types
         defaulted by <code>application/vnd.oci.image.config.v1+json</code>.
 
   - <code>oci/artifact</code>: uploading an OCI artifact to an OCI registry
-    
+
     The <code>artifact</code> downloader is able to transfer OCI artifact-like resources
     into an OCI registry given by the combination of the download target and the
     registration config.
-    
+
     If no config is given, the target must be an OCI reference with a potentially
     omitted repository. The repo part is derived from the reference hint provided
     by the resource's access specification.
-    
+
     If the config is given, the target is used as repository name prefixed with an
     optional repository prefix given by the configuration.
-    
+
     The following artifact media types are supported:
       - <code>application/vnd.oci.image.manifest.v1+tar+gzip</code>
       - <code>application/vnd.oci.image.index.v1+tar+gzip</code>
-    
+
     It accepts a config with the following fields:
       - <code>namespacePrefix</code>: a namespace prefix used for the uploaded artifacts
       - <code>ociRef</code>: an OCI repository reference
       - <code>repository</code>: an OCI repository specification for the target OCI registry
 
   - <code>plugin</code>: [downloaders provided by plugins]
-    
+
     sub namespace of the form <code>&lt;plugin name>/&lt;handler></code>
 
   - <code>landscaper/blueprint</code>: uploading an OCI artifact to an OCI registry
-    
+
     The <code>artifact</code> downloader is able to transfer OCI artifact-like resources
     into an OCI registry given by the combination of the download target and the
     registration config.
-    
+
     If no config is given, the target must be an OCI reference with a potentially
     omitted repository. The repo part is derived from the reference hint provided
     by the resource's access specification.
-    
+
     If the config is given, the target is used as repository name prefixed with an
     optional repository prefix given by the configuration.
-    
+
     The following artifact media types are supported:
       - <code>application/vnd.docker.distribution.manifest.v2+tar</code>
       - <code>application/vnd.docker.distribution.manifest.v2+tar+gzip</code>
@@ -99,14 +99,14 @@ The following handler names are possible:
       - <code>application/x-tar</code>
       - <code>application/x-tar+gzip</code>
       - <code>application/x-tgz</code>
-    
+
     It accepts a config with the following fields:
       - <code>ociConfigTypes</code>: a list of accepted OCI config archive mime types
         defaulted by <code>application/vnd.gardener.landscaper.blueprint.config.v1</code>.
-    
-    
-    
-    This handler is by default registered for the following artifact types: 
+
+
+
+    This handler is by default registered for the following artifact types:
     landscaper.gardener.cloud/blueprint,blueprint
 
 

--- a/docs/reference/ocm_ocm-downloadhandlers.md
+++ b/docs/reference/ocm_ocm-downloadhandlers.md
@@ -14,7 +14,7 @@ For example, a pre-registered helm download handler will store
 OCI-based helm artifacts as regular helm archives in the local
 file system.
 
-### Handler Registration
+### Handler Registration 
 
 Programmatically any kind of handlers can be registered for various
 download conditions. But this feature is available as command-line option, also.
@@ -31,7 +31,7 @@ exact behaviour of the handler for selected artifacts.
 
 The following handler names are possible:
   - <code>ocm/dirtree</code>: downloading directory tree-like resources
-
+    
     The <code>dirtree</code> downloader is able to download directory-tree like
     resources as directory structure (default) or archive.
     The following artifact media types are supported:
@@ -39,55 +39,55 @@ The following handler names are possible:
       - <code>application/x-tgz</code>
       - <code>application/x-tar+gzip</code>
       - <code>application/x-tar</code>
-
+    
     By default, it is registered for the following resource types:
       - <code>directoryTree</code>
       - <code>filesystem</code>
-
+    
     It accepts a config with the following fields:
       - <code>asArchive</code>: flag to request an archive download
       - <code>ociConfigTypes</code>: a list of accepted OCI config archive mime types
         defaulted by <code>application/vnd.oci.image.config.v1+json</code>.
 
   - <code>oci/artifact</code>: uploading an OCI artifact to an OCI registry
-
+    
     The <code>artifact</code> downloader is able to transfer OCI artifact-like resources
     into an OCI registry given by the combination of the download target and the
     registration config.
-
+    
     If no config is given, the target must be an OCI reference with a potentially
     omitted repository. The repo part is derived from the reference hint provided
     by the resource's access specification.
-
+    
     If the config is given, the target is used as repository name prefixed with an
     optional repository prefix given by the configuration.
-
+    
     The following artifact media types are supported:
       - <code>application/vnd.oci.image.manifest.v1+tar+gzip</code>
       - <code>application/vnd.oci.image.index.v1+tar+gzip</code>
-
+    
     It accepts a config with the following fields:
       - <code>namespacePrefix</code>: a namespace prefix used for the uploaded artifacts
       - <code>ociRef</code>: an OCI repository reference
       - <code>repository</code>: an OCI repository specification for the target OCI registry
 
   - <code>plugin</code>: [downloaders provided by plugins]
-
+    
     sub namespace of the form <code>&lt;plugin name>/&lt;handler></code>
 
   - <code>landscaper/blueprint</code>: uploading an OCI artifact to an OCI registry
-
+    
     The <code>artifact</code> downloader is able to transfer OCI artifact-like resources
     into an OCI registry given by the combination of the download target and the
     registration config.
-
+    
     If no config is given, the target must be an OCI reference with a potentially
     omitted repository. The repo part is derived from the reference hint provided
     by the resource's access specification.
-
+    
     If the config is given, the target is used as repository name prefixed with an
     optional repository prefix given by the configuration.
-
+    
     The following artifact media types are supported:
       - <code>application/vnd.docker.distribution.manifest.v2+tar</code>
       - <code>application/vnd.docker.distribution.manifest.v2+tar+gzip</code>
@@ -99,14 +99,14 @@ The following handler names are possible:
       - <code>application/x-tar</code>
       - <code>application/x-tar+gzip</code>
       - <code>application/x-tgz</code>
-
+    
     It accepts a config with the following fields:
       - <code>ociConfigTypes</code>: a list of accepted OCI config archive mime types
         defaulted by <code>application/vnd.gardener.landscaper.blueprint.config.v1</code>.
-
-
-
-    This handler is by default registered for the following artifact types:
+    
+    
+    
+    This handler is by default registered for the following artifact types: 
     landscaper.gardener.cloud/blueprint,blueprint
 
 

--- a/pkg/contexts/credentials/cpi/const.go
+++ b/pkg/contexts/credentials/cpi/const.go
@@ -11,12 +11,13 @@ import (
 const (
 	ID_TYPE = internal.ID_TYPE
 
-	ATTR_TYPE           = internal.ATTR_TYPE
-	ATTR_USERNAME       = internal.ATTR_USERNAME
-	ATTR_PASSWORD       = internal.ATTR_PASSWORD
-	ATTR_SERVER_ADDRESS = internal.ATTR_SERVER_ADDRESS
-	ATTR_TOKEN          = internal.ATTR_TOKEN
-	ATTR_IDENTITY_TOKEN = internal.ATTR_IDENTITY_TOKEN
-	ATTR_REGISTRY_TOKEN = internal.ATTR_REGISTRY_TOKEN
-	ATTR_KEY            = internal.ATTR_KEY
+	ATTR_TYPE                  = internal.ATTR_TYPE
+	ATTR_USERNAME              = internal.ATTR_USERNAME
+	ATTR_PASSWORD              = internal.ATTR_PASSWORD
+	ATTR_SERVER_ADDRESS        = internal.ATTR_SERVER_ADDRESS
+	ATTR_TOKEN                 = internal.ATTR_TOKEN
+	ATTR_IDENTITY_TOKEN        = internal.ATTR_IDENTITY_TOKEN
+	ATTR_REGISTRY_TOKEN        = internal.ATTR_REGISTRY_TOKEN
+	ATTR_KEY                   = internal.ATTR_KEY
+	ATTR_CERTIFICATE_AUTHORITY = internal.ATTR_CERTIFICATE_AUTHORITY
 )

--- a/pkg/contexts/oci/identity/identity.go
+++ b/pkg/contexts/oci/identity/identity.go
@@ -23,9 +23,10 @@ const (
 
 // used credential properties.
 const (
-	ATTR_USERNAME       = cpi.ATTR_USERNAME
-	ATTR_PASSWORD       = cpi.ATTR_PASSWORD
-	ATTR_IDENTITY_TOKEN = cpi.ATTR_IDENTITY_TOKEN
+	ATTR_USERNAME              = cpi.ATTR_USERNAME
+	ATTR_PASSWORD              = cpi.ATTR_PASSWORD
+	ATTR_IDENTITY_TOKEN        = cpi.ATTR_IDENTITY_TOKEN
+	ATTR_CERTIFICATE_AUTHORITY = cpi.ATTR_CERTIFICATE_AUTHORITY
 )
 
 func init() {
@@ -33,6 +34,7 @@ func init() {
 		ATTR_USERNAME, "the basic auth user name",
 		ATTR_PASSWORD, "the basic auth password",
 		ATTR_IDENTITY_TOKEN, "the bearer token used for non-basic auth authorization",
+		ATTR_CERTIFICATE_AUTHORITY, "the certificate authority certificate used to verify certificates",
 	})
 
 	cpi.RegisterStandardIdentity(CONSUMER_TYPE, IdentityMatcher, `OCI registry credential matcher

--- a/pkg/contexts/oci/repositories/ocireg/repository.go
+++ b/pkg/contexts/oci/repositories/ocireg/repository.go
@@ -145,7 +145,7 @@ func (r *RepositoryImpl) getResolver(comp string) (resolve.Resolver, error) {
 			},
 			DefaultScheme: r.info.Scheme,
 			DefaultTLS: &tls.Config{
-				MinVersion: tls.VersionTLS10,
+				MinVersion: tls.VersionTLS13,
 				RootCAs: func() *x509.CertPool {
 					rootCAs, _ := x509.SystemCertPool()
 					if rootCAs == nil {

--- a/pkg/contexts/oci/repositories/ocireg/repository.go
+++ b/pkg/contexts/oci/repositories/ocireg/repository.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"github.com/open-component-model/ocm/pkg/contexts/oci/identity"
 	"path"
 	"strings"
 
@@ -20,6 +19,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/artdesc"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/cpi"
+	"github.com/open-component-model/ocm/pkg/contexts/oci/identity"
 	ociidentity "github.com/open-component-model/ocm/pkg/contexts/oci/identity"
 	"github.com/open-component-model/ocm/pkg/docker"
 	"github.com/open-component-model/ocm/pkg/docker/resolve"
@@ -145,6 +145,7 @@ func (r *RepositoryImpl) getResolver(comp string) (resolve.Resolver, error) {
 			},
 			DefaultScheme: r.info.Scheme,
 			DefaultTLS: &tls.Config{
+				MinVersion: tls.VersionTLS10,
 				RootCAs: func() *x509.CertPool {
 					rootCAs, _ := x509.SystemCertPool()
 					if rootCAs == nil {

--- a/pkg/contexts/oci/repositories/ocireg/repository.go
+++ b/pkg/contexts/oci/repositories/ocireg/repository.go
@@ -6,6 +6,9 @@ package ocireg
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"github.com/open-component-model/ocm/pkg/contexts/oci/identity"
 	"path"
 	"strings"
 
@@ -141,6 +144,21 @@ func (r *RepositoryImpl) getResolver(comp string) (resolve.Resolver, error) {
 				return "", "", nil
 			},
 			DefaultScheme: r.info.Scheme,
+			DefaultTLS: &tls.Config{
+				RootCAs: func() *x509.CertPool {
+					rootCAs, _ := x509.SystemCertPool()
+					if rootCAs == nil {
+						rootCAs = x509.NewCertPool()
+					}
+					if creds != nil {
+						c := creds.GetProperty(identity.ATTR_CERTIFICATE_AUTHORITY)
+						if c != "" {
+							rootCAs.AppendCertsFromPEM([]byte(c))
+						}
+					}
+					return rootCAs
+				}(),
+			},
 		})),
 	}
 

--- a/pkg/contexts/oci/repositories/ocireg/repository.go
+++ b/pkg/contexts/oci/repositories/ocireg/repository.go
@@ -19,7 +19,6 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/artdesc"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/cpi"
-	"github.com/open-component-model/ocm/pkg/contexts/oci/identity"
 	ociidentity "github.com/open-component-model/ocm/pkg/contexts/oci/identity"
 	"github.com/open-component-model/ocm/pkg/docker"
 	"github.com/open-component-model/ocm/pkg/docker/resolve"
@@ -147,13 +146,14 @@ func (r *RepositoryImpl) getResolver(comp string) (resolve.Resolver, error) {
 			DefaultTLS: &tls.Config{
 				MinVersion: tls.VersionTLS13,
 				RootCAs: func() *x509.CertPool {
-					rootCAs, _ := x509.SystemCertPool()
-					if rootCAs == nil {
-						rootCAs = x509.NewCertPool()
-					}
+					var rootCAs *x509.CertPool
 					if creds != nil {
-						c := creds.GetProperty(identity.ATTR_CERTIFICATE_AUTHORITY)
+						c := creds.GetProperty(credentials.ATTR_CERTIFICATE_AUTHORITY)
 						if c != "" {
+							rootCAs, _ = x509.SystemCertPool()
+							if rootCAs == nil {
+								rootCAs = x509.NewCertPool()
+							}
 							rootCAs.AppendCertsFromPEM([]byte(c))
 						}
 					}

--- a/pkg/contexts/ocm/compdesc/logging_test.go
+++ b/pkg/contexts/ocm/compdesc/logging_test.go
@@ -7,17 +7,16 @@ package compdesc_test
 import (
 	"bytes"
 
-	"github.com/mandelsoft/logging"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 
 	"github.com/go-logr/logr"
+	"github.com/mandelsoft/logging"
+	"github.com/tonglil/buflogr"
 
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	ocmlog "github.com/open-component-model/ocm/pkg/logging"
 	"github.com/open-component-model/ocm/pkg/testutils"
-
-	"github.com/tonglil/buflogr"
 )
 
 var _ = Describe("logging", func() {

--- a/pkg/contexts/ocm/compdesc/meta/v1/labels_test.go
+++ b/pkg/contexts/ocm/compdesc/meta/v1/labels_test.go
@@ -7,8 +7,9 @@ package v1_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 	. "github.com/open-component-model/ocm/pkg/testutils"
+
+	v1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 )
 
 var _ = Describe("labels", func() {

--- a/pkg/contexts/ocm/compdesc/norm_test.go
+++ b/pkg/contexts/ocm/compdesc/norm_test.go
@@ -5,16 +5,16 @@
 package compdesc_test
 
 import (
-	v1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 	_ "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/normalizations"
 	_ "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
+	v1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1"
 )
 
 var CD1 = `

--- a/pkg/helm/identity/identity.go
+++ b/pkg/helm/identity/identity.go
@@ -5,7 +5,6 @@
 package identity
 
 import (
-	"github.com/open-component-model/ocm/pkg/listformat"
 	"strings"
 
 	"helm.sh/helm/v3/pkg/registry"
@@ -15,6 +14,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/identity/hostpath"
 	ociidentity "github.com/open-component-model/ocm/pkg/contexts/oci/identity"
+	"github.com/open-component-model/ocm/pkg/listformat"
 )
 
 // CONSUMER_TYPE is the Helm chart repository type.

--- a/pkg/helm/identity/identity.go
+++ b/pkg/helm/identity/identity.go
@@ -5,6 +5,7 @@
 package identity
 
 import (
+	"github.com/open-component-model/ocm/pkg/listformat"
 	"strings"
 
 	"helm.sh/helm/v3/pkg/registry"
@@ -35,14 +36,19 @@ const ID_PORT = hostpath.ID_PORT
 const ID_PATHPREFIX = hostpath.ID_PATHPREFIX
 
 func init() {
+	attrs := listformat.FormatListElements("", listformat.StringElementDescriptionList{
+		ATTR_USERNAME, "the basic auth user name",
+		ATTR_PASSWORD, "the basic auth password",
+		ATTR_CERTIFICATE, "TLS client certificate",
+		ATTR_PRIVATE_KEY, "TLS private key",
+		ATTR_CERTIFICATE_AUTHORITY, "TLS certificate authority",
+	})
+
 	cpi.RegisterStandardIdentity(CONSUMER_TYPE, IdentityMatcher, `Helm chart repository
 
 It matches the <code>`+CONSUMER_TYPE+`</code> consumer type and additionally acts like 
 the <code>`+hostpath.IDENTITY_TYPE+`</code> type.`,
-		`- **<code>`+ATTR_USERNAME+`</code>**: basic auth user name.
-- **<code>`+ATTR_PASSWORD+`</code>**: basic auth password.
-- **<code>`+ATTR_CERTIFICATE+`</code>**: TLS client certificate.
-- **<code>`+ATTR_PRIVATE_KEY+`</code>**: TLS private key.`)
+		attrs)
 }
 
 var identityMatcher = hostpath.IdentityMatcher(CONSUMER_TYPE)


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the possibility to verify TLS certificates of oci registries with CA certificates passed as part of the credentials. This is useful to e.g. run tests with locally running oci registries whose certificates might be dynamically generated.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
