### PR TITLE
relaxed TLS version for OCI access

### DIFF
--- a/pkg/contexts/oci/repositories/ocireg/repository.go
+++ b/pkg/contexts/oci/repositories/ocireg/repository.go
@@ -143,8 +143,9 @@ func (r *RepositoryImpl) getResolver(comp string) (resolve.Resolver, error) {
 				return "", "", nil
 			},
 			DefaultScheme: r.info.Scheme,
+			//nolint:gosec // used like the default, there are OCI servers (quay.io) not working with min version.
 			DefaultTLS: &tls.Config{
-				MinVersion: tls.VersionTLS13,
+				// MinVersion: tls.VersionTLS13,
 				RootCAs: func() *x509.CertPool {
 					var rootCAs *x509.CertPool
 					if creds != nil {


### PR DESCRIPTION
## Description
Remove the TLS version constraint for OCI registry access quay.io uses a much older one (303)

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
Fixes #532
> Remove if not applicable

## Screenshots

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Added to documentation?

- [ ] 📜 README.md
- [ ] 🙅 no documentation needed

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
