### PR TITLE
Fix OCI repository credential handling for downloading Helm charts

### DIFF
--- a/pkg/helm/downloader.go
+++ b/pkg/helm/downloader.go
@@ -17,6 +17,7 @@ import (
 	"helm.sh/helm/v3/pkg/repo"
 
 	"github.com/open-component-model/ocm/pkg/common"
+	"github.com/open-component-model/ocm/pkg/contexts/credentials"
 	"github.com/open-component-model/ocm/pkg/contexts/credentials/repositories/directcreds"
 	"github.com/open-component-model/ocm/pkg/contexts/oci"
 	ocihelm "github.com/open-component-model/ocm/pkg/contexts/ocm/download/handlers/helm"
@@ -73,7 +74,12 @@ func DownloadChart(out common.Printer, ctx oci.ContextProvider, ref, version, re
 	if registry.IsOCI(repourl) {
 		fs := osfs.New()
 		chart = vfs.Join(fs, dl.root, filepath.Base(ref)+".tgz")
-		creds := directcreds.NewCredentials(dl.creds)
+
+		var creds credentials.CredentialsSource
+		if dl.creds != nil {
+			creds = directcreds.NewCredentials(dl.creds)
+		}
+
 		chart, prov, aset, err = ocihelm.Download2(out, ctx.OCIContext(), identity.OCIRepoURL(repourl, ref)+":"+version, chart, osfs.New(), true, creds)
 		if prov != "" && dl.Verify > downloader.VerifyNever && dl.Verify != downloader.VerifyLater {
 			_, err = downloader.VerifyChart(chart, dl.Keyring)

--- a/pkg/helm/identity/identity.go
+++ b/pkg/helm/identity/identity.go
@@ -76,6 +76,10 @@ func OCIRepoURL(repourl string, chartname string) string {
 }
 
 func GetConsumerId(repourl string, chartname string) cpi.ConsumerIdentity {
+	i := strings.LastIndex(chartname, ":")
+	if i >= 0 {
+		chartname = chartname[:i]
+	}
 	if registry.IsOCI(repourl) {
 		repourl = strings.TrimSuffix(repourl, "/")
 		return ociidentity.GetConsumerId(OCIRepoURL(repourl, ""), chartname)
@@ -89,7 +93,7 @@ func GetCredentials(ctx credentials.ContextProvider, repourl string, chartname s
 	if id == nil {
 		return nil
 	}
-	creds, err := credentials.CredentialsForConsumer(ctx.CredentialsContext(), id, identityMatcher)
+	creds, err := credentials.CredentialsForConsumer(ctx.CredentialsContext(), id)
 	if creds == nil || err != nil {
 		return nil
 	}

--- a/pkg/helm/identity/identity_test.go
+++ b/pkg/helm/identity/identity_test.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2023 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package identity
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/open-component-model/ocm/pkg/common"
+	"github.com/open-component-model/ocm/pkg/contexts/credentials"
+	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
+	"github.com/open-component-model/ocm/pkg/contexts/oci"
+	ociidentity "github.com/open-component-model/ocm/pkg/contexts/oci/identity"
+)
+
+var _ = Describe("consumer id handling", func() {
+	Context("id deternation", func() {
+		It("handles helm repos", func() {
+			id := GetConsumerId("https://acme.org/charts", "demo:v1")
+			Expect(id).To(Equal(credentials.NewConsumerIdentity(CONSUMER_TYPE,
+				"pathprefix", "charts",
+				"port", "443",
+				"hostname", "acme.org",
+				"scheme", "https",
+			)))
+		})
+
+		It("handles oci repos", func() {
+			id := GetConsumerId("oci://acme.org/charts", "demo:v1")
+			Expect(id).To(Equal(credentials.NewConsumerIdentity(ociidentity.CONSUMER_TYPE,
+				"pathprefix", "charts/demo",
+				"hostname", "acme.org",
+			)))
+		})
+	})
+
+	Context("query credentials", func() {
+		var ctx oci.Context
+		var credctx credentials.Context
+
+		BeforeEach(func() {
+			ctx = oci.New(datacontext.MODE_EXTENDED)
+			credctx = ctx.CredentialsContext()
+		})
+
+		It("queries helm credentials", func() {
+			id := GetConsumerId("https://acme.org/charts", "demo:v1")
+			credctx.SetCredentialsForConsumer(id,
+				credentials.DirectCredentials{
+					ATTR_USERNAME: "helm",
+					ATTR_PASSWORD: "helmpass",
+				},
+			)
+
+			creds := GetCredentials(ctx, "https://acme.org/charts", "demo:v1")
+			Expect(creds).To(Equal(common.Properties{
+				ATTR_USERNAME: "helm",
+				ATTR_PASSWORD: "helmpass",
+			}))
+		})
+
+		It("queries oci credentials", func() {
+			id := GetConsumerId("oci://acme.org/charts", "demo:v1")
+			credctx.SetCredentialsForConsumer(id,
+				credentials.DirectCredentials{
+					ATTR_USERNAME: "oci",
+					ATTR_PASSWORD: "ocipass",
+				},
+			)
+
+			creds := GetCredentials(ctx, "oci://acme.org/charts", "demo:v1")
+			Expect(creds).To(Equal(common.Properties{
+				ATTR_USERNAME: "oci",
+				ATTR_PASSWORD: "ocipass",
+			}))
+		})
+	})
+})

--- a/pkg/helm/identity/suite_test.go
+++ b/pkg/helm/identity/suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package identity_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Helm Identity Suite")
+}


### PR DESCRIPTION
## Description

The helm download requires two kinds of credentials, helm credentials for helm repos and
OCI credentials for OCI registries. This PR fixes this and provides appropriate tests.


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)
> Remove if not applicable

## Screenshots

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Added to documentation?

- [ ] 📜 README.md
- [ ] 🙅 no documentation needed

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
