### PR TITLE
consider transport modes for transport flow decisions

### DIFF
--- a/pkg/contexts/ocm/compdesc/componentdescriptor.go
+++ b/pkg/contexts/ocm/compdesc/componentdescriptor.go
@@ -379,6 +379,11 @@ func GenericAccessSpec(un *runtime.UnstructuredTypedObject) AccessSpec {
 	}
 }
 
+// AccessProvider provides access to an access specification of elements.
+type AccessProvider interface {
+	GetAccess() AccessSpec
+}
+
 // Sources describes a set of source specifications.
 type Sources []Source
 

--- a/pkg/contexts/ocm/interface.go
+++ b/pkg/contexts/ocm/interface.go
@@ -46,6 +46,7 @@ type (
 	AccessType                       = internal.AccessType
 	DataAccess                       = internal.DataAccess
 	BlobAccess                       = internal.BlobAccess
+	AccessProvider                   = internal.AccessProvider
 	SourceAccess                     = internal.SourceAccess
 	SourceMeta                       = internal.SourceMeta
 	ResourceAccess                   = internal.ResourceAccess

--- a/pkg/contexts/ocm/internal/repository.go
+++ b/pkg/contexts/ocm/internal/repository.go
@@ -73,7 +73,7 @@ type (
 	ComponentReference = compdesc.ComponentReference
 )
 
-type BaseAccess interface {
+type AccessProvider interface {
 	ComponentVersion() ComponentVersionAccess
 	Access() (AccessSpec, error)
 	AccessMethod() (AccessMethod, error)
@@ -81,14 +81,14 @@ type BaseAccess interface {
 
 type ResourceAccess interface {
 	Meta() *ResourceMeta
-	BaseAccess
+	AccessProvider
 }
 
 type SourceMeta = compdesc.SourceMeta
 
 type SourceAccess interface {
 	Meta() *SourceMeta
-	BaseAccess
+	AccessProvider
 }
 
 type ComponentVersionAccessImpl interface {

--- a/pkg/contexts/ocm/transfer/debug.go
+++ b/pkg/contexts/ocm/transfer/debug.go
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package transfer
+
+var Breakpoints = false

--- a/pkg/contexts/ocm/transfer/needs.go
+++ b/pkg/contexts/ocm/transfer/needs.go
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package transfer
+
+import (
+	"github.com/go-test/deep"
+
+	"github.com/open-component-model/ocm/pkg/contexts/ocm"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
+)
+
+type baseAccess struct {
+	cv     ocm.ComponentVersionAccess
+	access compdesc.AccessSpec
+}
+
+func (r *baseAccess) ComponentVersion() ocm.ComponentVersionAccess {
+	return r.cv
+}
+
+func (r *baseAccess) Access() (ocm.AccessSpec, error) {
+	return r.cv.GetContext().AccessSpecForSpec(r.access)
+}
+
+func (r *baseAccess) AccessMethod() (ocm.AccessMethod, error) {
+	acc, err := r.Access()
+	if err != nil {
+		return nil, err
+	}
+	return r.cv.AccessMethod(acc)
+}
+
+type resourceAccess struct {
+	baseAccess
+	resource *compdesc.Resource
+}
+
+var _ ocm.ResourceAccess = (*resourceAccess)(nil)
+
+func (r *resourceAccess) Meta() *compdesc.ResourceMeta {
+	return &r.resource.ResourceMeta
+}
+
+type sourceAccess struct {
+	baseAccess
+	source *compdesc.Source
+}
+
+var _ ocm.SourceAccess = (*sourceAccess)(nil)
+
+func (r *sourceAccess) Meta() *compdesc.SourceMeta {
+	return &r.source.SourceMeta
+}
+
+func needsResourceTransport(cv ocm.ComponentVersionAccess, s, t *compdesc.ComponentDescriptor, handler TransferHandler) bool {
+	for _, r := range s.Resources {
+		rt, err := t.GetResourceByIdentity(r.GetIdentity(s.Resources))
+		if err != nil {
+			return true
+		}
+
+		sa := &resourceAccess{
+			baseAccess: baseAccess{
+				cv:     cv,
+				access: r.Access,
+			},
+			resource: &r,
+		}
+
+		sacc, err := sa.Access()
+		if err != nil {
+			return true
+		}
+		if needsTransport(cv.GetContext(), sa, &rt) {
+			ok, err := handler.TransferResource(cv, sacc, sa)
+			return ok || err != nil
+		}
+	}
+
+	for _, r := range s.Sources {
+		rt, err := t.GetSourceByIdentity(r.GetIdentity(s.Sources))
+		if err != nil {
+			return true
+		}
+
+		sa := &sourceAccess{
+			baseAccess: baseAccess{
+				cv:     cv,
+				access: r.Access,
+			},
+			source: &r,
+		}
+
+		sacc, err := sa.Access()
+		if err != nil {
+			return true
+		}
+		if needsTransport(cv.GetContext(), sa, &rt) {
+			ok, err := handler.TransferSource(cv, sacc, sa)
+			return ok || err != nil
+		}
+	}
+	return false
+}
+
+func needsTransport(ctx ocm.Context, s ocm.AccessProvider, t compdesc.AccessProvider) bool {
+	sacc, err := s.Access()
+	if err != nil {
+		return true
+	}
+	tacc, err := ctx.AccessSpecForSpec(t.GetAccess())
+	if err != nil {
+		return true
+	}
+
+	if sacc.IsLocal(ctx) && tacc.IsLocal(ctx) {
+		return false
+	}
+	return len(deep.Equal(sacc, tacc)) == 0
+}

--- a/pkg/contexts/ocm/transfer/transfer.go
+++ b/pkg/contexts/ocm/transfer/transfer.go
@@ -49,8 +49,6 @@ func transferVersion(printer common.Printer, log logging.Logger, state WalkingSt
 		}
 	}
 
-	doMerge := false
-	doCopy := true
 	d := src.GetDescriptor()
 
 	comp, err := tgt.LookupComponent(src.GetName())
@@ -62,6 +60,22 @@ func transferVersion(printer common.Printer, log logging.Logger, state WalkingSt
 	var ok bool
 	t, err := comp.LookupVersion(src.GetVersion())
 	defer accessio.Close(t)
+
+	// references have always to be handled, because of potentially different
+	// transport modes, which could affect the desired access methods in
+	// the target environment.
+
+	// doTransport controls, whether the transport of the local component
+	// version has to be re-considered.
+	doTransport := true
+
+	// doMerge controls. whether a potential current version in the target
+	// environment has to be merged into the transported one.
+	doMerge := false
+
+	// doCopy controls, whether the artifact content has to be considered.
+	doCopy := true
+
 	if err != nil {
 		if errors.IsErrNotFound(err) {
 			t, err = comp.NewVersion(src.GetVersion())
@@ -72,9 +86,10 @@ func transferVersion(printer common.Printer, log logging.Logger, state WalkingSt
 			if eq.IsEquivalent() {
 				if !needsResourceTransport(src, d, t.GetDescriptor(), handler) {
 					printer.Printf("  version %q already present -> skip transport\n", nv)
-					return nil
+					doTransport = false
+				} else {
+					printer.Printf("  version %q already present -> but requires resource transport\n", nv)
 				}
-				printer.Printf("  version %q already present -> but requires resource transport\n", nv)
 			} else {
 				ok, err = handler.UpdateVersion(src, t)
 				if err != nil {
@@ -143,43 +158,46 @@ func transferVersion(printer common.Printer, log logging.Logger, state WalkingSt
 		}
 	}
 
-	var n *compdesc.ComponentDescriptor
-	if doMerge {
-		log.WithValues("source", src.GetDescriptor(), "target", t.GetDescriptor()).Info("  applying 2-way merge")
-		n, err = internal.PrepareDescriptor(log, src.GetContext(), src.GetDescriptor(), t.GetDescriptor())
-		if err != nil {
-			return err
+	if doTransport {
+		var n *compdesc.ComponentDescriptor
+		if doMerge {
+			log.WithValues("source", src.GetDescriptor(), "target", t.GetDescriptor()).Info("  applying 2-way merge")
+			n, err = internal.PrepareDescriptor(log, src.GetContext(), src.GetDescriptor(), t.GetDescriptor())
+			if err != nil {
+				return err
+			}
+		} else {
+			n = src.GetDescriptor().Copy()
 		}
-	} else {
-		n = src.GetDescriptor().Copy()
-	}
 
-	var unstr *runtime.UnstructuredTypedObject
-	if !ocm.IsIntermediate(tgt.GetSpecification()) {
-		unstr, err = runtime.ToUnstructuredTypedObject(tgt.GetSpecification())
-		if err != nil {
-			unstr = nil
+		var unstr *runtime.UnstructuredTypedObject
+		if !ocm.IsIntermediate(tgt.GetSpecification()) {
+			unstr, err = runtime.ToUnstructuredTypedObject(tgt.GetSpecification())
+			if err != nil {
+				unstr = nil
+			}
 		}
-	}
-	if unstr != nil {
-		n.RepositoryContexts = append(n.RepositoryContexts, unstr)
-	}
-
-	// just to be sure: both modes set to false would produce
-	// corrupted content in target.
-	// If no copy is done, merge must keep the access methods in target!!!
-	if !doMerge || doCopy {
-		err = copyVersion(printer, log, state.History, src, t, n, handler)
-		if err != nil {
-			return err
+		if unstr != nil {
+			n.RepositoryContexts = append(n.RepositoryContexts, unstr)
 		}
-	} else {
-		*t.GetDescriptor() = *n
-	}
 
-	printer.Printf("...adding component version...\n")
-	log.Info("  adding component version")
-	return list.Add(comp.AddVersion(t)).Result()
+		// just to be sure: both modes set to false would produce
+		// corrupted content in target.
+		// If no copy is done, merge must keep the access methods in target!!!
+		if !doMerge || doCopy {
+			err = copyVersion(printer, log, state.History, src, t, n, handler)
+			if err != nil {
+				return err
+			}
+		} else {
+			*t.GetDescriptor() = *n
+		}
+
+		printer.Printf("...adding component version...\n")
+		log.Info("  adding component version")
+		list.Add(comp.AddVersion(t))
+	}
+	return list.Result()
 }
 
 func CopyVersion(printer common.Printer, log logging.Logger, hist common.History, src ocm.ComponentVersionAccess, t ocm.ComponentVersionAccess, handler TransferHandler) (rerr error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

To decide, which resources have to be transported the digest is not sufficient to handle re-transports
of exactly the same content with different transport modes (value vs reference).

This Pr checks, whether access methods would have to be changed according to the
the actual state in the target repository and the chosen transport mode. This then
controls the transport flow of a dedicated component version.

Additionally it should also handle the preserving of existing artifacts for overwrite transports.

There are several new tests now for those scenarios.
 
**Which issue(s) this PR fixes**:
Fixes #513

**Special notes for your reviewer**:

**Release Notes**:
<!--
Please ensure that the title of this PR is suitable for the release notes.
To exclude this PR from the release notes, add the tag "kind/skip-release-notes".
-->
```feature user

```
