### PR TITLE
Update Goreleaser cosign handling

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -70,6 +70,7 @@ signs:
       - '--output-certificate=${certificate}'
       - '--output-signature=${signature}'
       - '${artifact}'
+      - '--yes'
     artifacts: checksum
     output: true
 changelog:


### PR DESCRIPTION
## Description

Cosign >v2.0.0 requires the `--yes`  flag to be explicitly set in the goreleaser manifest.

ref: https://goreleaser.com/customization/sign/#signing-with-cosign