### PR TITLE
support for image back links

### DIFF
--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/docker/spec.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/docker/spec.go
@@ -5,6 +5,8 @@
 package docker
 
 import (
+	"github.com/open-component-model/ocm/pkg/contexts/oci"
+	"github.com/open-component-model/ocm/pkg/contexts/oci/annotations"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs"
@@ -64,7 +66,12 @@ func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (acces
 	if version == "" || version == "latest" {
 		version = info.ComponentVersion.GetVersion()
 	}
-	blob, err := artifactset.SynthesizeArtifactBlob(ns, version)
+	blob, err := artifactset.SynthesizeArtifactBlob(ns, version,
+		func(art oci.ArtifactAccess) error {
+			art.Artifact().SetAnnotation(annotations.COMPVERS_ANNOTATION, info.ComponentVersion.String())
+			return nil
+		},
+	)
 	if err != nil {
 		return nil, "", err
 	}

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/docker/type.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/docker/type.go
@@ -6,6 +6,7 @@ package docker
 
 import (
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs"
+	"github.com/open-component-model/ocm/pkg/contexts/oci/annotations"
 )
 
 const TYPE = "docker"
@@ -17,6 +18,8 @@ func init() {
 const usage = `
 The path must denote an image tag that can be found in the local
 docker daemon. The denoted image is packed as OCI artifact set.
+The OCI image will contain an informational back link to the component version
+using the manifest annotation <code>` + annotations.COMPVERS_ANNOTATION + `</code>.
 
 This blob type specification supports the following fields: 
 - **<code>path</code>** *string*

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/dockermulti/spec.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/dockermulti/spec.go
@@ -7,6 +7,7 @@ package dockermulti
 import (
 	"fmt"
 
+	"github.com/open-component-model/ocm/pkg/contexts/oci/annotations"
 	. "github.com/open-component-model/ocm/pkg/finalizer"
 
 	"github.com/opencontainers/go-digest"
@@ -102,6 +103,8 @@ func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (acces
 	index := artdesc.NewIndexArtifact()
 	i := 0
 
+	index.SetAnnotation(annotations.COMPVERS_ANNOTATION, info.ComponentVersion.String())
+
 	feedback := func(blob accessio.BlobAccess, art cpi.ArtifactAccess) error {
 		desc := artdesc.DefaultBlobDescriptor(blob)
 		if art.IsManifest() {
@@ -157,6 +160,7 @@ func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (acces
 			art, err = s.getVariant(ctx, &finalize, s.Variants[i])
 
 			if err == nil {
+				art.Artifact().SetAnnotation(annotations.COMPVERS_ANNOTATION, info.ComponentVersion.String())
 				blob, err = art.Blob()
 				if err == nil {
 					finalize.Close(art)

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/dockermulti/type.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/dockermulti/type.go
@@ -6,6 +6,7 @@ package dockermulti
 
 import (
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs"
+	"github.com/open-component-model/ocm/pkg/contexts/oci/annotations"
 )
 
 const TYPE = "dockermulti"
@@ -18,7 +19,10 @@ const usage = `
 This input type describes the composition of a multi-platform OCI image.
 The various variants are taken from the local docker daemon. They should be 
 built with the buildx command for cross platform docker builds.
-The denoted images, as well as the wrapping image index is packed as OCI artifact set.
+The denoted images, as well as the wrapping image index is packed as OCI
+artifact set.
+They will contain an informational back link to the component version
+using the manifest annotation <code>` + annotations.COMPVERS_ANNOTATION + `</code>.
 
 This blob type specification supports the following fields:
 - **<code>variants</code>** *[]string*

--- a/docs/names/labels.md
+++ b/docs/names/labels.md
@@ -32,7 +32,7 @@ of label names:
   Their format is described by the following regexp:
 
   ```regex
-  [a-z][a-zA-Z0-9]*
+  [a-z][-a-zA-Z0-9]*
   ```
 
 - vendor specific labels
@@ -53,7 +53,7 @@ of label names:
   So, the complete pattern looks as follows:
 
   ```
-  <DNS domain name>/[a-z][a-zA-Z0-9]*
+  <DNS domain name>/[a-z][-a-zA-Z0-9]*
   ```
   
 Every label must define a specification of its attributes,

--- a/docs/reference/ocm_add_resource-configuration.md
+++ b/docs/reference/ocm_add_resource-configuration.md
@@ -238,6 +238,8 @@ with the field <code>type</code> in the <code>input</code> field:
 
   The path must denote an image tag that can be found in the local
   docker daemon. The denoted image is packed as OCI artifact set.
+  The OCI image will contain an informational back link to the component version
+  using the manifest annotation <code>software.ocm/component-version</code>.
 
   This blob type specification supports the following fields:
   - **<code>path</code>** *string*
@@ -258,7 +260,10 @@ with the field <code>type</code> in the <code>input</code> field:
   This input type describes the composition of a multi-platform OCI image.
   The various variants are taken from the local docker daemon. They should be
   built with the buildx command for cross platform docker builds.
-  The denoted images, as well as the wrapping image index is packed as OCI artifact set.
+  The denoted images, as well as the wrapping image index is packed as OCI
+  artifact set.
+  They will contain an informational back link to the component version
+  using the manifest annotation <code>software.ocm/component-version</code>.
 
   This blob type specification supports the following fields:
   - **<code>variants</code>** *[]string*

--- a/docs/reference/ocm_add_resources.md
+++ b/docs/reference/ocm_add_resources.md
@@ -248,6 +248,8 @@ with the field <code>type</code> in the <code>input</code> field:
 
   The path must denote an image tag that can be found in the local
   docker daemon. The denoted image is packed as OCI artifact set.
+  The OCI image will contain an informational back link to the component version
+  using the manifest annotation <code>software.ocm/component-version</code>.
 
   This blob type specification supports the following fields:
   - **<code>path</code>** *string*
@@ -268,7 +270,10 @@ with the field <code>type</code> in the <code>input</code> field:
   This input type describes the composition of a multi-platform OCI image.
   The various variants are taken from the local docker daemon. They should be
   built with the buildx command for cross platform docker builds.
-  The denoted images, as well as the wrapping image index is packed as OCI artifact set.
+  The denoted images, as well as the wrapping image index is packed as OCI
+  artifact set.
+  They will contain an informational back link to the component version
+  using the manifest annotation <code>software.ocm/component-version</code>.
 
   This blob type specification supports the following fields:
   - **<code>variants</code>** *[]string*

--- a/docs/reference/ocm_add_routingslips.md
+++ b/docs/reference/ocm_add_routingslips.md
@@ -18,7 +18,7 @@ routingslips, routingslip, rs
   -S, --algorithm string     signature handler (default "RSASSA-PKCS1-V1_5")
       --digest string        parent digest to use
   -h, --help                 help for routingslips
-      --links strings        links to other slip/entries (<slipname>@<digest>)
+      --links strings        links to other slip/entries (<slipname>[@<digest>])
       --lookup stringArray   repository name or spec for closure lookup fallback
       --repo string          repository name or spec
 ```

--- a/docs/reference/ocm_add_source-configuration.md
+++ b/docs/reference/ocm_add_source-configuration.md
@@ -238,6 +238,8 @@ with the field <code>type</code> in the <code>input</code> field:
 
   The path must denote an image tag that can be found in the local
   docker daemon. The denoted image is packed as OCI artifact set.
+  The OCI image will contain an informational back link to the component version
+  using the manifest annotation <code>software.ocm/component-version</code>.
 
   This blob type specification supports the following fields:
   - **<code>path</code>** *string*
@@ -258,7 +260,10 @@ with the field <code>type</code> in the <code>input</code> field:
   This input type describes the composition of a multi-platform OCI image.
   The various variants are taken from the local docker daemon. They should be
   built with the buildx command for cross platform docker builds.
-  The denoted images, as well as the wrapping image index is packed as OCI artifact set.
+  The denoted images, as well as the wrapping image index is packed as OCI
+  artifact set.
+  They will contain an informational back link to the component version
+  using the manifest annotation <code>software.ocm/component-version</code>.
 
   This blob type specification supports the following fields:
   - **<code>variants</code>** *[]string*

--- a/docs/reference/ocm_add_sources.md
+++ b/docs/reference/ocm_add_sources.md
@@ -245,6 +245,8 @@ with the field <code>type</code> in the <code>input</code> field:
 
   The path must denote an image tag that can be found in the local
   docker daemon. The denoted image is packed as OCI artifact set.
+  The OCI image will contain an informational back link to the component version
+  using the manifest annotation <code>software.ocm/component-version</code>.
 
   This blob type specification supports the following fields:
   - **<code>path</code>** *string*
@@ -265,7 +267,10 @@ with the field <code>type</code> in the <code>input</code> field:
   This input type describes the composition of a multi-platform OCI image.
   The various variants are taken from the local docker daemon. They should be
   built with the buildx command for cross platform docker builds.
-  The denoted images, as well as the wrapping image index is packed as OCI artifact set.
+  The denoted images, as well as the wrapping image index is packed as OCI
+  artifact set.
+  They will contain an informational back link to the component version
+  using the manifest annotation <code>software.ocm/component-version</code>.
 
   This blob type specification supports the following fields:
   - **<code>variants</code>** *[]string*

--- a/pkg/contexts/oci/annotations/annotations.go
+++ b/pkg/contexts/oci/annotations/annotations.go
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package annotations
+
+import (
+	"github.com/open-component-model/ocm/pkg/contexts/oci/repositories/artifactset"
+)
+
+// MAINARTIFACT_ANNOTATION is the name of the OCI manifest annotation used to describe
+// the main artifact identity in an artifact set..
+const MAINARTIFACT_ANNOTATION = artifactset.MAINARTIFACT_ANNOTATION
+
+// TAGS_ANNOTATION is the name of the OCI manifest annotation used to describe a set of
+// tags assigned to a manifest in an artifact set.
+const TAGS_ANNOTATION = artifactset.TAGS_ANNOTATION
+
+const TYPE_ANNOTATION = artifactset.TYPE_ANNOTATION
+
+// OCITAG_ANNOTATION is the name of the OCI manifest annotation used to describe a tag.
+const OCITAG_ANNOTATION = artifactset.OCITAG_ANNOTATION
+
+// COMPVERS_ANNOTATION is the name of the OCI manifest annotation used to describe
+// the OCM identity of the origin of an OCI artifact. This is the identity of a
+// component version `<component name>:<component version>`.
+const COMPVERS_ANNOTATION = "software.ocm/component-version"

--- a/pkg/contexts/oci/artdesc/index.go
+++ b/pkg/contexts/oci/artdesc/index.go
@@ -44,6 +44,23 @@ func (i *Index) MimeType() string {
 	return ArtifactMimeType(i.MediaType, MediaTypeImageIndex, legacy)
 }
 
+func (i *Index) SetAnnotation(name, value string) {
+	if i.Annotations == nil {
+		i.Annotations = map[string]string{}
+	}
+	i.Annotations[name] = value
+}
+
+func (i *Index) DeleteAnnotation(name string) {
+	if i.Annotations == nil {
+		return
+	}
+	delete(i.Annotations, name)
+	if len(i.Annotations) == 0 {
+		i.Annotations = nil
+	}
+}
+
 func (i *Index) ToBlobAccess() (accessio.BlobAccess, error) {
 	i.MediaType = i.MimeType()
 	data, err := json.Marshal(i)

--- a/pkg/contexts/oci/artdesc/manifest.go
+++ b/pkg/contexts/oci/artdesc/manifest.go
@@ -57,6 +57,23 @@ func (m *Manifest) ToBlobAccess() (accessio.BlobAccess, error) {
 	return accessio.BlobAccessForData(m.MediaType, data), nil
 }
 
+func (m *Manifest) SetAnnotation(name, value string) {
+	if m.Annotations == nil {
+		m.Annotations = map[string]string{}
+	}
+	m.Annotations[name] = value
+}
+
+func (m *Manifest) DeleteAnnotation(name string) {
+	if m.Annotations == nil {
+		return
+	}
+	delete(m.Annotations, name)
+	if len(m.Annotations) == 0 {
+		m.Annotations = nil
+	}
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func DecodeManifest(data []byte) (*Manifest, error) {


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.


## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Fixes #523

## Screenshots

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [X] 🙅 no, because it would require an local docker daemon.
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Added to documentation?

- [X] 📜 OCI annotations are now bundled and documented in pkg/contexts/oci/annotations
- [X] 📜 CLI docu (for example docs/reference/ocm_add_resources.md)
- [ ] 📜 README.md
- [ ] 🙅 no documentation needed

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Tested locally against local docker daemon
- [ ] Any dependent changes have been merged and published in downstream modules
