### PR TITLE
adjust v3alpha1 schema version

### DIFF
--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/docker/spec.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/docker/spec.go
@@ -5,14 +5,14 @@
 package docker
 
 import (
-	"github.com/open-component-model/ocm/pkg/contexts/oci"
-	"github.com/open-component-model/ocm/pkg/contexts/oci/annotations"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs/cpi"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/inputs/types/ociimage"
 	"github.com/open-component-model/ocm/pkg/common/accessio/blobaccess"
+	"github.com/open-component-model/ocm/pkg/contexts/oci"
+	"github.com/open-component-model/ocm/pkg/contexts/oci/annotations"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/repositories/artifactset"
 	"github.com/open-component-model/ocm/pkg/contexts/oci/repositories/docker"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/ociartifact"

--- a/cmds/ocm/commands/ocmcmds/componentarchive/create/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/componentarchive/create/cmd_test.go
@@ -79,18 +79,18 @@ var _ = Describe("Test Environment", func() {
 		}))
 	})
 
-	It("creates comp arch with "+compdescv3.SchemaVersion, func() {
+	It("creates comp arch with "+compdescv3.VersionName, func() {
 
 		plabels := metav1.Labels{}
 		plabels.Set("email", "info@mandelsoft.de")
 		Expect(env.Execute("create", "ca", "-ft", "directory", "test.de/x", "v1", "--provider", "mandelsoft", "--file", "/tmp/ca",
-			"l1=value", "l2={\"name\":\"value\"}", "-p", "email=info@mandelsoft.de", "-S", compdescv3.SchemaVersion)).To(Succeed())
+			"l1=value", "l2={\"name\":\"value\"}", "-p", "email=info@mandelsoft.de", "-S", compdescv3.VersionName)).To(Succeed())
 		Expect(env.DirExists("/tmp/ca")).To(BeTrue())
 		data, err := env.ReadFile("/tmp/ca/" + comparch.ComponentDescriptorFileName)
 		Expect(err).To(Succeed())
 		cd, err := compdesc.Decode(data)
 		Expect(err).To(Succeed())
-		Expect(cd.Metadata.ConfiguredVersion).To(Equal(compdescv3.GroupVersion))
+		Expect(cd.Metadata.ConfiguredVersion).To(Equal(compdescv3.SchemaVersion))
 		Expect(cd.Name).To(Equal("test.de/x"))
 		Expect(cd.Version).To(Equal("v1"))
 		Expect(string(cd.Provider.Name)).To(Equal("mandelsoft"))

--- a/cmds/ocm/commands/ocmcmds/components/get/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/get/cmd_test.go
@@ -226,7 +226,7 @@ NESTING COMPONENT VERSION PROVIDER   IDENTITY
 			Expect(buf.String()).To(StringEqualTrimmedWithContext(
 				fmt.Sprintf(`
 ---
-apiVersion: ocm.software/%s
+apiVersion: %s
 kind: ComponentVersion
 metadata:
   name: test.de/y
@@ -239,7 +239,7 @@ spec:
   - componentName: test.de/x
     name: xx
     version: v1
-`, compdescv3.VersionName)))
+`, compdescv3.SchemaVersion)))
 		})
 	})
 })

--- a/cmds/ocm/commands/ocmcmds/components/get/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/get/cmd_test.go
@@ -222,7 +222,7 @@ NESTING COMPONENT VERSION PROVIDER   IDENTITY
 		It("lists converted yaml", func() {
 
 			buf := bytes.NewBuffer(nil)
-			Expect(env.CatchOutput(buf).Execute("get", "components", "-S", compdescv3.SchemaVersion, "-o", "yaml", "--repo", ARCH, COMP2)).To(Succeed())
+			Expect(env.CatchOutput(buf).Execute("get", "components", "-S", compdescv3.VersionName, "-o", "yaml", "--repo", ARCH, COMP2)).To(Succeed())
 			Expect(buf.String()).To(StringEqualTrimmedWithContext(
 				fmt.Sprintf(`
 ---
@@ -239,7 +239,7 @@ spec:
   - componentName: test.de/x
     name: xx
     version: v1
-`, compdescv3.SchemaVersion)))
+`, compdescv3.VersionName)))
 		})
 	})
 })

--- a/pkg/contexts/ocm/compdesc/compdesc_test.go
+++ b/pkg/contexts/ocm/compdesc/compdesc_test.go
@@ -144,7 +144,7 @@ spec:
     name: introspect
     type: git
     version: 1.0.0
-`, compdescv3.SchemaVersion))
+`, compdescv3.VersionName))
 
 	It("deserializes v2", func() {
 		cd, err := compdesc.Decode([]byte(CDv2))
@@ -156,11 +156,11 @@ spec:
 		Expect(string(data)).To(Equal(CDv2))
 	})
 
-	It("deserializes "+compdescv3.SchemaVersion, func() {
+	It("deserializes "+compdescv3.VersionName, func() {
 		cd, err := compdesc.Decode([]byte(CDv2))
 		Expect(err).To(Succeed())
 
-		cd.Metadata.ConfiguredVersion = compdescv3.GroupVersion
+		cd.Metadata.ConfiguredVersion = compdescv3.SchemaVersion
 		data, err := compdesc.Encode(cd)
 		Expect(err).To(Succeed())
 		Expect(string(data)).To(StringEqualWithContext(CDv3))

--- a/pkg/contexts/ocm/compdesc/compdesc_test.go
+++ b/pkg/contexts/ocm/compdesc/compdesc_test.go
@@ -86,7 +86,7 @@ var _ = Describe("serialization", func() {
 `)
 
 	var CDv3 = NormalizeYAML(fmt.Sprintf(`
-apiVersion: ocm.software/%s
+apiVersion: %s
 kind: ComponentVersion
 metadata:
   name: github.com/vasu1124/introspect
@@ -144,7 +144,7 @@ spec:
     name: introspect
     type: git
     version: 1.0.0
-`, compdescv3.VersionName))
+`, compdescv3.SchemaVersion))
 
 	It("deserializes v2", func() {
 		cd, err := compdesc.Decode([]byte(CDv2))

--- a/pkg/contexts/ocm/compdesc/norm_test.go
+++ b/pkg/contexts/ocm/compdesc/norm_test.go
@@ -272,7 +272,7 @@ var _ = Describe("Normalization", func() {
 
 	It("hashes v1 with complex provider for CD/v3", func() {
 		cd := cd1.Copy()
-		cd.Metadata.ConfiguredVersion = v3alpha1.GroupVersion
+		cd.Metadata.ConfiguredVersion = v3alpha1.SchemaVersion
 		cd.References = nil
 		cd.Resources = nil
 		cd.Sources = nil

--- a/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1/componentdescriptor.go
+++ b/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1/componentdescriptor.go
@@ -38,7 +38,7 @@ var _ compdesc.ComponentDescriptorVersion = (*ComponentDescriptor)(nil)
 // representation.
 func (cd *ComponentDescriptor) SchemaVersion() string {
 	if cd.APIVersion == "" {
-		return GroupVersion
+		return SchemaVersion
 	}
 	return cd.APIVersion
 }

--- a/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1/validation_test.go
+++ b/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1/validation_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Validation", func() {
 
 			comp = &ComponentDescriptor{
 				TypeMeta: meta.TypeMeta{
-					APIVersion: GroupVersion,
+					APIVersion: SchemaVersion,
 					Kind:       Kind,
 				},
 				ObjectMeta: meta.ObjectMeta{

--- a/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1/version.go
+++ b/pkg/contexts/ocm/compdesc/versions/ocm.software/v3alpha1/version.go
@@ -13,9 +13,11 @@ import (
 )
 
 const (
-	SchemaVersion = "v3alpha1"
-	GroupVersion  = metav1.GROUP + "/" + SchemaVersion
-	Kind          = metav1.KIND
+	SchemaVersion = GroupVersion
+
+	VersionName  = "v3alpha1"
+	GroupVersion = metav1.GROUP + "/" + VersionName
+	Kind         = metav1.KIND
 )
 
 func init() {
@@ -27,7 +29,7 @@ type DescriptorVersion struct{}
 var _ compdesc.Scheme = (*DescriptorVersion)(nil)
 
 func (v *DescriptorVersion) GetVersion() string {
-	return GroupVersion
+	return SchemaVersion
 }
 
 func (v *DescriptorVersion) Decode(data []byte, opts *compdesc.DecodeOptions) (compdesc.ComponentDescriptorVersion, error) {
@@ -190,7 +192,7 @@ func (v *DescriptorVersion) ConvertFrom(in *compdesc.ComponentDescriptor) (compd
 	}
 	out := &ComponentDescriptor{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: GroupVersion,
+			APIVersion: SchemaVersion,
 			Kind:       Kind,
 		},
 		ObjectMeta:         *in.ObjectMeta.Copy(),


### PR DESCRIPTION
## Description
So far, if one wanted to Encode/Decode a Component Descriptor to v3alpha1, this had to be specified with the corresponding constant v3alpha1.GroupVersion while for v2, this had to be specified with the corresponding constant v2.SchemaVersion.

This behaviour is quite confusing and should therefore be adjusted.
<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [X] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->

## Screenshots

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Added to documentation?

- [ ] 📜 README.md
- [ ] 🙅 no documentation needed

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
