### PR TITLE
Calculate orchestration digests based on initial blob instead of local access method

### DIFF
--- a/cmds/ocm/commands/ocmcmds/common/inputs/cpi/helper.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/cpi/helper.go
@@ -80,12 +80,12 @@ func (s *ProcessSpec) SetMediaTypeIfNotDefined(mediaType string) {
 	s.MediaType = mediaType
 }
 
-func (s *ProcessSpec) ProcessBlob(ctx inputs.Context, acc accessio.DataAccess, fs vfs.FileSystem) (accessio.TemporaryBlobAccess, string, error) {
+func (s *ProcessSpec) ProcessBlob(ctx inputs.Context, acc accessio.DataAccess, fs vfs.FileSystem) (accessio.BlobAccess, string, error) {
 	if !s.Compress() {
 		if s.MediaType == "" {
 			s.MediaType = mime.MIME_OCTET
 		}
-		return accessio.TemporaryBlobAccessFor(accessio.BlobAccessForDataAccess(accessio.BLOB_UNKNOWN_DIGEST, accessio.BLOB_UNKNOWN_SIZE, s.MediaType, acc)), "", nil
+		return accessio.BlobAccessForDataAccess(accessio.BLOB_UNKNOWN_DIGEST, accessio.BLOB_UNKNOWN_SIZE, s.MediaType, acc), "", nil
 	}
 
 	reader, err := acc.Reader()

--- a/cmds/ocm/commands/ocmcmds/common/inputs/inputtype.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/inputtype.go
@@ -87,7 +87,7 @@ type InputResourceInfo struct {
 type InputSpec interface {
 	runtime.VersionedTypedObject
 	Validate(fldPath *field.Path, ctx Context, inputFilePath string) field.ErrorList
-	GetBlob(ctx Context, info InputResourceInfo) (accessio.TemporaryBlobAccess, string, error)
+	GetBlob(ctx Context, info InputResourceInfo) (accessio.BlobAccess, string, error)
 	GetInputVersion(ctx Context) string
 }
 
@@ -272,7 +272,7 @@ func (r *UnknownInputSpec) Validate(fldPath *field.Path, ctx Context, inputFileP
 	return field.ErrorList{field.Invalid(fldPath.Child("type"), r.GetType(), "unknown type")}
 }
 
-func (r *UnknownInputSpec) GetBlob(ctx Context, info InputResourceInfo) (accessio.TemporaryBlobAccess, string, error) {
+func (r *UnknownInputSpec) GetBlob(ctx Context, info InputResourceInfo) (accessio.BlobAccess, string, error) {
 	return nil, "", errors.ErrUnknown("input type", r.GetType())
 }
 
@@ -329,7 +329,7 @@ func (s *GenericInputSpec) Validate(fldPath *field.Path, ctx Context, inputFileP
 	return s.effective.Validate(fldPath, ctx, inputFilePath)
 }
 
-func (s *GenericInputSpec) GetBlob(ctx Context, info InputResourceInfo) (accessio.TemporaryBlobAccess, string, error) {
+func (s *GenericInputSpec) GetBlob(ctx Context, info InputResourceInfo) (accessio.BlobAccess, string, error) {
 	if s.effective == nil {
 		var err error
 		s.effective, err = s.Evaluate(For(ctx))

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/binary/spec.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/binary/spec.go
@@ -39,6 +39,6 @@ func (s *Spec) Validate(fldPath *field.Path, ctx inputs.Context, inputFilePath s
 	return nil
 }
 
-func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.TemporaryBlobAccess, string, error) {
+func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.BlobAccess, string, error) {
 	return s.ProcessBlob(ctx, accessio.DataAccessForBytes([]byte(s.Data)), ctx.FileSystem())
 }

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/directory/spec.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/directory/spec.go
@@ -58,7 +58,7 @@ func (s *Spec) Validate(fldPath *field.Path, ctx inputs.Context, inputFilePath s
 	return allErrs
 }
 
-func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.TemporaryBlobAccess, string, error) {
+func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.BlobAccess, string, error) {
 	fs := ctx.FileSystem()
 	inputInfo, inputPath, err := inputs.FileInfo(ctx, s.Path, info.InputFilePath)
 	if err != nil {

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/docker/spec.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/docker/spec.go
@@ -47,7 +47,7 @@ func (s *Spec) Validate(fldPath *field.Path, ctx inputs.Context, inputFilePath s
 	return allErrs
 }
 
-func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.TemporaryBlobAccess, string, error) {
+func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.BlobAccess, string, error) {
 	ctx.Printf("image %s\n", s.Path)
 	locator, version, err := docker.ParseGenericRef(s.Path)
 	if err != nil {

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/dockermulti/spec.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/dockermulti/spec.go
@@ -99,7 +99,7 @@ func (s *Spec) getVariant(ctx clictx.Context, finalize *Finalizer, variant strin
 	return art, nil
 }
 
-func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.TemporaryBlobAccess, string, error) {
+func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.BlobAccess, string, error) {
 	index := artdesc.NewIndexArtifact()
 	i := 0
 

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/file/spec.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/file/spec.go
@@ -28,6 +28,6 @@ func (s *Spec) Validate(fldPath *field.Path, ctx inputs.Context, inputFilePath s
 	return (&FileProcessSpec{s.MediaFileSpec, nil}).Validate(fldPath, ctx, inputFilePath)
 }
 
-func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.TemporaryBlobAccess, string, error) {
+func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.BlobAccess, string, error) {
 	return (&FileProcessSpec{s.MediaFileSpec, nil}).GetBlob(ctx, info)
 }

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/file/support.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/file/support.go
@@ -35,7 +35,7 @@ func (s *FileProcessSpec) Validate(fldPath *field.Path, ctx inputs.Context, inpu
 	return allErrs
 }
 
-func (s *FileProcessSpec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.TemporaryBlobAccess, string, error) {
+func (s *FileProcessSpec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.BlobAccess, string, error) {
 	fs := ctx.FileSystem()
 	inputInfo, inputPath, err := inputs.FileInfo(ctx, s.Path, info.InputFilePath)
 	if err != nil {
@@ -75,9 +75,9 @@ func (s *FileProcessSpec) GetBlob(ctx inputs.Context, info inputs.InputResourceI
 		}
 		if data == nil {
 			inputBlob.Close()
-			return accessio.TemporaryBlobAccessFor(accessio.BlobAccessForFile(s.MediaType, inputPath, fs)), "", nil
+			return accessio.BlobAccessForFile(s.MediaType, inputPath, fs), "", nil
 		}
-		return accessio.TemporaryBlobAccessFor(accessio.BlobAccessForData(s.MediaType, data)), "", nil
+		return accessio.BlobAccessForData(s.MediaType, data), "", nil
 	}
 
 	temp, err := accessio.NewTempFile(fs, "", "compressed*.gzip")

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/ociimage/spec.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/ociimage/spec.go
@@ -47,7 +47,7 @@ func (s *Spec) Validate(fldPath *field.Path, ctx inputs.Context, inputFilePath s
 	return allErrs
 }
 
-func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.TemporaryBlobAccess, string, error) {
+func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.BlobAccess, string, error) {
 	ctx.Printf("image %s\n", s.Path)
 	ref, err := oci.ParseRef(s.Path)
 	if err != nil {

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/spiff/spec.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/spiff/spec.go
@@ -62,7 +62,7 @@ func (s *Spec) Validate(fldPath *field.Path, ctx inputs.Context, inputFilePath s
 	return allErrs
 }
 
-func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.TemporaryBlobAccess, string, error) {
+func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.BlobAccess, string, error) {
 	return (&file.FileProcessSpec{s.MediaFileSpec, s.process}).GetBlob(ctx, info)
 }
 

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/utf8/spec.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/utf8/spec.go
@@ -110,7 +110,7 @@ func (s *Spec) Validate(fldPath *field.Path, ctx inputs.Context, inputFilePath s
 	return nil
 }
 
-func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.TemporaryBlobAccess, string, error) {
+func (s *Spec) GetBlob(ctx inputs.Context, info inputs.InputResourceInfo) (accessio.BlobAccess, string, error) {
 	data, err := Plain([]byte(s.Text))
 
 	if s.Json != nil {

--- a/cmds/ocm/commands/ocmcmds/common/resources.go
+++ b/cmds/ocm/commands/ocmcmds/common/resources.go
@@ -476,13 +476,13 @@ func ProcessElements(ictx inputs.Context, cv ocm.ComponentVersionAccess, elems [
 					elem.Spec().SetVersion(iv)
 				}
 				acc, err = cv.AddBlob(blob, elem.Type(), hint, nil)
+				blob.Close()
 				if err == nil {
 					err = CheckHint(cv, acc)
 					if err == nil {
 						err = h.Set(cv, elem, acc)
 					}
 				}
-				blob.Close()
 			} else {
 				acc := elem.Input().Access
 				err = CheckHint(cv, acc)

--- a/cmds/ocm/commands/ocmcmds/common/resources.go
+++ b/cmds/ocm/commands/ocmcmds/common/resources.go
@@ -476,13 +476,13 @@ func ProcessElements(ictx inputs.Context, cv ocm.ComponentVersionAccess, elems [
 					elem.Spec().SetVersion(iv)
 				}
 				acc, err = cv.AddBlob(blob, elem.Type(), hint, nil)
-				blob.Close()
 				if err == nil {
 					err = CheckHint(cv, acc)
 					if err == nil {
 						err = h.Set(cv, elem, acc)
 					}
 				}
+				blob.Close()
 			} else {
 				acc := elem.Input().Access
 				err = CheckHint(cv, acc)

--- a/docs/formats/resources/README.md
+++ b/docs/formats/resources/README.md
@@ -7,7 +7,8 @@ The following resource types are centrally defined:
 - `ociImage`: an OCI image or image list
 - `helmChart`: a helm chart, either stored as OCI artifact or as tar blob (tar media type)
 - `blob`: any anonymous untyped blob data
-- `filesytem`: a directory structures stored as archive (tar, tgz).
+- `directoryTree`: a directory structures stored as archive (tar, tgz).
+- `filesystem`: (deprecated) a directory structures stored as archive (tar, tgz).
 
 For centrally defined resource types, there might be special support in the
 OCM library and tool set. For example, there is a dedicated downloader

--- a/pkg/common/accessio/access.go
+++ b/pkg/common/accessio/access.go
@@ -16,9 +16,9 @@ import (
 	"github.com/mandelsoft/filepath/pkg/filepath"
 	"github.com/mandelsoft/vfs/pkg/vfs"
 	"github.com/modern-go/reflect2"
-	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 	"github.com/opencontainers/go-digest"
 
+	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 	"github.com/open-component-model/ocm/pkg/errors"
 )
 
@@ -276,6 +276,17 @@ type blobAccess struct {
 type annotatedBlobAccessView[T DataAccess] struct {
 	_blobAccess
 	access T
+}
+
+func (a *annotatedBlobAccessView[T]) Dup() (BlobAccess, error) {
+	b, err := a._blobAccess.Dup()
+	if err != nil {
+		return nil, err
+	}
+	return &annotatedBlobAccessView[T]{
+		_blobAccess: b,
+		access:      a.access,
+	}, nil
 }
 
 func (a *annotatedBlobAccessView[T]) Source() T {

--- a/pkg/common/accessio/blobaccess/dirtree/access.go
+++ b/pkg/common/accessio/blobaccess/dirtree/access.go
@@ -21,7 +21,7 @@ func DataAccessForDirTree(path string, opts ...Option) (accessio.DataAccess, err
 	return blobAccess, nil
 }
 
-func BlobAccessForDirTree(path string, opts ...Option) (_ accessio.TemporaryBlobAccess, rerr error) {
+func BlobAccessForDirTree(path string, opts ...Option) (_ accessio.BlobAccess, rerr error) {
 	var eff Options
 	for _, opt := range opts {
 		opt.ApplyToDirtreeOptions(&eff)

--- a/pkg/common/accessio/blobaccess/interface.go
+++ b/pkg/common/accessio/blobaccess/interface.go
@@ -1,6 +1,8 @@
 package blobaccess
 
 import (
+	"io"
+
 	"github.com/mandelsoft/vfs/pkg/vfs"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
@@ -19,6 +21,18 @@ func ForData(mime string, data []byte) BlobAccess {
 
 func ForFile(mime string, path string, fss ...vfs.FileSystem) BlobAccess {
 	return accessio.BlobAccessForFile(mime, path, fss...)
+}
+
+func ForFileWithCLoser(closer io.Closer, mime string, path string, fss ...vfs.FileSystem) BlobAccess {
+	return accessio.BlobAccessForFileWithCloser(closer, mime, path, fss...)
+}
+
+func ForTemporaryFile(mime string, file vfs.File, fss ...vfs.FileSystem) BlobAccess {
+	return accessio.BlobAccessForTemporaryFile(mime, file, fss...)
+}
+
+func ForTemporaryFilePath(mime string, path string, fss ...vfs.FileSystem) BlobAccess {
+	return accessio.BlobAccessForTemporaryFilePath(mime, path, fss...)
 }
 
 func ForDirTree(path string, opts ...dirtree.Option) (BlobAccess, error) {

--- a/pkg/common/accessio/blobaccess/interface.go
+++ b/pkg/common/accessio/blobaccess/interface.go
@@ -24,3 +24,20 @@ func ForFile(mime string, path string, fss ...vfs.FileSystem) BlobAccess {
 func ForDirTree(path string, opts ...dirtree.Option) (BlobAccess, error) {
 	return dirtree.BlobAccessForDirTree(path, opts...)
 }
+
+// Validatable is an optional interface for DataAccess
+// implementations or any other object, which might reach
+// an error state. The error can then be queried with
+// the method ErrorProvider.Validate.
+// This is used to support objects with access methods not
+// returning an error. If the object is not valid,
+// those methods return an unknown/default state, but
+// the object should be queryable for its state.
+type Validatable = accessio.Validatable
+
+// Validate checks whether a blob access
+// is in error state. If yes, an appropriate
+// error is returned.
+func Validate(o BlobAccess) error {
+	return accessio.ValidateObject(o)
+}

--- a/pkg/common/accessio/blobaccess_test.go
+++ b/pkg/common/accessio/blobaccess_test.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package accessio_test
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/open-component-model/ocm/pkg/testutils"
+
+	"github.com/mandelsoft/vfs/pkg/osfs"
+	"github.com/mandelsoft/vfs/pkg/vfs"
+
+	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/mime"
+)
+
+var _ = Describe("blob access ref counting", func() {
+	It("handles ref counts", func() {
+
+		blob := accessio.BlobAccessForString(mime.MIME_TEXT, "test")
+		dup := Must(blob.Dup())
+		MustBeSuccessful(blob.Close())
+		Expect(blob.Close()).To(MatchError("closed"))
+		MustBeSuccessful(dup.Close())
+	})
+
+	It("releases temp file", func() {
+		temp := Must(os.CreateTemp("", "testfile*"))
+		path := temp.Name()
+		temp.Close()
+		blob := accessio.BlobAccessForTemporaryFilePath(mime.MIME_TEXT, path, osfs.OsFs)
+
+		Expect(vfs.FileExists(osfs.OsFs, path)).To(BeTrue())
+
+		dup := Must(blob.Dup())
+		MustBeSuccessful(blob.Close())
+		Expect(vfs.FileExists(osfs.OsFs, path)).To(BeTrue())
+		MustBeSuccessful(dup.Close())
+		Expect(vfs.FileExists(osfs.OsFs, path)).To(BeFalse())
+	})
+})

--- a/pkg/common/accessio/cache.go
+++ b/pkg/common/accessio/cache.go
@@ -16,10 +16,10 @@ import (
 	"github.com/mandelsoft/vfs/pkg/projectionfs"
 	"github.com/mandelsoft/vfs/pkg/vfs"
 	"github.com/marstr/guid"
-	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 	"github.com/opencontainers/go-digest"
 
 	"github.com/open-component-model/ocm/pkg/common"
+	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 	"github.com/open-component-model/ocm/pkg/errors"
 )
 

--- a/pkg/common/accessio/cache.go
+++ b/pkg/common/accessio/cache.go
@@ -16,128 +16,12 @@ import (
 	"github.com/mandelsoft/vfs/pkg/projectionfs"
 	"github.com/mandelsoft/vfs/pkg/vfs"
 	"github.com/marstr/guid"
+	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 	"github.com/opencontainers/go-digest"
 
 	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/errors"
-	"github.com/open-component-model/ocm/pkg/logging"
 )
-
-var ALLOC_REALM = logging.DefineSubRealm("reference counting", "refcnt")
-
-var allocLog = logging.DynamicLogger(ALLOC_REALM)
-
-type Allocatable interface {
-	Ref() error
-	Unref() error
-}
-
-type RefMgmt interface {
-	Allocatable
-	UnrefLast() error
-	IsClosed() bool
-
-	WithName(name string) RefMgmt
-}
-
-type refMgmt struct {
-	lock     sync.Mutex
-	refcount int
-	closed   bool
-	cleanup  func() error
-	name     string
-}
-
-func NewAllocatable(cleanup func() error, unused ...bool) RefMgmt {
-	n := 1
-	for _, b := range unused {
-		if b {
-			n = 0
-		}
-	}
-	return &refMgmt{refcount: n, cleanup: cleanup, name: "object"}
-}
-
-func (c *refMgmt) WithName(name string) RefMgmt {
-	c.name = name
-	return c
-}
-
-func (c *refMgmt) IsClosed() bool {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	return c.closed
-}
-
-func (c *refMgmt) Ref() error {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	if c.closed {
-		return ErrClosed
-	}
-	c.refcount++
-	allocLog.Trace("ref", "name", c.name, "refcnt", c.refcount)
-	return nil
-}
-
-func (c *refMgmt) Unref() error {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	if c.closed {
-		return ErrClosed
-	}
-
-	var err error
-
-	c.refcount--
-	allocLog.Trace("unref", "name", c.name, "refcnt", c.refcount)
-	if c.refcount <= 0 {
-		if c.cleanup != nil {
-			err = c.cleanup()
-		}
-
-		c.closed = true
-	}
-
-	if err != nil {
-		return fmt.Errorf("unable to unref %s: %w", c.name, err)
-	}
-
-	return nil
-}
-
-func (c *refMgmt) UnrefLast() error {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-	if c.closed {
-		return ErrClosed
-	}
-
-	if c.refcount > 1 {
-		return errors.ErrStillInUseWrap(errors.Newf("%d reference(s) pending", c.refcount), c.name)
-	}
-
-	var err error
-
-	c.refcount--
-	allocLog.Trace("unref last", "name", c.name, "refcnt", c.refcount)
-	if c.refcount <= 0 {
-		if c.cleanup != nil {
-			err = c.cleanup()
-		}
-
-		c.closed = true
-	}
-
-	if err != nil {
-		allocLog.Trace("cleanup last failed", "name", c.name, "error", err.Error())
-		return errors.Wrapf(err, "unable to cleanup %s while unref last", c.name)
-	}
-
-	return nil
-}
-
-////////////////////////////////////////////////////////////////////////////////
 
 type StaticAllocatable struct{}
 
@@ -145,12 +29,12 @@ func (_ StaticAllocatable) Ref() error   { return nil }
 func (_ StaticAllocatable) Unref() error { return nil }
 
 type BlobSource interface {
-	Allocatable
+	refmgmt.Allocatable
 	GetBlobData(digest digest.Digest) (int64, DataAccess, error)
 }
 
 type BlobSink interface {
-	Allocatable
+	refmgmt.Allocatable
 	AddBlob(blob BlobAccess) (int64, digest.Digest, error)
 }
 
@@ -174,7 +58,7 @@ type BlobCache interface {
 }
 
 type blobCache struct {
-	Allocatable
+	refmgmt.Allocatable
 	lock  sync.RWMutex
 	cache vfs.FileSystem
 }
@@ -202,7 +86,7 @@ func NewDefaultBlobCache(fss ...vfs.FileSystem) (BlobCache, error) {
 	c := &blobCache{
 		cache: fs,
 	}
-	c.Allocatable = NewAllocatable(c.cleanup)
+	c.Allocatable = refmgmt.NewAllocatable(c.cleanup)
 	return c, nil
 }
 
@@ -382,7 +266,7 @@ func (c *blobCache) AddData(data DataAccess) (int64, digest.Digest, error) {
 ////////////////////////////////////////////////////////////////////////////////
 
 type cascadedCache struct {
-	Allocatable
+	refmgmt.Allocatable
 	lock   sync.RWMutex
 	parent BlobSource
 	source BlobSource
@@ -401,7 +285,7 @@ func NewCascadedBlobCache(parent BlobCache) (BlobCache, error) {
 	c := &cascadedCache{
 		parent: parent,
 	}
-	c.Allocatable = NewAllocatable(c.cleanup)
+	c.Allocatable = refmgmt.NewAllocatable(c.cleanup)
 	return c, nil
 }
 
@@ -422,7 +306,7 @@ func NewCascadedBlobCacheForSource(parent BlobSource, src BlobSource) (BlobCache
 		parent: parent,
 		source: src,
 	}
-	c.Allocatable = NewAllocatable(c.cleanup)
+	c.Allocatable = refmgmt.NewAllocatable(c.cleanup)
 	return c, nil
 }
 
@@ -444,7 +328,7 @@ func NewCascadedBlobCacheForCache(parent BlobSource, src BlobCache) (BlobCache, 
 		source: src,
 		sink:   src,
 	}
-	c.Allocatable = NewAllocatable(c.cleanup)
+	c.Allocatable = refmgmt.NewAllocatable(c.cleanup)
 	return c, nil
 }
 
@@ -518,7 +402,7 @@ func (c *cascadedCache) AddBlob(blob BlobAccess) (int64, digest.Digest, error) {
 ////////////////////////////////////////////////////////////////////////////////
 
 type cached struct {
-	Allocatable
+	refmgmt.Allocatable
 	lock   sync.RWMutex
 	source BlobSource
 	sink   BlobSink
@@ -627,7 +511,7 @@ func CachedAccess(src BlobSource, dst BlobSink, cache BlobCache) (BlobCache, err
 		}
 	}
 	c := &cached{source: src, sink: dst, cache: cache}
-	c.Allocatable = NewAllocatable(c.cleanup)
+	c.Allocatable = refmgmt.NewAllocatable(c.cleanup)
 	return c, nil
 }
 

--- a/pkg/common/accessio/refmgmt/doc.go
+++ b/pkg/common/accessio/refmgmt/doc.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package refmgmt provides a simple wrapper, which can be used
+// to map a closable object type into an interface supporting reference
+// counting and supporting a Dup() method.
+//
+// The caller must provide an appropriate interface with the
+// base object methods and additionally the Dup() (O, error) interface.
+// Additionally, a struct type must be implemented hosting a View object
+// (which implements the View.Close() and View.Dup() method) and
+// the base object. It must implement the other interface methods
+// by forwarding them to the base object.
+// To create such a view object an appropriate creator function has to
+// be provided.
+//
+// The following example illustrates the usage:
+//
+//	 // Objectbase is the base interface for the
+//	 // object type to be wrapped.
+//	 type ObjectBase interface {
+//	 	io.Closer
+//
+//	 	Value() (string, error)
+//	 }
+//
+//	 ////////////////////////////////////////////////////////////////////////////////
+//
+//	 // Object is the final user facing interface.
+//	 // It includes the base interface plus the Dup method.
+//	 type Object interface {
+//	 	ObjectBase
+//			Dup() (Object, error)
+//	 }
+//
+//	 ////////////////////////////////////////////////////////////////////////////////
+//
+//	 // object is the implementation type for the bse object.
+//	 type object struct {
+//	 	lock   sync.Mutex
+//			closed bool
+//	 	value  string
+//	 }
+//
+//	 func (o *object) Value() (string, error) {
+//			if o.closed {
+//	 		return "", fmt.Errorf("should not happen")
+//			}
+//	 	return o.value, nil
+//	 }
+//
+//	 func (o *object) Close() error {
+//			o.lock.Lock()
+//			defer o.lock.Unlock()
+//
+//			if o.closed {
+//		 		return refmgmt.ErrClosed
+//			}
+//			o.closed = true
+//			return nil
+//	 }
+//
+//	 ////////////////////////////////////////////////////////////////////////////////
+//
+//	 // view is the view object used to wrap the base object.
+//	 // It forwards all methods to the base object using the
+//	 // Execute function of the manager, to assure execution
+//	 // on non-closed views, only.
+//	 type view struct {
+//			*refmgmt.View[Object]
+//			obj ObjectBase
+//	 }
+//
+//	 func (v *view) Value() (string, error) {
+//			value := ""
+//
+//			err := v.Execute(func() (err error) {
+//		 		value, err = v.obj.Value() // forward to viewd object
+//		 		return
+//			})
+//			return value, err
+//	 }
+//
+//	 // creator is the view object creator based on
+//	 // the base object and the view manager.
+//	 func creator(obj ObjectBase, v *refmgmt.View[Object]) Object {
+//	 	return &view{v, obj}
+//	 }
+package refmgmt

--- a/pkg/common/accessio/refmgmt/refcloser.go
+++ b/pkg/common/accessio/refmgmt/refcloser.go
@@ -1,8 +1,8 @@
-// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package accessio
+package refmgmt
 
 import (
 	"io"
@@ -10,6 +10,8 @@ import (
 
 	"github.com/open-component-model/ocm/pkg/errors"
 )
+
+var ErrClosed = errors.ErrClosed()
 
 // ReferencableCloser manages closable views to a basic closer.
 // If the last view is closed, the basic closer is finally closed.

--- a/pkg/common/accessio/refmgmt/refmgmt.go
+++ b/pkg/common/accessio/refmgmt/refmgmt.go
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package refmgmt
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/logging"
+)
+
+var ALLOC_REALM = logging.DefineSubRealm("reference counting", "refcnt")
+
+var allocLog = logging.DynamicLogger(ALLOC_REALM)
+
+type Allocatable interface {
+	Ref() error
+	Unref() error
+}
+
+type RefMgmt interface {
+	Allocatable
+	UnrefLast() error
+	IsClosed() bool
+
+	WithName(name string) RefMgmt
+}
+
+type refMgmt struct {
+	lock     sync.Mutex
+	refcount int
+	closed   bool
+	cleanup  func() error
+	name     string
+}
+
+func NewAllocatable(cleanup func() error, unused ...bool) RefMgmt {
+	n := 1
+	for _, b := range unused {
+		if b {
+			n = 0
+		}
+	}
+	return &refMgmt{refcount: n, cleanup: cleanup, name: "object"}
+}
+
+func (c *refMgmt) WithName(name string) RefMgmt {
+	c.name = name
+	return c
+}
+
+func (c *refMgmt) IsClosed() bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.closed
+}
+
+func (c *refMgmt) Ref() error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.closed {
+		return ErrClosed
+	}
+	c.refcount++
+	allocLog.Trace("ref", "name", c.name, "refcnt", c.refcount)
+	return nil
+}
+
+func (c *refMgmt) Unref() error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.closed {
+		return ErrClosed
+	}
+
+	var err error
+
+	c.refcount--
+	allocLog.Trace("unref", "name", c.name, "refcnt", c.refcount)
+	if c.refcount <= 0 {
+		if c.cleanup != nil {
+			err = c.cleanup()
+		}
+
+		c.closed = true
+	}
+
+	if err != nil {
+		return fmt.Errorf("unable to unref %s: %w", c.name, err)
+	}
+
+	return nil
+}
+
+func (c *refMgmt) UnrefLast() error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.closed {
+		return ErrClosed
+	}
+
+	if c.refcount > 1 {
+		return errors.ErrStillInUseWrap(errors.Newf("%d reference(s) pending", c.refcount), c.name)
+	}
+
+	var err error
+
+	c.refcount--
+	allocLog.Trace("unref last", "name", c.name, "refcnt", c.refcount)
+	if c.refcount <= 0 {
+		if c.cleanup != nil {
+			err = c.cleanup()
+		}
+
+		c.closed = true
+	}
+
+	if err != nil {
+		allocLog.Trace("cleanup last failed", "name", c.name, "error", err.Error())
+		return errors.Wrapf(err, "unable to cleanup %s while unref last", c.name)
+	}
+
+	return nil
+}

--- a/pkg/common/accessio/refmgmt/suite_test.go
+++ b/pkg/common/accessio/refmgmt/suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package refmgmt_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Referencable Resource Test Suite")
+}

--- a/pkg/common/accessio/refmgmt/view.go
+++ b/pkg/common/accessio/refmgmt/view.go
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package refmgmt
+
+import (
+	"io"
+	"sync"
+)
+
+type ViewManager[V io.Closer] interface {
+	View(closerView CloserView) (V, error)
+}
+
+type viewManager[O, V io.Closer /* O */] struct {
+	refs    ReferencableCloser
+	obj     O
+	creator func(O, *View[V]) V
+}
+
+func WithView[O, V io.Closer](obj O, creator func(O, *View[V]) V, closer ...io.Closer) V {
+	var c Closers
+
+	c.Add(obj)
+	c.Add(closer...)
+	m := &viewManager[O, V]{
+		refs:    NewRefCloser(c.Effective(), true),
+		obj:     obj,
+		creator: creator,
+	}
+	v, _ := m.View(nil)
+	return v
+}
+
+func (m *viewManager[O, V]) View(v CloserView) (V, error) {
+	if v != nil {
+		var n V
+		err := v.Execute(func() (err error) {
+			n, err = m.view()
+			return
+		})
+		return n, err
+	}
+	return m.view()
+}
+
+func (m *viewManager[O, V]) view() (V, error) {
+	var _nil V
+
+	v, err := m.refs.View(false)
+	if err != nil {
+		return _nil, err
+	}
+
+	return m.creator(m.obj, NewView[V](m, v)), nil
+}
+
+type View[V io.Closer] struct {
+	lock sync.Mutex
+	mgr  ViewManager[V]
+	view CloserView
+}
+
+func NewView[V io.Closer](mgr ViewManager[V], v CloserView) *View[V] {
+	return &View[V]{mgr: mgr, view: v}
+}
+
+func (v *View[V]) Dup() (V, error) {
+	return v.mgr.View(v.view)
+}
+
+func (v *View[V]) Close() error {
+	return v.view.Close()
+}
+
+func (v *View[V]) IsClosed() bool {
+	return v.view.IsClosed()
+}
+
+func (v *View[V]) Execute(f func() error) error {
+	return v.view.Execute(f)
+}

--- a/pkg/common/accessio/refmgmt/view.go
+++ b/pkg/common/accessio/refmgmt/view.go
@@ -6,7 +6,6 @@ package refmgmt
 
 import (
 	"io"
-	"sync"
 )
 
 type ViewManager[V io.Closer] interface {
@@ -57,7 +56,6 @@ func (m *viewManager[O, V]) view() (V, error) {
 }
 
 type View[V io.Closer] struct {
-	lock sync.Mutex
 	mgr  ViewManager[V]
 	view CloserView
 }

--- a/pkg/common/accessio/refmgmt/view_test.go
+++ b/pkg/common/accessio/refmgmt/view_test.go
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package refmgmt_test
+
+import (
+	"fmt"
+	"io"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/open-component-model/ocm/pkg/testutils"
+
+	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
+)
+
+// Objectbase is the base interface for the
+// object type to be wrapped.
+type ObjectBase interface {
+	io.Closer
+
+	Value() (string, error)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Object is the final user facing interface.
+// It includes the base interface plus the Dup method.
+type Object interface {
+	ObjectBase
+	Dup() (Object, error)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// object is the implementation type for the bse object.
+type object struct {
+	lock   sync.Mutex
+	closed bool
+	value  string
+}
+
+func (o *object) Value() (string, error) {
+	if o.closed {
+		return "", fmt.Errorf("should not happen")
+	}
+	return o.value, nil
+}
+
+func (o *object) Close() error {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+
+	if o.closed {
+		return refmgmt.ErrClosed
+	}
+	o.closed = true
+	return nil
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// view is the view object used to wrap the base object.
+// It forwards all methods to the base object using the
+// Execute function of the manager, to assure execution
+// on non-closed views, only.
+type view struct {
+	*refmgmt.View[Object]
+	obj ObjectBase
+}
+
+func (v *view) Value() (string, error) {
+	value := ""
+
+	err := v.Execute(func() (err error) {
+		value, err = v.obj.Value() // forward to viewd object
+		return
+	})
+	return value, err
+}
+
+// creator is the view object creator based on
+// the base object and the view manager.
+func creator(obj ObjectBase, v *refmgmt.View[Object]) Object {
+	return &view{v, obj}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+var _ = Describe("view management wrapper", func() {
+	It("wraps object", func() {
+		o := &object{value: "test"}
+
+		v := refmgmt.WithView[ObjectBase, Object](o, creator)
+		Expect(v.Value()).To(Equal("test"))
+
+		d := Must(v.Dup())
+		Expect(d.Value()).To(Equal("test"))
+
+		MustBeSuccessful(d.Close())
+		Expect(o.closed).To(BeFalse())
+		ExpectError(d.Value()).To(Equal(refmgmt.ErrClosed))
+		Expect(v.Value()).To(Equal("test"))
+
+		MustBeSuccessful(v.Close())
+		Expect(o.closed).To(BeTrue())
+		ExpectError(v.Value()).To(Equal(refmgmt.ErrClosed))
+	})
+})

--- a/pkg/common/accessio/resource/resource.go
+++ b/pkg/common/accessio/resource/resource.go
@@ -8,6 +8,7 @@ import (
 	"io"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 )
 
 type CloserView interface {
@@ -17,7 +18,7 @@ type CloserView interface {
 	Lazy()
 }
 
-var _ CloserView = accessio.CloserView(nil)
+var _ CloserView = refmgmt.CloserView(nil)
 
 var ErrClosed = accessio.ErrClosed
 
@@ -64,7 +65,7 @@ type ViewManager[T any] interface {
 type ResourceViewCreator[T any, I io.Closer] func(I, CloserView, ViewManager[T]) T
 
 type viewManager[T any, I ResourceImplementation[T]] struct {
-	refs    accessio.ReferencableCloser
+	refs    refmgmt.ReferencableCloser
 	creator ResourceViewCreator[T, I]
 	impl    I
 }
@@ -81,7 +82,7 @@ type ResourceImplementation[T any] interface {
 // function.
 func NewResource[T any, I ResourceImplementation[T]](impl I, c ResourceViewCreator[T, I], name string, main ...bool) T {
 	i := &viewManager[T, I]{
-		refs:    accessio.NewRefCloser(impl, true).WithName(name),
+		refs:    refmgmt.NewRefCloser(impl, true).WithName(name),
 		creator: c,
 		impl:    impl,
 	}

--- a/pkg/common/accessobj/accessstate.go
+++ b/pkg/common/accessobj/accessstate.go
@@ -253,7 +253,7 @@ func (s *state) HasChanged() bool {
 
 func (s *state) GetBlob() (accessio.BlobAccess, error) {
 	if !s.HasChanged() {
-		return s.originalBlob, nil
+		return s.originalBlob.Dup()
 	}
 	data, err := s.handler.Encode(s.current)
 	if err != nil {

--- a/pkg/common/accessobj/cachedblob.go
+++ b/pkg/common/accessobj/cachedblob.go
@@ -28,14 +28,14 @@ type CachedBlobAccess struct {
 	effective accessio.BlobAccess
 }
 
-var _ accessio.BlobAccess = (*CachedBlobAccess)(nil)
+var _ accessio.BlobAccessBase = (*CachedBlobAccess)(nil)
 
 func CachedBlobAccessForWriter(ctx datacontext.Context, mime string, src accessio.DataWriter) accessio.BlobAccess {
-	return &CachedBlobAccess{
+	return accessio.NewMultiViewBlobAccess(&CachedBlobAccess{
 		source: src,
 		mime:   mime,
 		cache:  tmpcache.Get(ctx),
-	}
+	})
 }
 
 func CachedBlobAccessForDataAccess(ctx datacontext.Context, mime string, src accessio.DataAccess) accessio.BlobAccess {

--- a/pkg/common/accessobj/cachedblob.go
+++ b/pkg/common/accessobj/cachedblob.go
@@ -31,7 +31,7 @@ type CachedBlobAccess struct {
 var _ accessio.BlobAccessBase = (*CachedBlobAccess)(nil)
 
 func CachedBlobAccessForWriter(ctx datacontext.Context, mime string, src accessio.DataWriter) accessio.BlobAccess {
-	return accessio.NewMultiViewBlobAccess(&CachedBlobAccess{
+	return accessio.NewBlobAccessForBase(&CachedBlobAccess{
 		source: src,
 		mime:   mime,
 		cache:  tmpcache.Get(ctx),

--- a/pkg/common/accessobj/format-tar.go
+++ b/pkg/common/accessobj/format-tar.go
@@ -95,6 +95,7 @@ func (h TarHandler) WriteToStream(obj *AccessObject, writer io.Writer, opts acce
 	if err != nil {
 		return fmt.Errorf("unable to write to get state blob: %w", err)
 	}
+	defer data.Close()
 
 	tw := tar.NewWriter(writer)
 	cdHeader := &tar.Header{

--- a/pkg/contexts/oci/cpi/support/namespace.go
+++ b/pkg/contexts/oci/cpi/support/namespace.go
@@ -5,10 +5,10 @@
 package support
 
 import (
-	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 	"github.com/opencontainers/go-digest"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/artdesc"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/cpi"
 	"github.com/open-component-model/ocm/pkg/errors"

--- a/pkg/contexts/oci/cpi/support/namespace.go
+++ b/pkg/contexts/oci/cpi/support/namespace.go
@@ -5,6 +5,7 @@
 package support
 
 import (
+	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 	"github.com/opencontainers/go-digest"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
@@ -15,7 +16,7 @@ import (
 
 // BlobProvider manages the technical access to blobs.
 type BlobProvider interface {
-	accessio.Allocatable
+	refmgmt.Allocatable
 	cpi.BlobSource
 	cpi.BlobSink
 }

--- a/pkg/contexts/oci/cpi/view.go
+++ b/pkg/contexts/oci/cpi/view.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/opencontainers/go-digest"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio/resource"
@@ -343,6 +344,9 @@ func (a *artifactAccessView) GetBlobData(digest digest.Digest) (size int64, acc 
 }
 
 func (a *artifactAccessView) AddBlob(access internal.BlobAccess) error {
+	if err := accessio.ValidateObject(access); err != nil {
+		return err
+	}
 	return a.Execute(func() error {
 		return a.impl.AddBlob(access)
 	})
@@ -381,6 +385,10 @@ func (a *artifactAccessView) NewArtifact(art ...*artdesc.Artifact) (acc Artifact
 }
 
 func (a *artifactAccessView) AddLayer(access internal.BlobAccess, descriptor *artdesc.Descriptor) (index int, err error) {
+	if err := accessio.ValidateObject(access); err != nil {
+		return -1, err
+	}
+
 	index = -1
 	err = a.Execute(func() error {
 		index, err = a.impl.AddLayer(access, descriptor)

--- a/pkg/contexts/oci/cpi/view.go
+++ b/pkg/contexts/oci/cpi/view.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/opencontainers/go-digest"
 
+	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/common/accessio/resource"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/artdesc"

--- a/pkg/contexts/oci/repositories/artifactset/utils_synthesis.go
+++ b/pkg/contexts/oci/repositories/artifactset/utils_synthesis.go
@@ -24,7 +24,7 @@ import (
 const SynthesizedBlobFormat = "+tar+gzip"
 
 type ArtifactBlob interface {
-	accessio.TemporaryFileSystemBlobAccess
+	accessio.BlobAccess
 }
 
 type Producer func(set *ArtifactSet) (string, error)

--- a/pkg/contexts/oci/repositories/ctf/ctf_test.go
+++ b/pkg/contexts/oci/repositories/ctf/ctf_test.go
@@ -11,7 +11,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 	. "github.com/open-component-model/ocm/pkg/contexts/oci/repositories/ctf/testhelper"
 	. "github.com/open-component-model/ocm/pkg/testutils"
 
@@ -21,6 +20,7 @@ import (
 	"github.com/opencontainers/go-digest"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 	"github.com/open-component-model/ocm/pkg/common/accessobj"
 	"github.com/open-component-model/ocm/pkg/contexts/oci"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/cpi"

--- a/pkg/contexts/oci/repositories/ctf/ctf_test.go
+++ b/pkg/contexts/oci/repositories/ctf/ctf_test.go
@@ -11,6 +11,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 	. "github.com/open-component-model/ocm/pkg/contexts/oci/repositories/ctf/testhelper"
 	. "github.com/open-component-model/ocm/pkg/testutils"
 
@@ -35,7 +36,7 @@ var _ = Describe("ctf management", func() {
 
 	var spec *ctf.RepositorySpec
 
-	ocmlog.Context().AddRule(logging.NewConditionRule(logging.TraceLevel, accessio.ALLOC_REALM))
+	ocmlog.Context().AddRule(logging.NewConditionRule(logging.TraceLevel, refmgmt.ALLOC_REALM))
 
 	BeforeEach(func() {
 		t, err := osfs.NewTempFileSystem()

--- a/pkg/contexts/oci/repositories/ctf/repository.go
+++ b/pkg/contexts/oci/repositories/ctf/repository.go
@@ -6,9 +6,9 @@ package ctf
 
 import (
 	"github.com/mandelsoft/vfs/pkg/vfs"
-	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 	"github.com/open-component-model/ocm/pkg/common/accessobj"
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext/attrs/vfsattr"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/cpi"

--- a/pkg/contexts/oci/repositories/ctf/repository.go
+++ b/pkg/contexts/oci/repositories/ctf/repository.go
@@ -6,6 +6,7 @@ package ctf
 
 import (
 	"github.com/mandelsoft/vfs/pkg/vfs"
+	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/common/accessobj"
@@ -132,7 +133,7 @@ func (r *RepositoryImpl) LookupArtifact(name string, ref string) (acc cpi.Artifa
 		return nil, err
 	}
 
-	defer accessio.PropagateCloseTemporary(&err, ns) // temporary namespace object not exposed.
+	defer refmgmt.PropagateCloseTemporary(&err, ns) // temporary namespace object not exposed.
 
 	a := r.getIndex().GetArtifactInfo(name, ref)
 	if a == nil {

--- a/pkg/contexts/oci/repositories/ocireg/repository.go
+++ b/pkg/contexts/oci/repositories/ocireg/repository.go
@@ -14,8 +14,8 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/remotes/docker/config"
 	"github.com/mandelsoft/logging"
-	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 
+	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/artdesc"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/cpi"

--- a/pkg/contexts/oci/repositories/ocireg/repository.go
+++ b/pkg/contexts/oci/repositories/ocireg/repository.go
@@ -14,8 +14,8 @@ import (
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/remotes/docker/config"
 	"github.com/mandelsoft/logging"
+	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 
-	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/artdesc"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/cpi"
@@ -204,7 +204,7 @@ func (r *RepositoryImpl) LookupArtifact(name string, version string) (acc cpi.Ar
 	if err != nil {
 		return nil, err
 	}
-	defer accessio.PropagateCloseTemporary(&err, ns) // temporary namespace object not exposed.
+	defer refmgmt.PropagateCloseTemporary(&err, ns) // temporary namespace object not exposed.
 
 	return ns.GetArtifact(version)
 }

--- a/pkg/contexts/ocm/accessmethods/ociartifact/method.go
+++ b/pkg/contexts/ocm/accessmethods/ociartifact/method.go
@@ -46,7 +46,7 @@ func init() {
 }
 
 func Is(spec cpi.AccessSpec) bool {
-	return spec != nil && spec.GetKind() == Type || spec.GetKind() == LegacyType
+	return spec != nil && (spec.GetKind() == Type || spec.GetKind() == LegacyType)
 }
 
 // AccessSpec describes the access for a oci registry.

--- a/pkg/contexts/ocm/blobhandler/handlers/oci/ocirepo/blobhandler.go
+++ b/pkg/contexts/ocm/blobhandler/handlers/oci/ocirepo/blobhandler.go
@@ -87,7 +87,7 @@ func (b *blobHandler) StoreBlob(blob cpi.BlobAccess, artType, hint string, globa
 		"mediatype", blob.MimeType(),
 		"hint", hint,
 	}
-	if m, ok := blob.(accessio.AnnotatedBlobAccess[cpi.AccessMethod]); ok {
+	if m, ok := blob.(accessio.AnnotatedBlobAccess[cpi.AccessMethodView]); ok {
 		cpi.BlobHandlerLogger(ctx.GetContext()).Debug("oci blob handler with ocm access source",
 			generics.AppendedSlice[any](values, "sourcetype", m.Source().AccessSpec().GetType())...,
 		)
@@ -150,12 +150,12 @@ func (b *artifactHandler) StoreBlob(blob cpi.BlobAccess, artType, hint string, g
 
 	keep := keepblobattr.Get(ctx.GetContext())
 
-	if m, ok := blob.(accessio.AnnotatedBlobAccess[cpi.AccessMethod]); ok {
+	if m, ok := blob.(accessio.AnnotatedBlobAccess[cpi.AccessMethodView]); ok {
 		// prepare for optimized point to point implementation
 		log.Debug("oci artifact handler with ocm access source",
 			generics.AppendedSlice[any](values, "sourcetype", m.Source().AccessSpec().GetType())...,
 		)
-		if ocimeth, ok := m.Source().(ociartifact.AccessMethod); !keep && ok {
+		if ocimeth, ok := m.Source().Base().(ociartifact.AccessMethod); !keep && ok {
 			art, _, err = ocimeth.GetArtifact(&finalizer)
 			if err != nil {
 				return nil, errors.Wrapf(err, "cannot access source artifact")

--- a/pkg/contexts/ocm/cpi/interface.go
+++ b/pkg/contexts/ocm/cpi/interface.go
@@ -55,6 +55,7 @@ type (
 	GenericAccessSpec                = internal.GenericAccessSpec
 	AccessMethod                     = internal.AccessMethod
 	AccessMethodSupport              = internal.AccessMethodSupport
+	AccessProvider                   = internal.AccessProvider
 	AccessType                       = internal.AccessType
 	AccessTypeProvider               = internal.AccessTypeProvider
 	AccessTypeScheme                 = internal.AccessTypeScheme

--- a/pkg/contexts/ocm/cpi/methodview.go
+++ b/pkg/contexts/ocm/cpi/methodview.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package cpi
+
+import (
+	"io"
+
+	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/internal"
+)
+
+// AccessMethodView can be used map wrap an access method
+// into a managed method with multiple views. The original method
+// object is closed once the last view is closed.
+type AccessMethodView interface {
+	AccessMethod
+
+	Base() interface{}
+	Dup() (AccessMethodView, error)
+}
+
+// AccessMethodAsView wrap an access method object into
+// a multi-view version. The original method is closed when
+// the last view is closed.
+// After an access method is used as base object, it should not
+// explicitly closed anymore, because the views will stop
+// functioning.
+func AccessMethodAsView(acc AccessMethod, closer ...io.Closer) AccessMethodView {
+	return refmgmt.WithView[AccessMethod, AccessMethodView](acc, accessMethodViewCreator, closer...)
+}
+
+func AccessMethodViewForSpec(spec AccessSpec, cv ComponentVersionAccess) (AccessMethodView, error) {
+	m, err := spec.AccessMethod(cv)
+	if err != nil {
+		return nil, err
+	}
+	return AccessMethodAsView(m), nil
+}
+
+func AccessMethodViewForAccessProvider(p AccessProvider) (AccessMethodView, error) {
+	m, err := p.AccessMethod()
+	if err != nil {
+		return nil, err
+	}
+	return AccessMethodAsView(m), nil
+}
+
+func accessMethodViewCreator(acc AccessMethod, view *refmgmt.View[AccessMethodView]) AccessMethodView {
+	return &accessMethodView{view, acc}
+}
+
+type accessMethodView struct {
+	*refmgmt.View[AccessMethodView]
+	access AccessMethod
+}
+
+func (a *accessMethodView) Base() interface{} {
+	return a.access
+}
+
+func (a *accessMethodView) Get() ([]byte, error) {
+	var result []byte
+	err := a.Execute(func() (err error) {
+		result, err = a.access.Get()
+		return
+	})
+	return result, err
+}
+
+func (a *accessMethodView) Reader() (io.ReadCloser, error) {
+	var result io.ReadCloser
+	err := a.Execute(func() (err error) {
+		result, err = a.access.Reader()
+		return
+	})
+	return result, err
+}
+
+func (a *accessMethodView) GetKind() string {
+	return a.access.GetKind()
+}
+
+func (a accessMethodView) AccessSpec() internal.AccessSpec {
+	return a.access.AccessSpec()
+}
+
+func (a accessMethodView) MimeType() string {
+	return a.access.MimeType()
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+func BlobAccessForAccessMethod(m AccessMethodView) (accessio.AnnotatedBlobAccess[AccessMethodView], error) {
+	m, err := m.Dup()
+	if err != nil {
+		return nil, err
+	}
+	return accessio.BlobAccessForDataAccess("", -1, m.MimeType(), m), nil
+}

--- a/pkg/contexts/ocm/cpi/utils.go
+++ b/pkg/contexts/ocm/cpi/utils.go
@@ -7,9 +7,7 @@ package cpi
 import (
 	"io"
 
-	"github.com/modern-go/reflect2"
 	"github.com/open-component-model/ocm/pkg/common/accessio"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 )
 
 type AccessMethodSource interface {
@@ -58,36 +56,4 @@ func ResourceData(s AccessMethodSource) ([]byte, error) {
 	}
 	defer meth.Close()
 	return meth.Get()
-}
-
-type WrappedAccessSpec interface {
-	UnwrapAccessSpec() AccessSpec
-}
-
-func EffecticveAccessSpec(spec AccessSpec) AccessSpec {
-	for {
-		if reflect2.IsNil(spec) {
-			return nil
-		}
-		if w, ok := spec.(WrappedAccessSpec); ok {
-			spec = w.UnwrapAccessSpec()
-		} else {
-			break
-		}
-	}
-	return spec
-}
-
-func effecticveAccessSpec(spec compdesc.AccessSpec) compdesc.AccessSpec {
-	for {
-		if reflect2.IsNil(spec) {
-			return nil
-		}
-		if w, ok := spec.(WrappedAccessSpec); ok {
-			spec = w.UnwrapAccessSpec()
-		} else {
-			break
-		}
-	}
-	return spec
 }

--- a/pkg/contexts/ocm/cpi/utils.go
+++ b/pkg/contexts/ocm/cpi/utils.go
@@ -7,7 +7,9 @@ package cpi
 import (
 	"io"
 
+	"github.com/modern-go/reflect2"
 	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 )
 
 type AccessMethodSource interface {
@@ -56,4 +58,36 @@ func ResourceData(s AccessMethodSource) ([]byte, error) {
 	}
 	defer meth.Close()
 	return meth.Get()
+}
+
+type WrappedAccessSpec interface {
+	UnwrapAccessSpec() AccessSpec
+}
+
+func EffecticveAccessSpec(spec AccessSpec) AccessSpec {
+	for {
+		if reflect2.IsNil(spec) {
+			return nil
+		}
+		if w, ok := spec.(WrappedAccessSpec); ok {
+			spec = w.UnwrapAccessSpec()
+		} else {
+			break
+		}
+	}
+	return spec
+}
+
+func effecticveAccessSpec(spec compdesc.AccessSpec) compdesc.AccessSpec {
+	for {
+		if reflect2.IsNil(spec) {
+			return nil
+		}
+		if w, ok := spec.(WrappedAccessSpec); ok {
+			spec = w.UnwrapAccessSpec()
+		} else {
+			break
+		}
+	}
+	return spec
 }

--- a/pkg/contexts/ocm/cpi/view.go
+++ b/pkg/contexts/ocm/cpi/view.go
@@ -8,7 +8,9 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"sync"
 
+	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/common/accessio/resource"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
@@ -287,8 +289,7 @@ type ComponentVersionAccessImpl interface {
 	GetStorageContext(cv ComponentVersionAccess) StorageContext
 
 	// AddBlobFor stores a local blob together with the component and
-	// potentially provides a global reference according to the OCI distribution spec
-	// if the blob described an oci artifact.
+	// potentially provides a global reference.
 	// The resulting access information (global and local) is provided as
 	// an access method specification usable in a component descriptor.
 	// This is the direct technical storage, without caring about any handler.
@@ -296,6 +297,76 @@ type ComponentVersionAccessImpl interface {
 
 	IsReadOnly() bool
 	Update(final bool) error
+
+	// GetBlobCache retieves the blob cache used to store preliminary
+	// blob accesses for freshly generated local access specs not directly
+	// usable until a component version is finally added to the repository.
+	GetBlobCache() BlobCache
+}
+
+type BlobCache interface {
+	// AddBlobFor stores blobs for added blobs not yet accessible
+	// by generated access method until version is finally added.
+	AddBlobFor(acc compdesc.AccessSpec, blob BlobAccess) error
+
+	// GetBlobFor retrieves the original blob access for
+	// a given access specification.
+	GetBlobFor(acc compdesc.AccessSpec) BlobAccess
+
+	RemoveBlobFor(acc compdesc.AccessSpec)
+	Clear() error
+}
+
+type blobCache struct {
+	lock      sync.Mutex
+	blobcache map[interface{}]accessio.BlobAccess
+}
+
+func NewBlobCache() BlobCache {
+	return &blobCache{
+		blobcache: map[interface{}]accessio.BlobAccess{},
+	}
+}
+
+func (c *blobCache) RemoveBlobFor(acc compdesc.AccessSpec) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if b := c.blobcache[acc]; b != nil {
+		b.Close()
+		delete(c.blobcache, acc)
+	}
+}
+
+func (c *blobCache) AddBlobFor(acc compdesc.AccessSpec, blob BlobAccess) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.blobcache[acc] == nil {
+		blob, err := blob.Dup()
+		if err != nil {
+			return err
+		}
+		c.blobcache[acc] = blob
+	}
+	return nil
+}
+
+func (c *blobCache) GetBlobFor(acc compdesc.AccessSpec) BlobAccess {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	return c.blobcache[acc]
+}
+
+func (c *blobCache) Clear() error {
+	list := errors.ErrList()
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	for _, b := range c.blobcache {
+		list.Add(b.Close())
+	}
+	c.blobcache = map[interface{}]accessio.BlobAccess{}
+	return list.Result()
 }
 
 type _ComponentVersionAccessImplBase = resource.ResourceImplBase[ComponentVersionAccess]
@@ -305,6 +376,9 @@ type ComponentVersionAccessImplBase struct {
 	ctx     Context
 	name    string
 	version string
+
+	lock      sync.Mutex
+	blobcache BlobCache
 }
 
 func NewComponentVersionAccessImplBase(ctx Context, name, version string, repo ComponentAccessViewManager, closer ...io.Closer) (*ComponentVersionAccessImplBase, error) {
@@ -317,11 +391,15 @@ func NewComponentVersionAccessImplBase(ctx Context, name, version string, repo C
 		ctx:                             ctx,
 		name:                            name,
 		version:                         version,
+		blobcache:                       NewBlobCache(),
 	}, nil
 }
 
 func (b *ComponentVersionAccessImplBase) Close() error {
-	return b._ComponentVersionAccessImplBase.Close() // just for debugger to catch Close on this type
+	list := errors.ErrListf("closing %s", common.VersionedElementKey(b))
+	list.Add(b._ComponentVersionAccessImplBase.Close())
+	list.Add(b.blobcache.Clear())
+	return list.Result()
 }
 
 func (b *ComponentVersionAccessImplBase) GetContext() Context {
@@ -334,6 +412,10 @@ func (b *ComponentVersionAccessImplBase) GetName() string {
 
 func (b *ComponentVersionAccessImplBase) GetVersion() string {
 	return b.version
+}
+
+func (b *ComponentVersionAccessImplBase) GetBlobCache() BlobCache {
+	return b.blobcache
 }
 
 type componentVersionAccessView struct {
@@ -361,6 +443,10 @@ func NewComponentVersionAccess(impl ComponentVersionAccessImpl) ComponentVersion
 	return resource.NewResource[ComponentVersionAccess](impl, artifactAccessViewCreator, fmt.Sprintf("component version  %s/%s", impl.GetName(), impl.GetVersion()), true)
 }
 
+func (c *componentVersionAccessView) Close() error {
+	return c._ComponentVersionAccessView.Close()
+}
+
 func (c *componentVersionAccessView) Repository() Repository {
 	return c.impl.Repository()
 }
@@ -382,9 +468,6 @@ func (c *componentVersionAccessView) GetDescriptor() *compdesc.ComponentDescript
 }
 
 func (c *componentVersionAccessView) AccessMethod(spec AccessSpec) (meth AccessMethod, err error) {
-	if f, ok := spec.(*fakeSpec); ok {
-		return f.AccessMethod(c)
-	}
 	err = c.Execute(func() error {
 		if !spec.IsLocal(c.GetContext()) {
 			// fall back to original version
@@ -411,28 +494,6 @@ func (c *componentVersionAccessView) GetInexpensiveContentVersionIdentity(spec A
 	return id
 }
 
-// fakeSpec redirects the blob access to the original blob,
-// because the uploaded blob might not yet be accessible without
-// finally adding the version (for example ghcr.io).
-type fakeSpec struct {
-	AccessSpec
-	blob accessio.BlobAccess
-}
-
-var _ WrappedAccessSpec = (*fakeSpec)(nil)
-
-func (f *fakeSpec) UnwrapAccessSpec() AccessSpec {
-	return f.AccessSpec
-}
-
-func (f *fakeSpec) AccessMethod(comp ComponentVersionAccess) (AccessMethod, error) {
-	meth, err := f.AccessSpec.AccessMethod(comp)
-	if err != nil {
-		return nil, err
-	}
-	return &fakeMethod{meth, f.blob}, nil
-}
-
 func (c *componentVersionAccessView) AddBlob(blob cpi.BlobAccess, artType, refName string, global AccessSpec) (AccessSpec, error) {
 	if blob == nil {
 		return nil, errors.New("a resource has to be defined")
@@ -440,6 +501,16 @@ func (c *componentVersionAccessView) AddBlob(blob cpi.BlobAccess, artType, refNa
 	if c.impl.IsReadOnly() {
 		return nil, accessio.ErrReadOnly
 	}
+	blob, err := blob.Dup()
+	if err != nil {
+		return nil, errors.Wrapf(err, "inavlid blob access")
+	}
+	defer blob.Close()
+	err = accessio.ValidateObject(blob)
+	if err != nil {
+		return nil, errors.Wrapf(err, "inavlid blob access")
+	}
+
 	storagectx := c.impl.GetStorageContext(c)
 	h := c.GetContext().BlobHandlers().LookupHandler(storagectx.GetImplementationRepositoryType(), artType, blob.MimeType())
 	if h != nil {
@@ -449,7 +520,7 @@ func (c *componentVersionAccessView) AddBlob(blob cpi.BlobAccess, artType, refNa
 		}
 		if acc != nil {
 			if !keepblobattr.Get(c.GetContext()) || acc.IsLocal(c.GetContext()) {
-				return &fakeSpec{acc, blob}, nil
+				return c.cacheBlob(acc, blob)
 			}
 			global = acc
 		}
@@ -458,13 +529,19 @@ func (c *componentVersionAccessView) AddBlob(blob cpi.BlobAccess, artType, refNa
 	if err != nil {
 		return nil, err
 	}
+	return c.cacheBlob(acc, blob)
+}
+
+func (c *componentVersionAccessView) cacheBlob(acc AccessSpec, blob BlobAccess) (AccessSpec, error) {
 	if acc.IsLocal(c.GetContext()) {
 		// local blobs might not be accessible from the underlying
 		// repository implementation if the component version is not
 		// finally added (for example ghcr.io as OCI repository).
-		// Therefore, we create a temporary access falling back to
-		// the initial blob content.
-		acc = &fakeSpec{acc, blob}
+		// Therefore, we keep a copy of the blo access for further usage.
+		err := c.impl.GetBlobCache().AddBlobFor(acc, blob)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return acc, nil
 }
@@ -487,6 +564,7 @@ func (c *componentVersionAccessView) SetResourceBlob(meta *ResourceMeta, blob cp
 	if err != nil {
 		return fmt.Errorf("unable to add blob (component %s:%s resource %s): %w", c.GetName(), c.GetVersion(), meta.GetName(), err)
 	}
+	defer c.impl.GetBlobCache().RemoveBlobFor(acc)
 
 	if err := c.SetResource(meta, acc, append(opts, internal.ModifyResource())...); err != nil {
 		return fmt.Errorf("unable to set resource: %w", err)
@@ -512,6 +590,7 @@ func (c *componentVersionAccessView) SetSourceBlob(meta *SourceMeta, blob BlobAc
 	if err != nil {
 		return fmt.Errorf("unable to add blob: (component %s:%s source %s): %w", c.GetName(), c.GetVersion(), meta.GetName(), err)
 	}
+	defer c.impl.GetBlobCache().RemoveBlobFor(acc)
 
 	if err := c.SetSource(meta, acc); err != nil {
 		return fmt.Errorf("unable to set source: %w", err)
@@ -533,6 +612,25 @@ func (f *fakeMethod) Get() ([]byte, error) {
 	return f.blob.Get()
 }
 
+func (c *componentVersionAccessView) getMethod(acc compdesc.AccessSpec) (AccessMethod, error) {
+	spec, err := c.impl.GetContext().AccessSpecForSpec(acc)
+	if err != nil {
+		return nil, err
+	}
+
+	meth, err := c.AccessMethod(spec)
+	if err != nil {
+		return nil, err
+	}
+	if b := c.impl.GetBlobCache().GetBlobFor(acc); b != nil {
+		meth = &fakeMethod{
+			AccessMethod: meth,
+			blob:         b,
+		}
+	}
+	return meth, nil
+}
+
 func (c *componentVersionAccessView) SetResource(meta *internal.ResourceMeta, acc compdesc.AccessSpec, modopts ...internal.ModificationOption) error {
 	if c.impl.IsReadOnly() {
 		return accessio.ErrReadOnly
@@ -540,19 +638,14 @@ func (c *componentVersionAccessView) SetResource(meta *internal.ResourceMeta, ac
 
 	res := &compdesc.Resource{
 		ResourceMeta: *meta.Copy(),
-		Access:       effecticveAccessSpec(acc),
+		Access:       acc,
 	}
 
 	ctx := c.impl.GetContext()
 	opts := internal.NewModificationOptions(modopts...)
 	CompleteModificationOptions(ctx, opts)
 
-	spec, err := ctx.AccessSpecForSpec(acc)
-	if err != nil {
-		return err
-	}
-
-	meth, err := c.AccessMethod(spec)
+	meth, err := c.getMethod(acc)
 	if err != nil {
 		return err
 	}
@@ -678,7 +771,7 @@ func (c *componentVersionAccessView) SetSource(meta *internal.SourceMeta, acc co
 
 	res := &compdesc.Source{
 		SourceMeta: *meta.Copy(),
-		Access:     effecticveAccessSpec(acc),
+		Access:     acc,
 	}
 	return c.Execute(func() error {
 		if res.Version == "" {

--- a/pkg/contexts/ocm/interface.go
+++ b/pkg/contexts/ocm/interface.go
@@ -114,10 +114,6 @@ func NewGenericAccessSpec(spec string) (AccessSpec, error) {
 	return internal.NewGenericAccessSpec([]byte(spec))
 }
 
-func EffecticveAccessSpec(spec AccessSpec) AccessSpec {
-	return cpi.EffecticveAccessSpec(spec)
-}
-
 func ToGenericAccessSpec(spec AccessSpec) (*GenericAccessSpec, error) {
 	return internal.ToGenericAccessSpec(spec)
 }

--- a/pkg/contexts/ocm/interface.go
+++ b/pkg/contexts/ocm/interface.go
@@ -114,6 +114,10 @@ func NewGenericAccessSpec(spec string) (AccessSpec, error) {
 	return internal.NewGenericAccessSpec([]byte(spec))
 }
 
+func EffecticveAccessSpec(spec AccessSpec) AccessSpec {
+	return cpi.EffecticveAccessSpec(spec)
+}
+
 func ToGenericAccessSpec(spec AccessSpec) (*GenericAccessSpec, error) {
 	return internal.ToGenericAccessSpec(spec)
 }

--- a/pkg/contexts/ocm/interface.go
+++ b/pkg/contexts/ocm/interface.go
@@ -6,9 +6,12 @@ package ocm
 
 import (
 	"context"
+	"io"
 
+	"github.com/open-component-model/ocm/pkg/common/accessio"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
 	metav1 "github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc/meta/v1"
+	ocm "github.com/open-component-model/ocm/pkg/contexts/ocm/context"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/internal"
 	"github.com/open-component-model/ocm/pkg/runtime"
@@ -180,4 +183,30 @@ func SkipVerify(flag ...bool) ModificationOption {
 // Deprecated: for legacy code, only.
 func SkipDigest(flag ...bool) ModificationOption {
 	return internal.SkipDigest(flag...)
+}
+
+/////////////////////////////////////////////////////////////////////////////////
+
+type AccessMethodView = cpi.AccessMethodView
+
+func BlobAccessForAccessMethod(m AccessMethodView) (accessio.AnnotatedBlobAccess[AccessMethodView], error) {
+	return cpi.BlobAccessForAccessMethod(m)
+}
+
+// AccessMethodAsView wrap an access method object into
+// a multi-view version. The original method is closed when
+// the last view is closed.
+// After an access method is used as base object, it should not
+// explicitly closed anymore, because the the views will stop
+// functioning.
+func AccessMethodAsView(acc ocm.AccessMethod, closer ...io.Closer) AccessMethodView {
+	return cpi.AccessMethodAsView(acc, closer...)
+}
+
+func AccessMethodViewForSpec(spec ocm.AccessSpec, cv ocm.ComponentVersionAccess) (AccessMethodView, error) {
+	return cpi.AccessMethodViewForSpec(spec, cv)
+}
+
+func AccessMethodViewForAccessProvider(p AccessProvider) (AccessMethodView, error) {
+	return cpi.AccessMethodViewForAccessProvider(p)
 }

--- a/pkg/contexts/ocm/repositories/genericocireg/componentversion.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/componentversion.go
@@ -126,7 +126,6 @@ func (c *ComponentVersionContainer) AccessMethod(a cpi.AccessSpec) (cpi.AccessMe
 		return nil, err
 	}
 
-	accessSpec = cpi.EffecticveAccessSpec(accessSpec)
 	switch a.GetKind() {
 	case localblob.Type:
 		return newLocalBlobAccessMethod(accessSpec.(*localblob.AccessSpec), c.comp.namespace, c.access), nil

--- a/pkg/contexts/ocm/repositories/genericocireg/componentversion.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/componentversion.go
@@ -126,6 +126,7 @@ func (c *ComponentVersionContainer) AccessMethod(a cpi.AccessSpec) (cpi.AccessMe
 		return nil, err
 	}
 
+	accessSpec = cpi.EffecticveAccessSpec(accessSpec)
 	switch a.GetKind() {
 	case localblob.Type:
 		return newLocalBlobAccessMethod(accessSpec.(*localblob.AccessSpec), c.comp.namespace, c.access), nil

--- a/pkg/contexts/ocm/repositories/genericocireg/repo_test.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/repo_test.go
@@ -5,6 +5,7 @@
 package genericocireg_test
 
 import (
+	"fmt"
 	"path"
 	"reflect"
 
@@ -131,7 +132,7 @@ var _ = Describe("component repository mapping", func() {
 
 		// check provided actual access to be local blob
 		Expect(acc.GetKind()).To(Equal(localblob.Type))
-		l, ok := acc.(*localblob.AccessSpec)
+		l, ok := cpi.EffecticveAccessSpec(acc).(*localblob.AccessSpec)
 		Expect(ok).To(BeTrue())
 		Expect(l.LocalReference).To(Equal(blob.Digest().String()))
 		Expect(l.GlobalAccess).To(BeNil())
@@ -174,7 +175,7 @@ var _ = Describe("component repository mapping", func() {
 
 		// check provided actual access to be local blob
 		Expect(acc.GetKind()).To(Equal(localblob.Type))
-		l, ok := acc.(*localblob.AccessSpec)
+		l, ok := cpi.EffecticveAccessSpec(acc).(*localblob.AccessSpec)
 		Expect(ok).To(BeTrue())
 		Expect(l.LocalReference).To(Equal(blob.Digest().String()))
 		Expect(l.GlobalAccess).NotTo(BeNil())
@@ -223,6 +224,7 @@ var _ = Describe("component repository mapping", func() {
 		vers := finalizer.ClosingWith(nested, Must(comp.NewVersion("v1")))
 		blob := accessio.BlobAccessForFile(mime, "test.tgz", tempfs)
 
+		fmt.Printf("physical digest: %s\n", blob.Digest())
 		acc := Must(vers.AddBlob(blob, "", "artifact1", nil))
 		Expect(acc.GetKind()).To(Equal(localblob.Type))
 

--- a/pkg/contexts/ocm/repositories/genericocireg/repo_test.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/repo_test.go
@@ -132,7 +132,7 @@ var _ = Describe("component repository mapping", func() {
 
 		// check provided actual access to be local blob
 		Expect(acc.GetKind()).To(Equal(localblob.Type))
-		l, ok := cpi.EffecticveAccessSpec(acc).(*localblob.AccessSpec)
+		l, ok := acc.(*localblob.AccessSpec)
 		Expect(ok).To(BeTrue())
 		Expect(l.LocalReference).To(Equal(blob.Digest().String()))
 		Expect(l.GlobalAccess).To(BeNil())
@@ -175,7 +175,7 @@ var _ = Describe("component repository mapping", func() {
 
 		// check provided actual access to be local blob
 		Expect(acc.GetKind()).To(Equal(localblob.Type))
-		l, ok := cpi.EffecticveAccessSpec(acc).(*localblob.AccessSpec)
+		l, ok := acc.(*localblob.AccessSpec)
 		Expect(ok).To(BeTrue())
 		Expect(l.LocalReference).To(Equal(blob.Digest().String()))
 		Expect(l.GlobalAccess).NotTo(BeNil())

--- a/pkg/contexts/ocm/repositories/genericocireg/repository.go
+++ b/pkg/contexts/ocm/repositories/genericocireg/repository.go
@@ -11,7 +11,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials"
 	"github.com/open-component-model/ocm/pkg/contexts/oci"
 	ocicpi "github.com/open-component-model/ocm/pkg/contexts/oci/cpi"
@@ -178,7 +178,7 @@ func (r *RepositoryImpl) LookupComponentVersion(name string, version string) (cp
 	if err != nil {
 		return nil, err
 	}
-	defer accessio.PropagateCloseTemporary(&err, c) // temporary component object not exposed.
+	defer refmgmt.PropagateCloseTemporary(&err, c) // temporary component object not exposed.
 	return c.LookupVersion(version)
 }
 

--- a/pkg/contexts/ocm/repositories/virtual/repository.go
+++ b/pkg/contexts/ocm/repositories/virtual/repository.go
@@ -5,7 +5,7 @@
 package virtual
 
 import (
-	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 )
 
@@ -67,6 +67,6 @@ func (r *RepositoryImpl) LookupComponentVersion(name string, version string) (cp
 	if err != nil {
 		return nil, err
 	}
-	defer accessio.PropagateCloseTemporary(&err, c) // temporary component object not exposed.
+	defer refmgmt.PropagateCloseTemporary(&err, c) // temporary component object not exposed.
 	return c.LookupVersion(version)
 }

--- a/pkg/contexts/ocm/transfer/transfer.go
+++ b/pkg/contexts/ocm/transfer/transfer.go
@@ -243,7 +243,7 @@ func copyVersion(printer common.Printer, log logging.Logger, hist common.History
 					var msgs []interface{}
 					if !errors.IsErrNotFound(err) {
 						if err != nil {
-							return err
+							return errors.Join(err, m.Close())
 						}
 						if !changed && valueNeeded {
 							msgs = []interface{}{"copy"}

--- a/pkg/contexts/ocm/transfer/transfer.go
+++ b/pkg/contexts/ocm/transfer/transfer.go
@@ -215,11 +215,11 @@ func copyVersion(printer common.Printer, log logging.Logger, hist common.History
 	*t.GetDescriptor() = *prep
 	log.Info("  transferring resources")
 	for i, r := range src.GetResources() {
-		var m ocm.AccessMethod
+		var m ocmcpi.AccessMethodView
 
 		a, err := r.Access()
 		if err == nil {
-			m, err = r.AccessMethod()
+			m, err = ocmcpi.AccessMethodViewForSpec(a, src)
 		}
 		if err == nil {
 			ok := a.IsLocal(src.GetContext())
@@ -272,11 +272,11 @@ func copyVersion(printer common.Printer, log logging.Logger, hist common.History
 
 	log.Info("  transferring sources")
 	for i, r := range src.GetSources() {
-		var m ocm.AccessMethod
+		var m ocmcpi.AccessMethodView
 
 		a, err := r.Access()
 		if err == nil {
-			m, err = r.AccessMethod()
+			m, err = ocmcpi.AccessMethodViewForSpec(a, src)
 		}
 		if err == nil {
 			ok := a.IsLocal(src.GetContext())

--- a/pkg/contexts/ocm/transfer/transferhandler/transferhandler.go
+++ b/pkg/contexts/ocm/transfer/transferhandler/transferhandler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/config"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/compdesc"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 	"github.com/open-component-model/ocm/pkg/errors"
 )
 
@@ -98,9 +99,9 @@ type TransferHandler interface {
 	TransferSource(src ocm.ComponentVersionAccess, a ocm.AccessSpec, r ocm.SourceAccess) (bool, error)
 
 	// HandleTransferResource technically transfers a resource.
-	HandleTransferResource(r ocm.ResourceAccess, m ocm.AccessMethod, hint string, t ocm.ComponentVersionAccess) error
+	HandleTransferResource(r ocm.ResourceAccess, m cpi.AccessMethodView, hint string, t ocm.ComponentVersionAccess) error
 	// HandleTransferSource technically transfers a source.
-	HandleTransferSource(r ocm.SourceAccess, m ocm.AccessMethod, hint string, t ocm.ComponentVersionAccess) error
+	HandleTransferSource(r ocm.SourceAccess, m cpi.AccessMethodView, hint string, t ocm.ComponentVersionAccess) error
 }
 
 func ApplyOptions(set TransferOptions, opts ...TransferOption) error {

--- a/pkg/env/builder/blob.go
+++ b/pkg/env/builder/blob.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+import (
+	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/common/accessio/blobaccess/dirtree"
+)
+
+const T_BLOBACCESS = "blob access"
+
+func (b *Builder) BlobStringData(mime string, data string) {
+	b.expect(b.blob, T_BLOBACCESS)
+	if b.ocm_acc != nil && *b.ocm_acc != nil {
+		b.fail("access already set")
+	}
+	*(b.blob) = accessio.BlobAccessForData(mime, []byte(data))
+}
+
+func (b *Builder) BlobData(mime string, data []byte) {
+	b.expect(b.blob, T_BLOBACCESS)
+	if b.ocm_acc != nil && *b.ocm_acc != nil {
+		b.fail("access already set")
+	}
+	*(b.blob) = accessio.BlobAccessForData(mime, data)
+}
+
+func (b *Builder) BlobFromFile(mime string, path string) {
+	b.expect(b.blob, T_BLOBACCESS)
+	if b.ocm_acc != nil && *b.ocm_acc != nil {
+		b.fail("access already set")
+	}
+	*(b.blob) = accessio.BlobAccessForFile(mime, path, b.FileSystem())
+	b.failOn(accessio.ValidateObject(*(b.blob)))
+}
+
+func (b *Builder) BlobFromDirTree(path string, opts ...dirtree.Option) {
+	b.expect(b.blob, T_BLOBACCESS)
+	if b.ocm_acc != nil && *b.ocm_acc != nil {
+		b.fail("access already set")
+	}
+	var err error
+	*(b.blob), err = dirtree.BlobAccessForDirTree(path, append([]dirtree.Option{dirtree.WithFileSystem(b.FileSystem())}, opts...)...)
+	b.failOn(err)
+}

--- a/pkg/env/builder/builder.go
+++ b/pkg/env/builder/builder.go
@@ -202,32 +202,6 @@ func (b *Builder) Configure(funcs ...func()) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-const T_BLOBACCESS = "blob access"
-
-func (b *Builder) BlobStringData(mime string, data string) {
-	b.expect(b.blob, T_BLOBACCESS)
-	if b.ocm_acc != nil && *b.ocm_acc != nil {
-		b.fail("access already set")
-	}
-	*(b.blob) = accessio.BlobAccessForData(mime, []byte(data))
-}
-
-func (b *Builder) BlobData(mime string, data []byte) {
-	b.expect(b.blob, T_BLOBACCESS)
-	if b.ocm_acc != nil && *b.ocm_acc != nil {
-		b.fail("access already set")
-	}
-	*(b.blob) = accessio.BlobAccessForData(mime, data)
-}
-
-func (b *Builder) BlobFromFile(mime string, path string) {
-	b.expect(b.blob, T_BLOBACCESS)
-	if b.ocm_acc != nil && *b.ocm_acc != nil {
-		b.fail("access already set")
-	}
-	*(b.blob) = accessio.BlobAccessForFile(mime, path, b.FileSystem())
-}
-
 func (b *Builder) Hint(hint string) {
 	b.expect(b.hint, T_OCMACCESS)
 	if b.ocm_acc != nil && *b.ocm_acc != nil {

--- a/pkg/helm/chartaccess.go
+++ b/pkg/helm/chartaccess.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
+	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 	"helm.sh/helm/v3/pkg/registry"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
@@ -32,7 +33,7 @@ type ChartAccess interface {
 
 func newFileAccess(c *chartAccess, path string, mime string) accessio.BlobAccess {
 	c.refcnt++
-	return accessio.BlobAccessForFileWithCloser(accessio.CloserFunc(c.unref), mime, path, c.fs)
+	return accessio.BlobAccessForFileWithCloser(refmgmt.CloserFunc(c.unref), mime, path, c.fs)
 }
 
 type chartAccess struct {

--- a/pkg/helm/chartaccess.go
+++ b/pkg/helm/chartaccess.go
@@ -11,10 +11,10 @@ import (
 	"sync"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
-	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 	"helm.sh/helm/v3/pkg/registry"
 
 	"github.com/open-component-model/ocm/pkg/common/accessio"
+	"github.com/open-component-model/ocm/pkg/common/accessio/refmgmt"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/artdesc"
 	"github.com/open-component-model/ocm/pkg/errors"
 )

--- a/pkg/helm/chartaccess.go
+++ b/pkg/helm/chartaccess.go
@@ -25,14 +25,14 @@ const (
 
 type ChartAccess interface {
 	io.Closer
-	Chart() (accessio.TemporaryBlobAccess, error)
-	Prov() (accessio.TemporaryBlobAccess, error)
-	ArtefactSet() (accessio.TemporaryBlobAccess, error)
+	Chart() (accessio.BlobAccess, error)
+	Prov() (accessio.BlobAccess, error)
+	ArtefactSet() (accessio.BlobAccess, error)
 }
 
-func newFileAccess(c *chartAccess, path string, mime string) accessio.TemporaryBlobAccess {
+func newFileAccess(c *chartAccess, path string, mime string) accessio.BlobAccess {
 	c.refcnt++
-	return accessio.ReferencingBlobAccess(accessio.BlobAccessForFile(mime, path, c.fs), c.unref)
+	return accessio.BlobAccessForFileWithCloser(accessio.CloserFunc(c.unref), mime, path, c.fs)
 }
 
 type chartAccess struct {
@@ -97,7 +97,7 @@ func (c *chartAccess) Close() error {
 	return nil
 }
 
-func (c *chartAccess) Chart() (accessio.TemporaryBlobAccess, error) {
+func (c *chartAccess) Chart() (accessio.BlobAccess, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -108,7 +108,7 @@ func (c *chartAccess) Chart() (accessio.TemporaryBlobAccess, error) {
 	return newFileAccess(c, c.chart, ChartMediaType), nil
 }
 
-func (c *chartAccess) Prov() (accessio.TemporaryBlobAccess, error) {
+func (c *chartAccess) Prov() (accessio.BlobAccess, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -121,7 +121,7 @@ func (c *chartAccess) Prov() (accessio.TemporaryBlobAccess, error) {
 	return newFileAccess(c, c.prov, ProvenanceMediaType), nil
 }
 
-func (c *chartAccess) ArtefactSet() (accessio.TemporaryBlobAccess, error) {
+func (c *chartAccess) ArtefactSet() (accessio.BlobAccess, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 

--- a/pkg/helm/loader/access.go
+++ b/pkg/helm/loader/access.go
@@ -24,11 +24,11 @@ func (l *accessLoader) Close() error {
 	return l.access.Close()
 }
 
-func (l *accessLoader) ChartArchive() (accessio.TemporaryBlobAccess, error) {
+func (l *accessLoader) ChartArchive() (accessio.BlobAccess, error) {
 	return l.access.Chart()
 }
 
-func (l *accessLoader) ChartArtefactSet() (accessio.TemporaryBlobAccess, error) {
+func (l *accessLoader) ChartArtefactSet() (accessio.BlobAccess, error) {
 	return l.access.ArtefactSet()
 }
 

--- a/pkg/helm/loader/loader.go
+++ b/pkg/helm/loader/loader.go
@@ -15,8 +15,8 @@ import (
 )
 
 type Loader interface {
-	ChartArchive() (accessio.TemporaryBlobAccess, error)
-	ChartArtefactSet() (accessio.TemporaryBlobAccess, error)
+	ChartArchive() (accessio.BlobAccess, error)
+	ChartArtefactSet() (accessio.BlobAccess, error)
 	Chart() (*chart.Chart, error)
 	Provenance() ([]byte, error)
 
@@ -38,14 +38,14 @@ func VFSLoader(path string, fss ...vfs.FileSystem) Loader {
 	}
 }
 
-func (l *vfsLoader) ChartArchive() (accessio.TemporaryBlobAccess, error) {
+func (l *vfsLoader) ChartArchive() (accessio.BlobAccess, error) {
 	if ok, err := vfs.IsFile(l.fs, l.path); !ok || err != nil {
 		return nil, err
 	}
-	return accessio.TemporaryBlobAccessForBlob(accessio.BlobAccessForFile(helm.ChartMediaType, l.path, l.fs)), nil
+	return accessio.BlobAccessForFile(helm.ChartMediaType, l.path, l.fs), nil
 }
 
-func (l *vfsLoader) ChartArtefactSet() (accessio.TemporaryBlobAccess, error) {
+func (l *vfsLoader) ChartArtefactSet() (accessio.BlobAccess, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
## Description

The digest calculation is based on the access method provided by the AddBlob method.
Unfortunately this method cannot resolve the blob content under all circumstances.
There are OCI registries, which do not provide access to uploaded blobs until
a manifest using this blob has been pushed.

To circumvent this problem, the initial BlobAccess is cached and the digest is
calculated based on this blob access instead of the access method.

Therefore, the blob access must be accessible independently of
the life time of the initially passed BlobAccess. To achieve this the BlobAccess
interface is extended to support a Dup() method to provide a separately 
closable instance.

Additionally, Blob Access interfaces not required anymore are removed including
their useless usages.

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->


## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

Fixes #531

## Screenshots

<!-- Visual changes require screenshots -->


## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Added to documentation?

- [ ] 📜 README.md
- [ ] 🙅 no documentation needed

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
