### PR TITLE
switch to reworked logging version

### DIFF
--- a/cmds/ocm/app/app_test.go
+++ b/cmds/ocm/app/app_test.go
@@ -7,6 +7,7 @@ package app_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -71,8 +72,8 @@ var _ = Describe("Test Environment", func() {
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).ExecuteModified(addTestCommands, "logtest")).To(Succeed())
 		Expect(log.String()).To(StringEqualTrimmedWithContext(`
-ERROR <nil> ocm/test error
-ERROR <nil> ocm/test ctxerror
+ERROR <nil> error realm ocm realm test
+ERROR <nil> ctxerror realm ocm realm test
 `))
 	})
 
@@ -80,14 +81,14 @@ ERROR <nil> ocm/test ctxerror
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).ExecuteModified(addTestCommands, "-X", "plugindir=xxx", "-l", "Debug", "logtest")).To(Succeed())
 		Expect(log.String()).To(StringEqualTrimmedWithContext(`
-V[4] ocm/test debug
-V[3] ocm/test info
-V[2] ocm/test warn
-ERROR <nil> ocm/test error
-V[4] ocm/test ctxdebug
-V[3] ocm/test ctxinfo
-V[2] ocm/test ctxwarn
-ERROR <nil> ocm/test ctxerror
+V[4] debug realm ocm realm test
+V[3] info realm ocm realm test
+V[2] warn realm ocm realm test
+ERROR <nil> error realm ocm realm test
+V[4] ctxdebug realm ocm realm test
+V[3] ctxinfo realm ocm realm test
+V[2] ctxwarn realm ocm realm test
+ERROR <nil> ctxerror realm ocm realm test
 `))
 	})
 
@@ -95,14 +96,14 @@ ERROR <nil> ocm/test ctxerror
 		buf := bytes.NewBuffer(nil)
 		Expect(env.CatchOutput(buf).ExecuteModified(addTestCommands, "--logconfig", "@testdata/logcfg.yaml", "logtest")).To(Succeed())
 		Expect(log.String()).To(StringEqualTrimmedWithContext(`
-V[4] ocm/test debug
-V[3] ocm/test info
-V[2] ocm/test warn
-ERROR <nil> ocm/test error
-V[4] ocm/test ctxdebug
-V[3] ocm/test ctxinfo
-V[2] ocm/test ctxwarn
-ERROR <nil> ocm/test ctxerror
+V[4] debug realm ocm realm test
+V[3] info realm ocm realm test
+V[2] warn realm ocm realm test
+ERROR <nil> error realm ocm realm test
+V[4] ctxdebug realm ocm realm test
+V[3] ctxinfo realm ocm realm test
+V[2] ctxwarn realm ocm realm test
+ERROR <nil> ctxerror realm ocm realm test
 `))
 	})
 
@@ -116,14 +117,14 @@ rules:
       conditions:
         - realm: test`, "logtest")).To(Succeed())
 		Expect(log.String()).To(StringEqualTrimmedWithContext(`
-V[4] ocm/test debug
-V[3] ocm/test info
-V[2] ocm/test warn
-ERROR <nil> ocm/test error
-V[4] ocm/test ctxdebug
-V[3] ocm/test ctxinfo
-V[2] ocm/test ctxwarn
-ERROR <nil> ocm/test ctxerror
+V[4] debug realm ocm realm test
+V[3] info realm ocm realm test
+V[2] warn realm ocm realm test
+ERROR <nil> error realm ocm realm test
+V[4] ctxdebug realm ocm realm test
+V[3] ctxinfo realm ocm realm test
+V[2] ctxwarn realm ocm realm test
+ERROR <nil> ctxerror realm ocm realm test
 `))
 	})
 
@@ -134,7 +135,8 @@ ERROR <nil> ocm/test ctxerror
 		data, err := vfs.ReadFile(env.FileSystem(), "logfile")
 		Expect(err).To(Succeed())
 
-		Expect(len(string(data))).To(Equal(191))
+		fmt.Printf("%s\n", string(data))
+		Expect(len(string(data))).To(Equal(181))
 	})
 
 	It("sets attr from file", func() {

--- a/cmds/ocm/commands/ocicmds/common/handlers/artifacthdlr/attached.go
+++ b/cmds/ocm/commands/ocicmds/common/handlers/artifacthdlr/attached.go
@@ -7,6 +7,7 @@ package artifacthdlr
 import (
 	"strings"
 
+	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/opencontainers/go-digest"
 
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/output"
@@ -27,7 +28,7 @@ func explodeAttached(o interface{}) []interface{} {
 	dig := blob.Digest()
 	prefix := Attachment(dig, "")
 	list, err := obj.Namespace.ListTags()
-	hist := append(obj.History.Copy(), common.NewNameVersion("", dig.String()))
+	hist := generics.AppendedSlice(obj.History, common.NewNameVersion("", dig.String()))
 	if err == nil {
 		for _, l := range list {
 			if strings.HasPrefix(l, prefix) {

--- a/cmds/ocm/commands/ocmcmds/common/addconfig.go
+++ b/cmds/ocm/commands/ocmcmds/common/addconfig.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
+	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/yaml"
 
@@ -57,7 +58,7 @@ type ResourceConfigAdderCommand struct {
 // NewCommand creates a new ctf command.
 func NewResourceConfigAdderCommand(ctx clictx.Context, adder ElementSpecificationsProvider, opts ...options.Options) ResourceConfigAdderCommand {
 	return ResourceConfigAdderCommand{
-		BaseCommand: utils.NewBaseCommand(ctx, append(opts, templateroption.New("none"))...),
+		BaseCommand: utils.NewBaseCommand(ctx, generics.AppendedSlice[options.Options](opts, templateroption.New("none"))...),
 		Adder:       adder,
 	}
 }

--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/interface.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/interface.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/clictx"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/generics"
 )
 
 type ResourceInput struct {
@@ -54,7 +55,7 @@ func (s *sourceInfo) Sub(indices ...interface{}) SourceInfo {
 	}
 	return &sourceInfo{
 		origin:  s.origin,
-		indices: append(s.indices, indices...),
+		indices: generics.AppendedSlice(s.indices, indices...),
 	}
 }
 

--- a/cmds/ocm/commands/ocmcmds/common/handlers/elemhdlr/typehandler.go
+++ b/cmds/ocm/commands/ocmcmds/common/handlers/elemhdlr/typehandler.go
@@ -168,7 +168,7 @@ func (h *TypeHandler) all(c *comphdlr.Object) ([]output.Object, error) {
 			e := elemaccess.Get(i)
 			if h.filterElement(e) {
 				result = append(result, &Object{
-					History:   append(c.History, common.VersionedElementKey(c.ComponentVersion)),
+					History:   c.History.Append(common.VersionedElementKey(c.ComponentVersion)),
 					Version:   c.ComponentVersion,
 					VersionId: c.Identity,
 					Id:        e.GetMeta().GetIdentity(elemaccess),
@@ -179,7 +179,7 @@ func (h *TypeHandler) all(c *comphdlr.Object) ([]output.Object, error) {
 
 		if len(result) == 0 && h.forceEmpty {
 			result = append(result, &Object{
-				History:   append(c.History, common.VersionedElementKey(c.ComponentVersion)),
+				History:   c.History.Append(common.VersionedElementKey(c.ComponentVersion)),
 				Version:   c.ComponentVersion,
 				VersionId: c.Identity,
 				Id:        metav1.Identity{},
@@ -221,7 +221,7 @@ func (h *TypeHandler) get(c *comphdlr.Object, elemspec utils.ElemSpec) ([]output
 		ok, _ := selector.Match(eid)
 		if ok {
 			result = append(result, &Object{
-				History:   append(c.History, common.VersionedElementKey(c.ComponentVersion)),
+				History:   c.History.Append(common.VersionedElementKey(c.ComponentVersion)),
 				Version:   c.ComponentVersion,
 				VersionId: c.Identity,
 				Spec:      selector,
@@ -232,7 +232,7 @@ func (h *TypeHandler) get(c *comphdlr.Object, elemspec utils.ElemSpec) ([]output
 	}
 	if len(result) == 0 && h.forceEmpty {
 		result = append(result, &Object{
-			History:   append(c.History, common.VersionedElementKey(c.ComponentVersion)),
+			History:   c.History.Append(common.VersionedElementKey(c.ComponentVersion)),
 			Version:   c.ComponentVersion,
 			VersionId: c.Identity,
 			Id:        metav1.Identity{},

--- a/cmds/ocm/commands/ocmcmds/common/resources.go
+++ b/cmds/ocm/commands/ocmcmds/common/resources.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	_ "github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs/types"
+	"github.com/open-component-model/ocm/pkg/generics"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
 	"github.com/spf13/pflag"
@@ -131,7 +132,7 @@ type ElementMetaDataSpecificationsProvider struct {
 
 func NewElementMetaDataSpecificationsProvider(name string, adder flagsets.ConfigAdder, types ...flagsets.ConfigOptionType) *ElementMetaDataSpecificationsProvider {
 	meta := flagsets.NewPlainConfigProvider(name, flagsets.ComposedAdder(addMeta(name), adder),
-		append(types,
+		generics.AppendedSlice(types,
 			flagsets.NewYAMLOptionType(name, fmt.Sprintf("%s meta data (yaml)", name)),
 			flagsets.NewStringOptionType("name", fmt.Sprintf("%s name", name)),
 			flagsets.NewStringOptionType("version", fmt.Sprintf("%s version", name)),
@@ -227,7 +228,7 @@ func NewContentResourceSpecificationProvider(ctx clictx.Context, name string, ad
 		DefaultType: deftype,
 		ctx:         ctx,
 		ElementMetaDataSpecificationsProvider: NewElementMetaDataSpecificationsProvider(name, flagsets.ComposedAdder(addContentMeta, adder),
-			append(types,
+			generics.AppendedSlice(types,
 				flagsets.NewStringOptionType("type", fmt.Sprintf("%s type", name)),
 			)...,
 		),
@@ -369,7 +370,7 @@ type ResourceAdderCommand struct {
 
 func NewResourceAdderCommand(ctx clictx.Context, h ResourceSpecHandler, provider ElementSpecificationsProvider, opts ...options.Options) ResourceAdderCommand {
 	return ResourceAdderCommand{
-		BaseCommand: utils.NewBaseCommand(ctx, append(opts,
+		BaseCommand: utils.NewBaseCommand(ctx, generics.AppendedSlice[options.Options](opts,
 			fileoption.NewCompArch(),
 			dryrunoption.New(fmt.Sprintf("evaluate and print %s specifications", h.Key()), true),
 			templateroption.New(""),

--- a/cmds/ocm/commands/ocmcmds/resources/get/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/resources/get/cmd.go
@@ -5,6 +5,7 @@
 package get
 
 import (
+	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/spf13/cobra"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/common/options/closureoption"
@@ -119,7 +120,7 @@ func getTreewide(opts *output.Options) output.Output {
 
 func mapGetRegularOutput(e interface{}) interface{} {
 	r := common.Elem(e)
-	return append(elemhdlr.MapMetaOutput(e), r.Type, string(r.Relation))
+	return generics.AppendedSlice(elemhdlr.MapMetaOutput(e), r.Type, string(r.Relation))
 }
 
 func mapGetWideOutput(e interface{}) interface{} {

--- a/cmds/ocm/commands/ocmcmds/sources/get/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/sources/get/cmd.go
@@ -5,6 +5,7 @@
 package get
 
 import (
+	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/spf13/cobra"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/common/options/closureoption"
@@ -114,9 +115,9 @@ func getTree(opts *output.Options) output.Output {
 
 func mapGetRegularOutput(e interface{}) interface{} {
 	r := common.Elem(e)
-	return append(elemhdlr.MapMetaOutput(e), r.Type)
+	return generics.AppendedSlice(elemhdlr.MapMetaOutput(e), r.Type)
 }
 
 func mapGetWideOutput(e interface{}) interface{} {
-	return append(mapGetRegularOutput(e).([]string), elemhdlr.MapAccessOutput(common.Elem(e).Access)...)
+	return generics.AppendedSlice(mapGetRegularOutput(e).([]string), elemhdlr.MapAccessOutput(common.Elem(e).Access)...)
 }

--- a/cmds/ocm/topics/common/logging/topic.go
+++ b/cmds/ocm/topics/common/logging/topic.go
@@ -35,7 +35,7 @@ or by command line options of the <CMD>ocm</CMD> command. Details about
 the YAML structure of a logging settings can be found on https://github.com/mandelsoft/logging.
 
 The command line also supports some quick-config options for enabling log levels
-for dedicated tags and realms (logging keys).
+for dedicated tags and realms or realm prefixes (logging keys).
 
 ` + describe("tags", logging.GetTagDefinitions()) + `
 

--- a/docs/reference/ocm.md
+++ b/docs/reference/ocm.md
@@ -16,7 +16,7 @@ ocm [<options>] <sub command> ...
   -h, --help                    help for ocm
       --logconfig string        log config
   -L, --logfile string          set log file
-      --logkeys stringArray     log tags/realms(with leading /) to be enabled ([/]name{,[/]name}[=level])
+      --logkeys stringArray     log tags/realms(with leading /) to be enabled ([/[+]]name{,[/[+]]name}[=level])
   -l, --loglevel string         set log level
   -v, --verbose                 deprecated: enable logrus verbose logging
       --version                 show version
@@ -75,13 +75,19 @@ form
 </center>
 
 The <code>--log*</code> options can be used to configure the logging behaviour.
+For details see [ocm logging](ocm_logging.md).
+
 There is a quick config option <code>--logkeys</code> to configure simple
 tag/realm based condition rules. The comma-separated names build an AND rule.
-Hereby, names starting with a slash (<code>/</code>) denote a realm (without the leading slash).
-A realm is a slash separated sequence of identifiers, which matches all logging realms
-with the given realms as path prefix. A tag directly matches the logging tags.
-Used tags and realms can be found under topic [ocm logging](ocm_logging.md). The ocm coding basically
-uses the realm <code>ocm</code>.
+Hereby, names starting with a slash (<code>/</code>) denote a realm (without
+the leading slash). A realm is a slash separated sequence of identifiers. If
+the realm name starts with a plus (<code>+</code>) character the generated rule
+will match the realm and all its sub-realms, otherwise, only the dedicated
+realm is affected. For example <code>/+ocm=trace</code> will enable all log output of the
+OCM library.
+
+A tag directly matches the logging tags. Used tags and realms can be found under
+topic [ocm logging](ocm_logging.md). The ocm coding basically uses the realm <code>ocm</code>.
 The default level to enable is <code>info</code>. Separated by an equal sign (<code>=</code>)
 optionally a dedicated level can be specified. Log levels can be (<code>error</code>,
 <code>warn</code>, <code>info</code>, <code>debug</code> and <code>trace</code>.

--- a/docs/reference/ocm_logging.md
+++ b/docs/reference/ocm_logging.md
@@ -8,7 +8,7 @@ or by command line options of the [ocm](ocm.md) command. Details about
 the YAML structure of a logging settings can be found on https://github.com/mandelsoft/logging.
 
 The command line also supports some quick-config options for enabling log levels
-for dedicated tags and realms (logging keys).
+for dedicated tags and realms or realm prefixes (logging keys).
 
 The following *tags* are used by the command line tool:
   - <code>blobhandler</code>: execution of blob handler used to upload resource blobs to an ocm repository.
@@ -21,8 +21,8 @@ The following *realms* are used by the command line tool:
   - <code>ocm/compdesc</code>: component descriptor handling
   - <code>ocm/credentials/dockerconfig</code>: docker config handling as credential repository
   - <code>ocm/downloader</code>: Downloaders
-  - <code>ocm/oci.ocireg</code>: OCI repository handling
-  - <code>ocm/ocimapping</code>: OCM to OCI Registry Mapping
+  - <code>ocm/oci/mapping</code>: OCM to OCI Registry Mapping
+  - <code>ocm/oci/ocireg</code>: OCI repository handling
   - <code>ocm/plugins</code>: OCM plugin handling
   - <code>ocm/processing</code>: output processing chains
   - <code>ocm/refcnt</code>: reference counting

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/google/go-github/v45 v45.2.0
 	github.com/klauspost/compress v1.16.5
 	github.com/klauspost/pgzip v1.2.5
-	github.com/mandelsoft/logging v0.0.0-20230901151820-d2b141fbe4e0
+	github.com/mandelsoft/logging v0.0.0-20230904155400-33e44b3c12d5
 	github.com/mandelsoft/vfs v0.0.0-20230713123140-269aa4fb1338
 	github.com/marstr/guid v1.1.0
 	github.com/mitchellh/copystructure v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/google/go-github/v45 v45.2.0
 	github.com/klauspost/compress v1.16.5
 	github.com/klauspost/pgzip v1.2.5
-	github.com/mandelsoft/logging v0.0.0-20230904155400-33e44b3c12d5
+	github.com/mandelsoft/logging v0.0.0-20230905123808-7042ee3aae45
 	github.com/mandelsoft/vfs v0.0.0-20230713123140-269aa4fb1338
 	github.com/marstr/guid v1.1.0
 	github.com/mitchellh/copystructure v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/google/go-github/v45 v45.2.0
 	github.com/klauspost/compress v1.16.5
 	github.com/klauspost/pgzip v1.2.5
-	github.com/mandelsoft/logging v0.0.0-20230830150659-23eef406cc79
+	github.com/mandelsoft/logging v0.0.0-20230901151820-d2b141fbe4e0
 	github.com/mandelsoft/vfs v0.0.0-20230713123140-269aa4fb1338
 	github.com/marstr/guid v1.1.0
 	github.com/mitchellh/copystructure v1.2.0
@@ -219,7 +219,7 @@ require (
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.17 // indirect
+	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/miekg/pkcs11 v1.1.1 // indirect
@@ -272,6 +272,8 @@ require (
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
 	github.com/tjfoc/gmsm v1.3.2 // indirect
 	github.com/transparency-dev/merkle v0.0.2 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/vbatts/tar-split v0.11.3 // indirect
 	github.com/xanzy/go-gitlab v0.86.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect

--- a/go.sum
+++ b/go.sum
@@ -1133,6 +1133,8 @@ github.com/mandelsoft/logging v0.0.0-20230901151820-d2b141fbe4e0 h1:CxB7BSzgizMf
 github.com/mandelsoft/logging v0.0.0-20230901151820-d2b141fbe4e0/go.mod h1:J/kRqdfAOQmMPfJeAcV2pfX1QLV9/NlAQdAJzpnaU+g=
 github.com/mandelsoft/logging v0.0.0-20230904155400-33e44b3c12d5 h1:lG9tIZGdN2uGAQ7ft+EgANDZs8MwjrOog7ce6Q7ghcY=
 github.com/mandelsoft/logging v0.0.0-20230904155400-33e44b3c12d5/go.mod h1:J/kRqdfAOQmMPfJeAcV2pfX1QLV9/NlAQdAJzpnaU+g=
+github.com/mandelsoft/logging v0.0.0-20230905123808-7042ee3aae45 h1:BGJBqw9q1Brn3XAYcj52hhonjV7aHUftVJ3SuJpXQ/M=
+github.com/mandelsoft/logging v0.0.0-20230905123808-7042ee3aae45/go.mod h1:J/kRqdfAOQmMPfJeAcV2pfX1QLV9/NlAQdAJzpnaU+g=
 github.com/mandelsoft/spiff v1.7.0-beta-5 h1:3kC10nTviDQhL8diSxp7i4IC2iSiDg6KPbH1CAq7Lfw=
 github.com/mandelsoft/spiff v1.7.0-beta-5/go.mod h1:TwEeOPuRZxlzQBCLEyVTlHmBSruSGGNdiQ2fovVJ8ao=
 github.com/mandelsoft/vfs v0.0.0-20230713123140-269aa4fb1338 h1:06XAA8Z3qNQLdq8eUtxGRDgJ3dSzJuqt82y3E3siO6s=

--- a/go.sum
+++ b/go.sum
@@ -1131,6 +1131,8 @@ github.com/mandelsoft/logging v0.0.0-20230901143854-59760383a02a h1:XAWD6mhShwue
 github.com/mandelsoft/logging v0.0.0-20230901143854-59760383a02a/go.mod h1:J/kRqdfAOQmMPfJeAcV2pfX1QLV9/NlAQdAJzpnaU+g=
 github.com/mandelsoft/logging v0.0.0-20230901151820-d2b141fbe4e0 h1:CxB7BSzgizMfu8hTsPoGwf3VNh4JTGthA5SS1orP8xU=
 github.com/mandelsoft/logging v0.0.0-20230901151820-d2b141fbe4e0/go.mod h1:J/kRqdfAOQmMPfJeAcV2pfX1QLV9/NlAQdAJzpnaU+g=
+github.com/mandelsoft/logging v0.0.0-20230904155400-33e44b3c12d5 h1:lG9tIZGdN2uGAQ7ft+EgANDZs8MwjrOog7ce6Q7ghcY=
+github.com/mandelsoft/logging v0.0.0-20230904155400-33e44b3c12d5/go.mod h1:J/kRqdfAOQmMPfJeAcV2pfX1QLV9/NlAQdAJzpnaU+g=
 github.com/mandelsoft/spiff v1.7.0-beta-5 h1:3kC10nTviDQhL8diSxp7i4IC2iSiDg6KPbH1CAq7Lfw=
 github.com/mandelsoft/spiff v1.7.0-beta-5/go.mod h1:TwEeOPuRZxlzQBCLEyVTlHmBSruSGGNdiQ2fovVJ8ao=
 github.com/mandelsoft/vfs v0.0.0-20230713123140-269aa4fb1338 h1:06XAA8Z3qNQLdq8eUtxGRDgJ3dSzJuqt82y3E3siO6s=

--- a/go.sum
+++ b/go.sum
@@ -1127,6 +1127,10 @@ github.com/mandelsoft/filepath v0.0.0-20230412200429-36b1eb66bd27 h1:VivN6K8H4H0
 github.com/mandelsoft/filepath v0.0.0-20230412200429-36b1eb66bd27/go.mod h1:LxhqC7khDoRENwooP6f/vWvia9ivj6TqLYrR39zqkN0=
 github.com/mandelsoft/logging v0.0.0-20230830150659-23eef406cc79 h1:CNpizgLTmopPIkjXUX7iOAyEDm59WOg7yrriViF/sUw=
 github.com/mandelsoft/logging v0.0.0-20230830150659-23eef406cc79/go.mod h1:HjtBPH5tsJygvyYEu2r/ZwOOBGcu+oR2sKH73VEnHtg=
+github.com/mandelsoft/logging v0.0.0-20230901143854-59760383a02a h1:XAWD6mhShwue+rInkhbwBiFscwa9kAjfoISxQJKZ/HI=
+github.com/mandelsoft/logging v0.0.0-20230901143854-59760383a02a/go.mod h1:J/kRqdfAOQmMPfJeAcV2pfX1QLV9/NlAQdAJzpnaU+g=
+github.com/mandelsoft/logging v0.0.0-20230901151820-d2b141fbe4e0 h1:CxB7BSzgizMfu8hTsPoGwf3VNh4JTGthA5SS1orP8xU=
+github.com/mandelsoft/logging v0.0.0-20230901151820-d2b141fbe4e0/go.mod h1:J/kRqdfAOQmMPfJeAcV2pfX1QLV9/NlAQdAJzpnaU+g=
 github.com/mandelsoft/spiff v1.7.0-beta-5 h1:3kC10nTviDQhL8diSxp7i4IC2iSiDg6KPbH1CAq7Lfw=
 github.com/mandelsoft/spiff v1.7.0-beta-5/go.mod h1:TwEeOPuRZxlzQBCLEyVTlHmBSruSGGNdiQ2fovVJ8ao=
 github.com/mandelsoft/vfs v0.0.0-20230713123140-269aa4fb1338 h1:06XAA8Z3qNQLdq8eUtxGRDgJ3dSzJuqt82y3E3siO6s=
@@ -1156,6 +1160,8 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
+github.com/mattn/go-isatty v0.0.19 h1:JITubQf0MOLdlGRuRq+jtsDlekdYPia9ZFsB8h/APPA=
+github.com/mattn/go-isatty v0.0.19/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-oci8 v0.1.1/go.mod h1:wjDx6Xm9q7dFtHJvIlrI99JytznLw5wQ4R+9mNXJwGI=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
@@ -1577,6 +1583,10 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/urfave/cli v1.22.12/go.mod h1:sSBEIC79qR6OvcmsD4U3KABeOTxDqQtdDnaFuUN30b8=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
+github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/vbatts/tar-split v0.11.2/go.mod h1:vV3ZuO2yWSVsz+pfFzDG/upWH1JhjOiEaWq6kXyQ3VI=
 github.com/vbatts/tar-split v0.11.3 h1:hLFqsOLQ1SsppQNTMpkpPXClLDfC2A3Zgy9OUU+RVck=
 github.com/vbatts/tar-split v0.11.3/go.mod h1:9QlHN18E+fEH7RdG+QAJJcuya3rqT7eXSTY7wGrAokY=

--- a/pkg/cobrautils/flagsets/configoptions.go
+++ b/pkg/cobrautils/flagsets/configoptions.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/pflag"
+	"golang.org/x/exp/slices"
 )
 
 type Option interface {
@@ -57,7 +58,7 @@ func (o *configOptions) AddTypeSetGroupsToOptions(set ConfigOptionTypeSet) {
 }
 
 func (o *configOptions) Options() []Option {
-	return append(o.options[:0:0], o.options...)
+	return slices.Clone(o.options)
 }
 
 func (o *configOptions) GetValue(name string) (interface{}, bool) {

--- a/pkg/cobrautils/logopts/options_test.go
+++ b/pkg/cobrautils/logopts/options_test.go
@@ -27,6 +27,7 @@ var _ = Describe("log configuration", func() {
 			LogKeys: []string{
 				"tag=trace",
 				"/realm=info",
+				"/+all=info",
 			},
 		}
 
@@ -40,7 +41,11 @@ var _ = Describe("log configuration", func() {
 
 		Expect(logctx.GetDefaultLevel()).To(Equal(logging.DebugLevel))
 		Expect(logctx.Logger(logging.NewTag("tag")).Enabled(logging.TraceLevel)).To(BeTrue())
+		Expect(logctx.Logger(logging.NewRealm("all")).Enabled(logging.DebugLevel)).To(BeFalse())
+		Expect(logctx.Logger(logging.NewRealm("all/test")).Enabled(logging.DebugLevel)).To(BeFalse())
+		Expect(logctx.Logger(logging.NewRealm("realm")).Enabled(logging.InfoLevel)).To(BeTrue())
+		Expect(logctx.Logger(logging.NewRealm("realm")).Enabled(logging.DebugLevel)).To(BeFalse())
 		Expect(logctx.Logger(logging.NewRealm("realm/test")).Enabled(logging.InfoLevel)).To(BeTrue())
-		Expect(logctx.Logger(logging.NewRealm("realm/test")).Enabled(logging.DebugLevel)).To(BeFalse())
+		Expect(logctx.Logger(logging.NewRealm("realm/test")).Enabled(logging.DebugLevel)).To(BeTrue())
 	})
 })

--- a/pkg/common/history.go
+++ b/pkg/common/history.go
@@ -9,7 +9,10 @@ import (
 	"reflect"
 	"sort"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/generics"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -80,14 +83,11 @@ func (h *History) Add(kind string, nv NameVersion) error {
 
 // Append provides a new extended history without cycle check.
 func (h History) Append(nv ...NameVersion) History {
-	result := make(History, len(h)+len(nv))
-	copy(result, h)
-	copy(result[len(h):], nv)
-	return result
+	return generics.AppendedSlice(h, nv...)
 }
 
 func (h History) Copy() History {
-	return append(h[:0:0], h...)
+	return slices.Clone(h)
 }
 
 func (h History) RemovePrefix(prefix History) History {

--- a/pkg/contexts/credentials/internal/credentials.go
+++ b/pkg/contexts/credentials/internal/credentials.go
@@ -6,6 +6,8 @@ package internal
 
 import (
 	"github.com/modern-go/reflect2"
+
+	"github.com/open-component-model/ocm/pkg/generics"
 )
 
 // CredentialsSource is a factory for effective credentials.
@@ -27,5 +29,5 @@ func (c CredentialsChain) Credentials(ctx Context, creds ...CredentialsSource) (
 	if len(creds) == 0 {
 		return c[0].Credentials(ctx, c[1:]...)
 	}
-	return c[0].Credentials(ctx, append(append(c[:0:len(c)-1+len(creds)], c[1:]...), creds...))
+	return c[0].Credentials(ctx, generics.AppendedSlice(c[1:], creds...)...)
 }

--- a/pkg/contexts/datacontext/action/api/registry.go
+++ b/pkg/contexts/datacontext/action/api/registry.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"sync"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/runtime"
 	"github.com/open-component-model/ocm/pkg/utils"
@@ -131,7 +133,7 @@ func (r *actionRegistry) RegisterAction(name string, description string, usage s
 		name:       name,
 		shortdesc:  description,
 		usage:      usage,
-		attributes: append(attrs[:0:0], attrs...),
+		attributes: slices.Clone(attrs),
 		types:      map[string]ActionType{},
 	}
 	r.actions[name] = ai

--- a/pkg/contexts/datacontext/action/handlers/options.go
+++ b/pkg/contexts/datacontext/action/handlers/options.go
@@ -5,6 +5,8 @@
 package handlers
 
 import (
+	"golang.org/x/exp/slices"
+
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext/action/api"
 )
 
@@ -66,7 +68,7 @@ type versions struct {
 }
 
 func WithVersions(vers ...string) Option {
-	return versions{append(vers[:0:0], vers...)}
+	return versions{slices.Clone(vers)}
 }
 
 func (o versions) ApplyActionHandlerOptionTo(opts *Options) {

--- a/pkg/contexts/datacontext/action/handlers/registry.go
+++ b/pkg/contexts/datacontext/action/handlers/registry.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"sync"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext/action/api"
 	"github.com/open-component-model/ocm/pkg/errors"
@@ -142,7 +144,7 @@ func (r *registry) Register(h ActionHandler, olist ...Option) error {
 	if versions == nil {
 		versions = r.types.SupportedActionVersions(opts.Action)
 	}
-	versions = append(versions[:0:0], versions...)
+	versions = slices.Clone(versions)
 	if err := runtime.SortVersions(versions); err != nil {
 		return errors.Wrapf(err, "invalid version set")
 	}
@@ -217,8 +219,8 @@ func (r *registry) Get(spec api.ActionSpec, possible ...string) []ActionHandlerM
 }
 
 func MatchVersion(possible []string, avail []string) string {
-	p := append(possible[:0:0], possible...) //nolint: gocritic // yes
-	a := append(avail[:0:0], avail...)       //nolint: gocritic // yes
+	p := slices.Clone(possible)
+	a := slices.Clone(avail)
 
 	runtime.SortVersions(p)
 	runtime.SortVersions(a)

--- a/pkg/contexts/datacontext/config/logging/config_test.go
+++ b/pkg/contexts/datacontext/config/logging/config_test.go
@@ -43,9 +43,9 @@ var _ = Describe("logging configuration", func() {
 		LogTest(ctx)
 
 		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[3] ocm info
-V[2] ocm warn
-ERROR <nil> ocm error
+V[3] info realm ocm
+V[2] warn realm ocm
+ERROR <nil> error realm ocm
 `))
 	})
 
@@ -54,10 +54,10 @@ ERROR <nil> ocm error
 		LogTest(ctx)
 
 		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[4] ocm debug
-V[3] ocm info
-V[2] ocm warn
-ERROR <nil> ocm error
+V[4] debug realm ocm
+V[3] info realm ocm
+V[2] warn realm ocm
+ERROR <nil> error realm ocm
 `))
 	})
 
@@ -66,10 +66,10 @@ ERROR <nil> ocm error
 		LogTest(cfg)
 
 		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[4] ocm debug
-V[3] ocm info
-V[2] ocm warn
-ERROR <nil> ocm error
+V[4] debug realm ocm
+V[3] info realm ocm
+V[2] warn realm ocm
+ERROR <nil> error realm ocm
 `))
 	})
 
@@ -88,14 +88,14 @@ settings:
 		LogTest(cfg, "cfg")
 
 		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[4] ocm debug
-V[3] ocm info
-V[2] ocm warn
-ERROR <nil> ocm error
-V[4] ocm cfgdebug
-V[3] ocm cfginfo
-V[2] ocm cfgwarn
-ERROR <nil> ocm cfgerror
+V[4] debug realm ocm
+V[3] info realm ocm
+V[2] warn realm ocm
+ERROR <nil> error realm ocm
+V[4] cfgdebug realm ocm
+V[3] cfginfo realm ocm
+V[2] cfgwarn realm ocm
+ERROR <nil> cfgerror realm ocm
 `))
 	})
 
@@ -114,14 +114,14 @@ settings:
 		LogTest(cfg, "cfg")
 
 		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[4] ocm debug
-V[3] ocm info
-V[2] ocm warn
-ERROR <nil> ocm error
-V[4] ocm cfgdebug
-V[3] ocm cfginfo
-V[2] ocm cfgwarn
-ERROR <nil> ocm cfgerror
+V[4] debug realm ocm
+V[3] info realm ocm
+V[2] warn realm ocm
+ERROR <nil> error realm ocm
+V[4] cfgdebug realm ocm
+V[3] cfginfo realm ocm
+V[2] cfgwarn realm ocm
+ERROR <nil> cfgerror realm ocm
 `))
 	})
 
@@ -141,13 +141,13 @@ settings:
 		LogTest(cfg, "cfg")
 
 		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[3] ocm info
-V[2] ocm warn
-ERROR <nil> ocm error
-V[4] ocm cfgdebug
-V[3] ocm cfginfo
-V[2] ocm cfgwarn
-ERROR <nil> ocm cfgerror
+V[3] info realm ocm
+V[2] warn realm ocm
+ERROR <nil> error realm ocm
+V[4] cfgdebug realm ocm
+V[3] cfginfo realm ocm
+V[2] cfgwarn realm ocm
+ERROR <nil> cfgerror realm ocm
 `))
 	})
 
@@ -194,10 +194,10 @@ settings:
 			LogTest(ctx)
 
 			Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[4] ocm debug
-V[3] ocm info
-V[2] ocm warn
-ERROR <nil> ocm error
+V[4] debug realm ocm
+V[3] info realm ocm
+V[2] warn realm ocm
+ERROR <nil> error realm ocm
 `))
 		})
 
@@ -212,9 +212,9 @@ ERROR <nil> ocm error
 			LogTest(ctx)
 
 			Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[3] ocm info
-V[2] ocm warn
-ERROR <nil> ocm error
+V[3] info realm ocm
+V[2] warn realm ocm
+ERROR <nil> error realm ocm
 `))
 		})
 		It("re-applies config with extra id", func() {
@@ -228,10 +228,10 @@ ERROR <nil> ocm error
 			LogTest(ctx)
 
 			Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[4] ocm debug
-V[3] ocm info
-V[2] ocm warn
-ERROR <nil> ocm error
+V[4] debug realm ocm
+V[3] info realm ocm
+V[2] warn realm ocm
+ERROR <nil> error realm ocm
 `))
 		})
 	})

--- a/pkg/contexts/oci/internal/uniform.go
+++ b/pkg/contexts/oci/internal/uniform.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/runtime"
@@ -156,7 +157,7 @@ func (s *specHandlers) Copy() RepositorySpecHandlers {
 
 	n := NewRepositorySpecHandlers().(*specHandlers)
 	for typ, hdlrs := range s.handlers {
-		n.handlers[typ] = append(hdlrs[:0:0], hdlrs...)
+		n.handlers[typ] = slices.Clone(hdlrs)
 	}
 	return n
 }

--- a/pkg/contexts/oci/repositories/ocireg/logging.go
+++ b/pkg/contexts/oci/repositories/ocireg/logging.go
@@ -8,4 +8,4 @@ import (
 	ocmlog "github.com/open-component-model/ocm/pkg/logging"
 )
 
-var REALM = ocmlog.DefineSubRealm("OCI repository handling", "oci.ocireg")
+var REALM = ocmlog.DefineSubRealm("OCI repository handling", "oci", "ocireg")

--- a/pkg/contexts/ocm/blobhandler/handlers/generic/ocirepo/blobhandler.go
+++ b/pkg/contexts/ocm/blobhandler/handlers/generic/ocirepo/blobhandler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/attrs/ociuploadattr"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/open-component-model/ocm/pkg/utils"
 )
 
@@ -73,7 +74,7 @@ func (b *artifactHandler) StoreBlob(blob cpi.BlobAccess, artType, hint string, g
 	if m, ok := blob.(accessio.AnnotatedBlobAccess[cpi.AccessMethod]); ok {
 		// prepare for optimized point to point implementation
 		cpi.BlobHandlerLogger(ctx.GetContext()).Debug("oci generic artifact handler with ocm access source",
-			append(values, "sourcetype", m.Source().AccessSpec().GetType())...,
+			generics.AppendedSlice[any](values, "sourcetype", m.Source().AccessSpec().GetType())...,
 		)
 	} else {
 		cpi.BlobHandlerLogger(ctx.GetContext()).Debug("oci generic artifact handler", values...)

--- a/pkg/contexts/ocm/blobhandler/handlers/oci/ocirepo/blobhandler.go
+++ b/pkg/contexts/ocm/blobhandler/handlers/oci/ocirepo/blobhandler.go
@@ -30,6 +30,7 @@ import (
 	storagecontext "github.com/open-component-model/ocm/pkg/contexts/ocm/blobhandler/handlers/oci"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/generics"
 )
 
 func init() {
@@ -88,7 +89,7 @@ func (b *blobHandler) StoreBlob(blob cpi.BlobAccess, artType, hint string, globa
 	}
 	if m, ok := blob.(accessio.AnnotatedBlobAccess[cpi.AccessMethod]); ok {
 		cpi.BlobHandlerLogger(ctx.GetContext()).Debug("oci blob handler with ocm access source",
-			append(values, "sourcetype", m.Source().AccessSpec().GetType())...,
+			generics.AppendedSlice[any](values, "sourcetype", m.Source().AccessSpec().GetType())...,
 		)
 	} else {
 		cpi.BlobHandlerLogger(ctx.GetContext()).Debug("oci blob handler", values...)
@@ -152,7 +153,7 @@ func (b *artifactHandler) StoreBlob(blob cpi.BlobAccess, artType, hint string, g
 	if m, ok := blob.(accessio.AnnotatedBlobAccess[cpi.AccessMethod]); ok {
 		// prepare for optimized point to point implementation
 		log.Debug("oci artifact handler with ocm access source",
-			append(values, "sourcetype", m.Source().AccessSpec().GetType())...,
+			generics.AppendedSlice[any](values, "sourcetype", m.Source().AccessSpec().GetType())...,
 		)
 		if ocimeth, ok := m.Source().(ociartifact.AccessMethod); !keep && ok {
 			art, _, err = ocimeth.GetArtifact(&finalizer)
@@ -198,11 +199,11 @@ func (b *artifactHandler) StoreBlob(blob cpi.BlobAccess, artType, hint string, g
 		name = path.Join(prefix, mapped)
 		if mapped == orig {
 			log.Debug("namespace derived from hint",
-				append(values, "namespace", name),
+				generics.AppendedSlice[any](values, "namespace", name),
 			)
 		} else {
 			log.Debug("mapped namespace derived from hint",
-				append(values, "namespace", name),
+				generics.AppendedSlice[any](values, "namespace", name),
 			)
 		}
 

--- a/pkg/contexts/ocm/compdesc/helper.go
+++ b/pkg/contexts/ocm/compdesc/helper.go
@@ -10,6 +10,7 @@ import (
 
 	v1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/open-component-model/ocm/pkg/runtime"
 	"github.com/open-component-model/ocm/pkg/utils/selector"
 )
@@ -194,7 +195,7 @@ func (cd *ComponentDescriptor) GetResourcesByType(rtype string, selectors ...Ide
 // GetResourcesByName returns all local and external resources with a name.
 func (cd *ComponentDescriptor) GetResourcesByName(name string, selectors ...IdentitySelector) (Resources, error) {
 	return cd.GetResourcesBySelectors(
-		append(selectors, ByName(name)),
+		generics.AppendedSlice[IdentitySelector](selectors, ByName(name)),
 		nil)
 }
 
@@ -277,7 +278,7 @@ func (cd *ComponentDescriptor) GetReferenceByIdentity(id v1.Identity) (Component
 // GetReferencesByName returns references that match the given name.
 func (cd *ComponentDescriptor) GetReferencesByName(name string, selectors ...IdentitySelector) (References, error) {
 	return cd.GetReferencesBySelectors(
-		append(selectors, ByName(name)),
+		generics.AppendedSlice[IdentitySelector](selectors, ByName(name)),
 		nil)
 }
 

--- a/pkg/contexts/ocm/compdesc/logging_test.go
+++ b/pkg/contexts/ocm/compdesc/logging_test.go
@@ -43,7 +43,7 @@ var _ = Describe("logging", func() {
 		_, err := compdesc.Decode([]byte("[]"))
 		Expect(err).To(MatchError(`error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type struct { Meta v1.Metadata "json:\"meta\""; APIVersion string "json:\"apiVersion\"" }`))
 		Expect(buf.String()).To(testutils.StringEqualTrimmedWithContext(`
-V[4] ocm/compdesc decoding of component descriptor failed error error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type struct { Meta v1.Metadata "json:\"meta\""; APIVersion string "json:\"apiVersion\"" } data []
+V[4] decoding of component descriptor failed realm ocm realm ocm/compdesc error error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type struct { Meta v1.Metadata "json:\"meta\""; APIVersion string "json:\"apiVersion\"" } data []
 `))
 	})
 
@@ -64,7 +64,7 @@ component:
 `))
 		Expect(err).To(MatchError(`component.creationTime: Does not match format 'date-time'`))
 		Expect(buf.String()).To(testutils.StringEqualTrimmedWithContext(`
-V[4] ocm/compdesc versioned decoding of component descriptor failed error component.creationTime: Does not match format 'date-time' scheme v2 data meta: schemaVersion: v2 component: name: acme.org/test version: 1.0.0 provider: acme.org creationTime: "0815" repositoryContexts: [] resources: [] sources: [] componentReferences: []
+V[4] versioned decoding of component descriptor failed realm ocm realm ocm/compdesc error component.creationTime: Does not match format 'date-time' scheme v2 data meta: schemaVersion: v2 component: name: acme.org/test version: 1.0.0 provider: acme.org creationTime: "0815" repositoryContexts: [] resources: [] sources: [] componentReferences: []
 `))
 	})
 

--- a/pkg/contexts/ocm/cpi/interface.go
+++ b/pkg/contexts/ocm/cpi/interface.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/internal"
+	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/open-component-model/ocm/pkg/registrations"
 	"github.com/open-component-model/ocm/pkg/runtime"
 )
@@ -23,7 +24,7 @@ var TAG_BLOBHANDLER = logging.DefineTag("blobhandler", "execution of blob handle
 
 func BlobHandlerLogger(ctx Context, messageContext ...logging.MessageContext) logging.Logger {
 	if len(messageContext) > 0 {
-		messageContext = append(append(messageContext[:0:0], messageContext...), TAG_BLOBHANDLER)
+		messageContext = generics.AppendedSlice[logging.MessageContext](messageContext, TAG_BLOBHANDLER)
 		return ctx.Logger(messageContext...)
 	} else {
 		return ctx.Logger(TAG_BLOBHANDLER)

--- a/pkg/contexts/ocm/internal/digesthandler.go
+++ b/pkg/contexts/ocm/internal/digesthandler.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"sync"
 
+	"golang.org/x/exp/slices"
+
 	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 	"github.com/open-component-model/ocm/pkg/signing"
 	"github.com/open-component-model/ocm/pkg/utils"
@@ -167,10 +169,10 @@ func (r *blobDigesterRegistry) Copy() BlobDigesterRegistry {
 
 	n := NewBlobDigesterRegistry(r.base).(*blobDigesterRegistry)
 	for k, v := range r.typehandlers {
-		n.typehandlers[k] = append(v[:0:0], v...)
+		n.typehandlers[k] = slices.Clone(v)
 	}
 	for k, v := range r.normhandlers {
-		n.normhandlers[k] = append(v[:0:0], v...)
+		n.normhandlers[k] = slices.Clone(v)
 	}
 	for k, v := range r.digesters {
 		n.digesters[k] = v

--- a/pkg/contexts/ocm/internal/uniform.go
+++ b/pkg/contexts/ocm/internal/uniform.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/runtime"
@@ -120,7 +121,7 @@ func (s *specHandlers) Copy() RepositorySpecHandlers {
 
 	n := NewRepositorySpecHandlers().(*specHandlers)
 	for typ, hdlrs := range s.handlers {
-		n.handlers[typ] = append(hdlrs[:0:0], hdlrs...)
+		n.handlers[typ] = slices.Clone(hdlrs)
 	}
 	return n
 }

--- a/pkg/contexts/ocm/plugin/common/describe.go
+++ b/pkg/contexts/ocm/plugin/common/describe.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+	"golang.org/x/exp/slices"
 
 	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext/action/api"
@@ -175,8 +176,8 @@ func GetActionInfo(reg api.ActionTypeRegistry, actions []descriptor.ActionDescri
 		if i == nil {
 			i = &ActionInfo{
 				ActionDesc:   a.Description,
-				Versions:     append(a.Versions[:0:0], a.Versions...),
-				Selectors:    append(a.DefaultSelectors[:0:0], a.DefaultSelectors...),
+				Versions:     slices.Clone(a.Versions),
+				Selectors:    slices.Clone(a.DefaultSelectors),
 				ConsumerType: a.ConsumerType,
 			}
 			if err := runtime.SortVersions(i.Versions); err != nil {

--- a/pkg/contexts/ocm/plugin/descriptor/utils.go
+++ b/pkg/contexts/ocm/plugin/descriptor/utils.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/utils/registry"
+	"github.com/open-component-model/ocm/pkg/generics"
 )
 
 type Named interface {
@@ -56,5 +57,5 @@ next:
 		}
 		list = append(list, e)
 	}
-	return append(append(l[:0:0], l...), list...)
+	return generics.AppendedSlice(l, list...)
 }

--- a/pkg/contexts/ocm/repositories/genericocireg/logging.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/logging.go
@@ -10,7 +10,7 @@ import (
 	ocmlog "github.com/open-component-model/ocm/pkg/logging"
 )
 
-var REALM = ocmlog.DefineSubRealm("OCM to OCI Registry Mapping", "ocimapping")
+var REALM = ocmlog.DefineSubRealm("OCM to OCI Registry Mapping", "oci", "mapping")
 
 func Logger(ctx logging.ContextProvider, messageContext ...logging.MessageContext) logging.Logger {
 	return ctx.LoggingContext().Logger(append([]logging.MessageContext{REALM}, messageContext...))

--- a/pkg/contexts/ocm/signing/options.go
+++ b/pkg/contexts/ocm/signing/options.go
@@ -140,7 +140,7 @@ func SignerByName(n string) Option {
 func (o *signer) ApplySigningOption(opts *Options) {
 	n := strings.TrimSpace(o.name)
 	if n != "" {
-		opts.SignatureNames = append(append([]string{}, n), opts.SignatureNames...)
+		opts.SignatureNames = append([]string{n}, opts.SignatureNames...)
 	}
 	opts.Signer = o.signer
 }
@@ -211,7 +211,7 @@ func Resolver(h ...ocm.ComponentVersionResolver) Option {
 }
 
 func (o *resolver) ApplySigningOption(opts *Options) {
-	opts.Resolver = ocm.NewCompoundResolver(append(append([]ocm.ComponentVersionResolver{}, opts.Resolver), o.resolver...)...)
+	opts.Resolver = ocm.NewCompoundResolver(append([]ocm.ComponentVersionResolver{opts.Resolver}, o.resolver...)...)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/pkg/contexts/ocm/transfer/transferhandler/standard/handler_test.go
+++ b/pkg/contexts/ocm/transfer/transferhandler/standard/handler_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/open-component-model/ocm/pkg/contexts/oci/testhelper"
 	. "github.com/open-component-model/ocm/pkg/env"
 	. "github.com/open-component-model/ocm/pkg/env/builder"
+	"github.com/open-component-model/ocm/pkg/generics"
 	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
@@ -114,7 +115,7 @@ var _ = Describe("Transfer handler", func() {
 		Expect(err).To(Succeed())
 		defer tgt.Close()
 
-		err = transfer.Transfer(cv, tgt, append(topts, standard.ResourcesByValue(), &optionsChecker{})...)
+		err = transfer.Transfer(cv, tgt, generics.AppendedSlice[transferhandler.TransferOption](topts, standard.ResourcesByValue(), &optionsChecker{})...)
 		Expect(err).To(Succeed())
 		Expect(env.DirExists(OUT)).To(BeTrue())
 

--- a/pkg/contexts/ocm/transfer/transferhandler/standard/options.go
+++ b/pkg/contexts/ocm/transfer/transferhandler/standard/options.go
@@ -10,6 +10,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/transfer/transferhandler"
 	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/open-component-model/ocm/pkg/runtime"
 	"github.com/open-component-model/ocm/pkg/utils"
 )
@@ -426,7 +427,7 @@ type omitAccessTypesOption struct {
 func (o *omitAccessTypesOption) ApplyTransferOption(to transferhandler.TransferOptions) error {
 	if eff, ok := to.(OmitAccessTypesOption); ok {
 		if o.add {
-			eff.SetOmittedAccessTypes(append(eff.GetOmittedAccessTypes(), o.list...)...)
+			eff.SetOmittedAccessTypes(generics.AppendedSlice(eff.GetOmittedAccessTypes(), o.list...)...)
 		} else {
 			eff.SetOmittedAccessTypes(o.list...)
 		}

--- a/pkg/contexts/ocm/utils/localize/config.go
+++ b/pkg/contexts/ocm/utils/localize/config.go
@@ -13,6 +13,7 @@ import (
 	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/utils"
 	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/open-component-model/ocm/pkg/runtime"
 	"github.com/open-component-model/ocm/pkg/spiff"
 )
@@ -101,7 +102,7 @@ func Configure(
 			if l, ok := cur.([]interface{}); !ok {
 				return nil, errors.Newf("node 'configRules' in template must be a list of configuration requests")
 			} else {
-				temp["configRules"] = append(l, cfglist...)
+				temp["configRules"] = generics.AppendedSlice(l, cfglist...)
 			}
 		} else {
 			temp["configRules"] = cfglist
@@ -128,5 +129,5 @@ func Configure(
 		ConfigRules Substitutions `json:"configRules,omitempty"`
 	}
 	err = runtime.DefaultYAMLEncoding.Unmarshal(config, &subst)
-	return append(subst.Adjustments, subst.ConfigRules...), err
+	return generics.AppendedSlice(subst.Adjustments, subst.ConfigRules...), err
 }

--- a/pkg/contexts/ocm/utils/registry/registry.go
+++ b/pkg/contexts/ocm/utils/registry/registry.go
@@ -7,6 +7,8 @@ package registry
 import (
 	"strings"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/open-component-model/ocm/pkg/mime"
 )
@@ -51,7 +53,7 @@ func (p *Registry[H, K]) GetHandler(key K) []H {
 	if r == nil {
 		return nil
 	}
-	return append(r[:0:0], r...)
+	return slices.Clone(r)
 }
 
 func (p *Registry[H, K]) LookupHandler(key K) []H {

--- a/pkg/finalizer/object.go
+++ b/pkg/finalizer/object.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"runtime"
 	"sync"
+
+	"golang.org/x/exp/slices"
 )
 
 // NumberRange can be used as source for successive id numbers to tag
@@ -56,7 +58,7 @@ func (r *RuntimeFinalizationRecoder) Get() []ObjectIdentity {
 	r.lock.Lock()
 	defer r.lock.Unlock()
 
-	return append(r.ids[:0:0], r.ids...)
+	return slices.Clone(r.ids)
 }
 
 func (r *RuntimeFinalizationRecoder) Record(id ObjectIdentity) {

--- a/pkg/generics/slice.go
+++ b/pkg/generics/slice.go
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package generics
+
+import (
+	"golang.org/x/exp/slices"
+)
+
+func AppendedSlice[E any](slice []E, elems ...E) []E {
+	return append(slices.Clone(slice), elems...)
+}

--- a/pkg/logging/config_test.go
+++ b/pkg/logging/config_test.go
@@ -36,9 +36,9 @@ var _ = Describe("logging configuration", func() {
 	It("just logs with defaults", func() {
 		LogTest(ctx)
 		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[3] ocm info
-V[2] ocm warn
-ERROR <nil> ocm error
+V[3] info realm ocm
+V[2] warn realm ocm
+ERROR <nil> error realm ocm
 `))
 	})
 	It("just logs with config", func() {
@@ -50,10 +50,10 @@ ERROR <nil> ocm error
 		Expect(local.Configure(cfg)).To(Succeed())
 		LogTest(ctx)
 		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-V[4] ocm debug
-V[3] ocm info
-V[2] ocm warn
-ERROR <nil> ocm error
+V[4] debug realm ocm
+V[3] info realm ocm
+V[2] warn realm ocm
+ERROR <nil> error realm ocm
 `))
 	})
 

--- a/pkg/signing/handlers/rsa/format.go
+++ b/pkg/signing/handlers/rsa/format.go
@@ -12,6 +12,8 @@ import (
 	"fmt"
 	"io"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/utils"
 )
@@ -31,7 +33,7 @@ func GetPublicKey(key interface{}) (*rsa.PublicKey, []string, error) {
 		return &k.PublicKey, nil, nil
 	case *x509.Certificate:
 		if p, ok := k.PublicKey.(*rsa.PublicKey); ok {
-			names := append(k.DNSNames[:0:0], k.DNSNames...) //nolint: gocritic // yes
+			names := slices.Clone(k.DNSNames)
 			if k.Issuer.CommonName != "" {
 				names = append(names, k.Issuer.CommonName)
 			}

--- a/pkg/spiff/options.go
+++ b/pkg/spiff/options.go
@@ -15,6 +15,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext/attrs/vfsattr"
 	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/generics"
 )
 
 type Option interface {
@@ -110,14 +111,14 @@ func TemplateData(name string, data []byte) OptionFunction {
 
 func StubFile(path string, fss ...vfs.FileSystem) OptionFunction {
 	return func(r *Request) error {
-		r.Stubs = append(r.Stubs, spiffing.NewSourceFile(path, accessio.FileSystem(append(fss, r.FileSystem)...)))
+		r.Stubs = append(r.Stubs, spiffing.NewSourceFile(path, accessio.FileSystem(generics.AppendedSlice(fss, r.FileSystem)...)))
 		return nil
 	}
 }
 
 func TemplateFile(path string, fss ...vfs.FileSystem) OptionFunction {
 	return func(r *Request) error {
-		r.Template = spiffing.NewSourceFile(path, accessio.FileSystem(append(fss, r.FileSystem)...))
+		r.Template = spiffing.NewSourceFile(path, accessio.FileSystem(generics.AppendedSlice(fss, r.FileSystem)...))
 		return nil
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The new version moves the realm to a log message attribute.
This solves the problem of aggregative realm names in
former usage in logger names. Logger names can only extended, but realms are always absolute.

Additionally align the handling of slice appends to avoid overwriting of copied versions.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
