### PR TITLE
change the default compressing behavior to false for file input type

### DIFF
--- a/cmds/ocm/commands/ocmcmds/common/inputs/cpi/helper.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/cpi/helper.go
@@ -67,7 +67,7 @@ func NewProcessSpec(mediatype string, compress bool) ProcessSpec {
 // Compress returns if the blob should be compressed using gzip.
 func (s *ProcessSpec) Compress() bool {
 	if s.CompressWithGzip == nil {
-		return mime.IsGZip(s.MediaType)
+		return false
 	}
 	return *s.CompressWithGzip
 }

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/file/support.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/file/support.go
@@ -107,7 +107,7 @@ is set to <code>true</code>.
 This blob type specification supports the following fields: 
 - **<code>path</code>** *string*
 
-  This REQUIRED property describes the file path to the helm chart relative to the
+  This REQUIRED property describes the path to the file relative to the
   resource file location.
 ` + cpi.ProcessSpecUsage
 }


### PR DESCRIPTION
So far, the behavior was to deducted from the media type (if the media type contained the suffix gzip, the file was compressed). This is quite unintuitive especially since a user might quite frequently provide an already compressed file (such as a helm chart archive).
