### PR TITLE
enable using session with unmarshalable repository specs

### DIFF
--- a/cmds/ocm/app/app.go
+++ b/cmds/ocm/app/app.go
@@ -11,17 +11,15 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/open-component-model/ocm/cmds/ocm/commands/common/options/keyoption"
 	_ "github.com/open-component-model/ocm/pkg/contexts/clictx/config"
 	_ "github.com/open-component-model/ocm/pkg/contexts/ocm/attrs"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/attrs/signingattr"
-	"github.com/open-component-model/ocm/pkg/signing"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/cachecmds"
+	"github.com/open-component-model/ocm/cmds/ocm/commands/common/options/keyoption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/misccmds/action"
 	creds "github.com/open-component-model/ocm/cmds/ocm/commands/misccmds/credentials"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocicmds"
@@ -69,10 +67,12 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext/attrs/vfsattr"
 	datacfg "github.com/open-component-model/ocm/pkg/contexts/datacontext/config/attrs"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/attrs/signingattr"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/registration"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/utils"
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/out"
+	"github.com/open-component-model/ocm/pkg/signing"
 	"github.com/open-component-model/ocm/pkg/version"
 )
 

--- a/cmds/ocm/commands/common/options/keyoption/option.go
+++ b/cmds/ocm/commands/common/options/keyoption/option.go
@@ -8,7 +8,6 @@ import (
 	"encoding/base64"
 	"strings"
 
-	"github.com/open-component-model/ocm/pkg/utils"
 	"github.com/spf13/pflag"
 
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
@@ -16,6 +15,7 @@ import (
 	ocmsign "github.com/open-component-model/ocm/pkg/contexts/ocm/signing"
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/signing"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 func From(o options.OptionSetProvider) *Option {

--- a/cmds/ocm/commands/misccmds/action/execute/cmd.go
+++ b/cmds/ocm/commands/misccmds/action/execute/cmd.go
@@ -9,6 +9,9 @@ import (
 	"strings"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/names"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/verbs"
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/utils"
@@ -20,8 +23,6 @@ import (
 	"github.com/open-component-model/ocm/pkg/out"
 	"github.com/open-component-model/ocm/pkg/runtime"
 	utils2 "github.com/open-component-model/ocm/pkg/utils"
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
 var (

--- a/cmds/ocm/commands/misccmds/hash/cmd.go
+++ b/cmds/ocm/commands/misccmds/hash/cmd.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
-	utils2 "github.com/open-component-model/ocm/pkg/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -23,6 +22,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/out"
 	"github.com/open-component-model/ocm/pkg/signing"
 	"github.com/open-component-model/ocm/pkg/signing/handlers/rsa"
+	utils2 "github.com/open-component-model/ocm/pkg/utils"
 )
 
 var (

--- a/cmds/ocm/commands/misccmds/rsakeypair/cmd.go
+++ b/cmds/ocm/commands/misccmds/rsakeypair/cmd.go
@@ -13,7 +13,6 @@ import (
 
 	parse "github.com/mandelsoft/spiff/dynaml/x509"
 	"github.com/mandelsoft/vfs/pkg/vfs"
-	utils2 "github.com/open-component-model/ocm/pkg/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/out"
 	"github.com/open-component-model/ocm/pkg/signing"
 	"github.com/open-component-model/ocm/pkg/signing/handlers/rsa"
+	utils2 "github.com/open-component-model/ocm/pkg/utils"
 )
 
 var (

--- a/cmds/ocm/commands/ocicmds/common/handlers/artifacthdlr/attached.go
+++ b/cmds/ocm/commands/ocicmds/common/handlers/artifacthdlr/attached.go
@@ -7,12 +7,12 @@ package artifacthdlr
 import (
 	"strings"
 
-	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/opencontainers/go-digest"
 
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/output"
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/processing"
 	"github.com/open-component-model/ocm/pkg/common"
+	"github.com/open-component-model/ocm/pkg/generics"
 )
 
 func Attachment(d digest.Digest, suffix string) string {

--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/comp/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/comp/elements.go
@@ -7,8 +7,8 @@ package comp
 import (
 	"fmt"
 
-	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
 	. "github.com/open-component-model/ocm/pkg/finalizer"
+
 	"github.com/spf13/pflag"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common"
@@ -17,6 +17,7 @@ import (
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/addhdlrs/rscs"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/addhdlrs/srcs"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs"
+	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/utils"
 	"github.com/open-component-model/ocm/pkg/contexts/clictx"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"

--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/rscs/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/rscs/elements.go
@@ -7,13 +7,13 @@ package rscs
 import (
 	"fmt"
 
-	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/skipdigestoption"
-	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/addhdlrs"
+	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/skipdigestoption"
+	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
 	"github.com/open-component-model/ocm/pkg/contexts/clictx"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"

--- a/cmds/ocm/commands/ocmcmds/common/labels.go
+++ b/cmds/ocm/commands/ocmcmds/common/labels.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/mandelsoft/vfs/pkg/osfs"
 	"github.com/mandelsoft/vfs/pkg/vfs"
-	"github.com/open-component-model/ocm/pkg/utils"
 	"sigs.k8s.io/yaml"
 
 	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 func gkind(kind ...string) string {

--- a/cmds/ocm/commands/ocmcmds/common/options/optutils/registration.go
+++ b/cmds/ocm/commands/ocmcmds/common/options/optutils/registration.go
@@ -10,13 +10,13 @@ import (
 	"strings"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
-	"github.com/open-component-model/ocm/pkg/utils"
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/yaml"
 
 	"github.com/open-component-model/ocm/pkg/cobrautils/flag"
 	"github.com/open-component-model/ocm/pkg/contexts/clictx"
 	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 type Registration struct {

--- a/cmds/ocm/commands/ocmcmds/common/options/scriptoption/config.go
+++ b/cmds/ocm/commands/ocmcmds/common/options/scriptoption/config.go
@@ -8,12 +8,12 @@ import (
 	"encoding/json"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
-	"github.com/open-component-model/ocm/pkg/utils"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	cfgcpi "github.com/open-component-model/ocm/pkg/contexts/config/cpi"
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/runtime"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 const (

--- a/cmds/ocm/commands/ocmcmds/common/options/scriptoption/option.go
+++ b/cmds/ocm/commands/ocmcmds/common/options/scriptoption/option.go
@@ -6,7 +6,6 @@ package scriptoption
 
 import (
 	"github.com/mandelsoft/vfs/pkg/vfs"
-	"github.com/open-component-model/ocm/pkg/utils"
 	"github.com/spf13/pflag"
 
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
@@ -15,6 +14,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/transfer/transferhandler"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/transfer/transferhandler/spiff"
 	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 func From(o options.OptionSetProvider) *Option {

--- a/cmds/ocm/commands/ocmcmds/common/options/signoption/option.go
+++ b/cmds/ocm/commands/ocmcmds/common/options/signoption/option.go
@@ -8,10 +8,9 @@ import (
 	"crypto/x509"
 	"strings"
 
-	"github.com/open-component-model/ocm/cmds/ocm/commands/common/options/keyoption"
-	"github.com/open-component-model/ocm/pkg/utils"
 	"github.com/spf13/pflag"
 
+	"github.com/open-component-model/ocm/cmds/ocm/commands/common/options/keyoption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/hashoption"
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
 	"github.com/open-component-model/ocm/pkg/contexts/clictx"
@@ -24,6 +23,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/signing"
 	"github.com/open-component-model/ocm/pkg/signing/handlers/rsa"
 	"github.com/open-component-model/ocm/pkg/signing/hasher/sha256"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 func From(o options.OptionSetProvider) *Option {

--- a/cmds/ocm/commands/ocmcmds/common/options/skipdigestoption/option.go
+++ b/cmds/ocm/commands/ocmcmds/common/options/skipdigestoption/option.go
@@ -5,11 +5,11 @@
 package skipdigestoption
 
 import (
-	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 	"github.com/spf13/pflag"
 
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
 	"github.com/open-component-model/ocm/pkg/cobrautils/flag"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 )
 
 func From(o options.OptionSetProvider) *Option {

--- a/cmds/ocm/commands/ocmcmds/common/resources.go
+++ b/cmds/ocm/commands/ocmcmds/common/resources.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	_ "github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs/types"
-	"github.com/open-component-model/ocm/pkg/generics"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
 	"github.com/spf13/pflag"
@@ -33,6 +32,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/comparch"
 	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/open-component-model/ocm/pkg/logging"
 	"github.com/open-component-model/ocm/pkg/mime"
 )

--- a/cmds/ocm/commands/ocmcmds/componentarchive/transfer/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/componentarchive/transfer/cmd.go
@@ -5,7 +5,6 @@
 package transfer
 
 import (
-	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
 	"github.com/spf13/cobra"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/common/options/formatoption"
@@ -17,6 +16,7 @@ import (
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/srcbyvalueoption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/names"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/verbs"
+	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/utils"
 	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/common/accessobj"

--- a/cmds/ocm/commands/ocmcmds/components/add/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/components/add/cmd.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
-	topicocmlabels "github.com/open-component-model/ocm/cmds/ocm/topics/ocm/labels"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -25,6 +24,7 @@ import (
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/names"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/verbs"
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/utils"
+	topicocmlabels "github.com/open-component-model/ocm/cmds/ocm/topics/ocm/labels"
 	common2 "github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/common/accessobj"

--- a/cmds/ocm/commands/ocmcmds/components/add/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/add/cmd_test.go
@@ -9,7 +9,6 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
 	. "github.com/open-component-model/ocm/pkg/contexts/oci/testhelper"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/valuemergehandler/handlers/defaultmerge"
 	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
@@ -23,6 +22,7 @@ import (
 	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/ctf"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/resourcetypes"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/valuemergehandler/handlers/defaultmerge"
 	"github.com/open-component-model/ocm/pkg/mime"
 )
 

--- a/cmds/ocm/commands/ocmcmds/components/download/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/download/cmd_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/resourcetypes"
 	. "github.com/open-component-model/ocm/pkg/contexts/ocm/testhelper"
 	. "github.com/open-component-model/ocm/pkg/testutils"
 
@@ -20,6 +19,7 @@ import (
 	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/grammar"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/comparch"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/resourcetypes"
 	"github.com/open-component-model/ocm/pkg/mime"
 )
 

--- a/cmds/ocm/commands/ocmcmds/components/hash/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/hash/cmd_test.go
@@ -10,10 +10,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/resourcetypes"
 	"github.com/open-component-model/ocm/pkg/mime"

--- a/cmds/ocm/commands/ocmcmds/components/transfer/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/components/transfer/cmd.go
@@ -7,7 +7,6 @@ package transfer
 import (
 	"fmt"
 
-	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
 	"github.com/spf13/cobra"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/common/options/closureoption"
@@ -27,6 +26,7 @@ import (
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/versionconstraintsoption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/names"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/verbs"
+	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/output"
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/utils"
 	"github.com/open-component-model/ocm/pkg/common"

--- a/cmds/ocm/commands/ocmcmds/components/transfer/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/transfer/cmd_test.go
@@ -13,7 +13,6 @@ import (
 	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
 	. "github.com/open-component-model/ocm/pkg/contexts/oci/testhelper"
 	. "github.com/open-component-model/ocm/pkg/testutils"
-	"github.com/open-component-model/ocm/pkg/utils"
 
 	"github.com/spf13/cobra"
 
@@ -31,6 +30,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/resourcetypes"
 	handlercfg "github.com/open-component-model/ocm/pkg/contexts/ocm/transfer/transferhandler/config"
 	"github.com/open-component-model/ocm/pkg/mime"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 const ARCH = "/tmp/ctf"

--- a/cmds/ocm/commands/ocmcmds/ctf/transfer/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/ctf/transfer/cmd.go
@@ -5,7 +5,6 @@
 package transfer
 
 import (
-	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
 	"github.com/spf13/cobra"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/common/options/closureoption"
@@ -22,6 +21,7 @@ import (
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/uploaderoption"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/names"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/verbs"
+	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/utils"
 	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/common/accessobj"

--- a/cmds/ocm/commands/ocmcmds/resources/get/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/resources/get/cmd.go
@@ -5,7 +5,6 @@
 package get
 
 import (
-	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/spf13/cobra"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/common/options/closureoption"
@@ -23,6 +22,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/clictx"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
+	"github.com/open-component-model/ocm/pkg/generics"
 )
 
 var (

--- a/cmds/ocm/commands/ocmcmds/sources/get/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/sources/get/cmd.go
@@ -5,7 +5,6 @@
 package get
 
 import (
-	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/spf13/cobra"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/common/options/closureoption"
@@ -23,6 +22,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/clictx"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
+	"github.com/open-component-model/ocm/pkg/generics"
 )
 
 var (

--- a/cmds/ocm/pkg/options/interfaces.go
+++ b/cmds/ocm/pkg/options/interfaces.go
@@ -7,10 +7,10 @@ package options
 import (
 	"reflect"
 
-	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/spf13/pflag"
 
 	"github.com/open-component-model/ocm/pkg/contexts/clictx"
+	"github.com/open-component-model/ocm/pkg/generics"
 	"github.com/open-component-model/ocm/pkg/out"
 )
 

--- a/cmds/ocm/pkg/template/template.go
+++ b/cmds/ocm/pkg/template/template.go
@@ -13,12 +13,12 @@ import (
 	"strings"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
-	utils2 "github.com/open-component-model/ocm/pkg/utils"
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v3"
 
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/runtime"
+	utils2 "github.com/open-component-model/ocm/pkg/utils"
 )
 
 type Values map[string]interface{}

--- a/cmds/ocm/topics/ocm/labels/topic.go
+++ b/cmds/ocm/topics/ocm/labels/topic.go
@@ -5,10 +5,10 @@
 package topicocmlabels
 
 import (
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/valuemergehandler"
 	"github.com/spf13/cobra"
 
 	"github.com/open-component-model/ocm/pkg/contexts/clictx"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/valuemergehandler"
 )
 
 func New(ctx clictx.Context) *cobra.Command {

--- a/pkg/contexts/ocm/compdesc/equal_test.go
+++ b/pkg/contexts/ocm/compdesc/equal_test.go
@@ -7,13 +7,13 @@ package compdesc_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/equivalent/testhelper"
+
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/none"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/ociartifact"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/equivalent"
-	. "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/equivalent/testhelper"
-
 	v1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 )
 

--- a/pkg/contexts/ocm/compdesc/meta/v1/identity_test.go
+++ b/pkg/contexts/ocm/compdesc/meta/v1/identity_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/equivalent/testhelper"
+
 	v1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 )
 

--- a/pkg/contexts/ocm/plugin/plugin_test.go
+++ b/pkg/contexts/ocm/plugin/plugin_test.go
@@ -9,11 +9,9 @@ package plugin_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	common2 "github.com/open-component-model/ocm/pkg/common"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/common"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/valuemergehandler"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/valuemergehandler/handlers/defaultmerge"
+	. "github.com/open-component-model/ocm/pkg/testutils"
 
+	common2 "github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/actions/oci-repository-prepare"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
@@ -23,9 +21,11 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/plugin"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/cache"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/common"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/plugins"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/registration"
-	. "github.com/open-component-model/ocm/pkg/testutils"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/valuemergehandler"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/valuemergehandler/handlers/defaultmerge"
 )
 
 var _ = Describe("setup plugin cache", func() {

--- a/pkg/contexts/ocm/repositories/comparch/comparch_test.go
+++ b/pkg/contexts/ocm/repositories/comparch/comparch_test.go
@@ -9,11 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/digester/digesters/blob"
 	. "github.com/open-component-model/ocm/pkg/contexts/ocm/testhelper"
-	"github.com/open-component-model/ocm/pkg/env"
-	"github.com/open-component-model/ocm/pkg/finalizer"
-	"github.com/open-component-model/ocm/pkg/signing/hasher/sha256"
 	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/mandelsoft/filepath/pkg/filepath"
@@ -26,10 +22,14 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/digester/digesters/blob"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/comparch"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/resourcetypes"
+	"github.com/open-component-model/ocm/pkg/env"
+	"github.com/open-component-model/ocm/pkg/finalizer"
 	"github.com/open-component-model/ocm/pkg/mime"
 	"github.com/open-component-model/ocm/pkg/runtime"
+	"github.com/open-component-model/ocm/pkg/signing/hasher/sha256"
 	"github.com/open-component-model/ocm/pkg/utils/tarutils"
 )
 

--- a/pkg/contexts/ocm/repositories/genericocireg/repo_test.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/repo_test.go
@@ -10,10 +10,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/attrs/keepblobattr"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/digester/digesters/artifact"
-	ocmtesthelper "github.com/open-component-model/ocm/pkg/contexts/ocm/testhelper"
-	"github.com/open-component-model/ocm/pkg/signing/hasher/sha256"
 	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/mandelsoft/vfs/pkg/osfs"
@@ -35,18 +31,22 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/ociartifact"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/ociblob"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/attrs/compatattr"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/attrs/keepblobattr"
 	storagecontext "github.com/open-component-model/ocm/pkg/contexts/ocm/blobhandler/handlers/oci"
 	handler "github.com/open-component-model/ocm/pkg/contexts/ocm/blobhandler/handlers/oci/ocirepo"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/digester/digesters/artifact"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/genericocireg"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/genericocireg/componentmapping"
 	ocmreg "github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/ocireg"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/resourcetypes"
+	ocmtesthelper "github.com/open-component-model/ocm/pkg/contexts/ocm/testhelper"
 	ocmutils "github.com/open-component-model/ocm/pkg/contexts/ocm/utils"
 	"github.com/open-component-model/ocm/pkg/finalizer"
 	"github.com/open-component-model/ocm/pkg/mime"
+	"github.com/open-component-model/ocm/pkg/signing/hasher/sha256"
 )
 
 var DefaultContext = ocm.New()

--- a/pkg/contexts/ocm/session.go
+++ b/pkg/contexts/ocm/session.go
@@ -6,12 +6,12 @@ package ocm
 
 import (
 	"fmt"
-	"github.com/open-component-model/ocm/pkg/utils"
 	"reflect"
 
 	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 type ComponentContainer interface {

--- a/pkg/contexts/ocm/session.go
+++ b/pkg/contexts/ocm/session.go
@@ -5,8 +5,8 @@
 package ocm
 
 import (
-	"encoding/json"
 	"fmt"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/utils"
 	"reflect"
 
 	"github.com/open-component-model/ocm/pkg/common"
@@ -41,7 +41,6 @@ type Session interface {
 	EvaluateVersionRef(ctx Context, ref string) (*EvaluationResult, error)
 	DetermineRepository(ctx Context, ref string) (Repository, UniformRepositorySpec, error)
 	DetermineRepositoryBySpec(ctx Context, spec *UniformRepositorySpec) (Repository, error)
-	Key(spec RepositorySpec) (string, error)
 }
 
 type session struct {
@@ -97,7 +96,7 @@ func (s *session) LookupRepository(ctx Context, spec RepositorySpec) (Repository
 		return nil, err
 	}
 
-	keyName, err := s.Key(spec)
+	keyName, err := utils.Key(spec)
 	if err != nil {
 		return nil, err
 	}
@@ -292,21 +291,4 @@ func (s *session) DetermineRepositoryBySpec(ctx Context, spec *UniformRepository
 		return nil, err
 	}
 	return s.LookupRepository(ctx, rspec)
-}
-
-type KeyProvider interface {
-	Key() (string, error)
-}
-
-func (s *session) Key(spec RepositorySpec) (string, error) {
-	k, ok := spec.(KeyProvider)
-	if ok {
-		return k.Key()
-	} else {
-		data, err := json.Marshal(spec)
-		if err != nil {
-			return "", fmt.Errorf("cannot marshal spec %w, consider implementing a Key() function", err)
-		}
-		return string(data), err
-	}
 }

--- a/pkg/contexts/ocm/session.go
+++ b/pkg/contexts/ocm/session.go
@@ -6,7 +6,7 @@ package ocm
 
 import (
 	"fmt"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/utils"
+	"github.com/open-component-model/ocm/pkg/utils"
 	"reflect"
 
 	"github.com/open-component-model/ocm/pkg/common"

--- a/pkg/contexts/ocm/session_test.go
+++ b/pkg/contexts/ocm/session_test.go
@@ -6,7 +6,7 @@ package ocm_test
 
 import (
 	"encoding/json"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/utils"
+	"github.com/open-component-model/ocm/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/pkg/contexts/ocm/session_test.go
+++ b/pkg/contexts/ocm/session_test.go
@@ -6,13 +6,13 @@ package ocm_test
 
 import (
 	"encoding/json"
-	"github.com/open-component-model/ocm/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	ocmreg "github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/ocireg"
+	"github.com/open-component-model/ocm/pkg/utils"
 )
 
 var TEST_KEY = "test"

--- a/pkg/contexts/ocm/session_test.go
+++ b/pkg/contexts/ocm/session_test.go
@@ -6,12 +6,12 @@ package ocm_test
 
 import (
 	"encoding/json"
-	. "github.com/onsi/gomega"
-	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm"
-	. "github.com/open-component-model/ocm/pkg/testutils"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/utils"
 
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/open-component-model/ocm/pkg/testutils"
+
 	ocmreg "github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/ocireg"
 )
 
@@ -26,16 +26,15 @@ func (*test_spec) Key() (string, error) {
 }
 
 var _ = Describe("session", func() {
-	var session = ocm.NewSession(datacontext.NewSession())
 
 	It("spec without key function", func() {
 		spec := ocmreg.NewRepositorySpec("gcr.io", nil)
-		key := Must(session.Key(spec))
+		key := Must(utils.Key(spec))
 		Expect(key).To(Equal(string(Must(json.Marshal(spec)))))
 	})
 
 	It("spec with key function", func() {
-		key := Must(session.Key(&test_spec{}))
+		key := Must(utils.Key(&test_spec{}))
 		Expect(key).To(Equal(TEST_KEY))
 	})
 })

--- a/pkg/contexts/ocm/session_test.go
+++ b/pkg/contexts/ocm/session_test.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package ocm_test
+
+import (
+	"encoding/json"
+	. "github.com/onsi/gomega"
+	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm"
+	. "github.com/open-component-model/ocm/pkg/testutils"
+
+	. "github.com/onsi/ginkgo/v2"
+	ocmreg "github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/ocireg"
+)
+
+var TEST_KEY = "test"
+
+type test_spec struct {
+	ocmreg.RepositorySpec
+}
+
+func (*test_spec) Key() (string, error) {
+	return TEST_KEY, nil
+}
+
+var _ = Describe("session", func() {
+	var session = ocm.NewSession(datacontext.NewSession())
+
+	It("spec without key function", func() {
+		spec := ocmreg.NewRepositorySpec("gcr.io", nil)
+		key := Must(session.Key(spec))
+		Expect(key).To(Equal(string(Must(json.Marshal(spec)))))
+	})
+
+	It("spec with key function", func() {
+		key := Must(session.Key(&test_spec{}))
+		Expect(key).To(Equal(TEST_KEY))
+	})
+})

--- a/pkg/contexts/ocm/signing/transport_test.go
+++ b/pkg/contexts/ocm/signing/transport_test.go
@@ -9,27 +9,26 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/open-component-model/ocm/pkg/common"
 	. "github.com/open-component-model/ocm/pkg/contexts/oci/testhelper"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/attrs/signingattr"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/signing"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/transfer"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/transfer/transferhandler/standard"
-	"github.com/open-component-model/ocm/pkg/finalizer"
-	"github.com/open-component-model/ocm/pkg/signing/handlers/rsa"
-
 	// . "github.com/open-component-model/ocm/pkg/contexts/ocm/signing"
 	. "github.com/open-component-model/ocm/pkg/contexts/ocm/testhelper"
 	. "github.com/open-component-model/ocm/pkg/env/builder"
 	. "github.com/open-component-model/ocm/pkg/testutils"
 
+	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/common/accessobj"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/attrs/signingattr"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/repositories/ctf"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/signing"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/transfer"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/transfer/transferhandler/standard"
+	"github.com/open-component-model/ocm/pkg/finalizer"
+	"github.com/open-component-model/ocm/pkg/signing/handlers/rsa"
 )
 
 const (
@@ -187,7 +186,7 @@ var _ = Describe("transport and signing", func() {
 			Value:                  D_COMPA,
 		}
 		descSigned.Signatures = []compdesc.Signature{
-			compdesc.Signature{
+			{
 				Name:   SIGNATURE,
 				Digest: *digSpec,
 				Signature: metav1.SignatureSpec{
@@ -304,7 +303,7 @@ func sourceSignature(cv, tcv ocm.ComponentVersionAccess, merged *compdesc.Compon
 	ExpectWithOffset(1, err).To(Succeed())
 
 	signatures := []compdesc.Signature{
-		compdesc.Signature{
+		{
 			Name:   SIGNATURE2,
 			Digest: *spec,
 			Signature: metav1.SignatureSpec{

--- a/pkg/contexts/ocm/utils/utils.go
+++ b/pkg/contexts/ocm/utils/utils.go
@@ -5,6 +5,8 @@
 package utils
 
 import (
+	"encoding/json"
+	"fmt"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/ociartifact"
@@ -30,4 +32,19 @@ func GetOCIArtifactRef(ctx ocm.Context, r ocm.ResourceAccess) (string, error) {
 		return acc.(*ociartifact.AccessSpec).ImageReference, nil
 	}
 	return "", errors.Newf("cannot map access to external image reference")
+}
+
+type KeyProvider interface {
+	Key() (string, error)
+}
+
+func Key(keyProvider interface{}) (string, error) {
+	if k, ok := keyProvider.(KeyProvider); ok {
+		return k.Key()
+	}
+	data, err := json.Marshal(keyProvider)
+	if err != nil {
+		return "", fmt.Errorf("cannot marshal spec %w, consider implementing a Key() function", err)
+	}
+	return string(data), err
 }

--- a/pkg/contexts/ocm/utils/utils.go
+++ b/pkg/contexts/ocm/utils/utils.go
@@ -5,8 +5,6 @@
 package utils
 
 import (
-	"encoding/json"
-	"fmt"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/ociartifact"
@@ -32,19 +30,4 @@ func GetOCIArtifactRef(ctx ocm.Context, r ocm.ResourceAccess) (string, error) {
 		return acc.(*ociartifact.AccessSpec).ImageReference, nil
 	}
 	return "", errors.Newf("cannot map access to external image reference")
-}
-
-type KeyProvider interface {
-	Key() (string, error)
-}
-
-func Key(keyProvider interface{}) (string, error) {
-	if k, ok := keyProvider.(KeyProvider); ok {
-		return k.Key()
-	}
-	data, err := json.Marshal(keyProvider)
-	if err != nil {
-		return "", fmt.Errorf("cannot marshal spec %w, consider implementing a Key() function", err)
-	}
-	return string(data), err
 }

--- a/pkg/contexts/ocm/valuemergehandler/handlers/plugin/handler_test.go
+++ b/pkg/contexts/ocm/valuemergehandler/handlers/plugin/handler_test.go
@@ -9,7 +9,6 @@ package plugin_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/valuemergehandler/hpi"
 	. "github.com/open-component-model/ocm/pkg/env/builder"
 	. "github.com/open-component-model/ocm/pkg/testutils"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/registration"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/valuemergehandler"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/valuemergehandler/handlers/defaultmerge"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/valuemergehandler/hpi"
 )
 
 const PLUGIN = "merge"

--- a/pkg/signing/normalization_test.go
+++ b/pkg/signing/normalization_test.go
@@ -10,13 +10,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/normalizations/rules"
 	. "github.com/open-component-model/ocm/pkg/testutils"
 
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/localblob"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/ociartifact"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/normalizations/rules"
 	"github.com/open-component-model/ocm/pkg/mime"
 	"github.com/open-component-model/ocm/pkg/runtime"
 	"github.com/open-component-model/ocm/pkg/signing"

--- a/pkg/utils/key.go
+++ b/pkg/utils/key.go
@@ -1,0 +1,21 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type KeyProvider interface {
+	Key() (string, error)
+}
+
+func Key(keyProvider interface{}) (string, error) {
+	if k, ok := keyProvider.(KeyProvider); ok {
+		return k.Key()
+	}
+	data, err := json.Marshal(keyProvider)
+	if err != nil {
+		return "", fmt.Errorf("cannot marshal spec %w, consider implementing a Key() function", err)
+	}
+	return string(data), err
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
The session's `LookupRepository()` method so far always calculated the respective key to cache the repository through calling json.Marshal on the RepositorySpec. This led to errors when the given RepositorySpec contained fields that cannot be Marshaled (such as file systems).
This PR introduces a `Key()`. Instead of calling json.Marshal, the `LookupRepository()` method now first checks whether the RepositorySpec implements `Key()` to provide an alternative key. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
