### PR TITLE
fix ref detection for ca/ctf

### DIFF
--- a/cmds/ocm/commands/ocmcmds/components/sign/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/sign/cmd_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/signing/signutils"
 )
 
+const COMPARCH = "/tmp/ca"
 const ARCH = "/tmp/ctf"
 const ARCH2 = "/tmp/ctf2"
 const PROVIDER = "mandelsoft"
@@ -239,7 +240,7 @@ Error: signing: github.com/mandelsoft/ref:v1: failed resolving component referen
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchErrorOutput(buf).Execute("sign", "components", "-s", SIGNATURE, "-K", PRIVKEY, "--repo", ARCH, COMPONENTB+":"+VERSION)).To(HaveOccurred())
 			Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-Error: signing: github.com/mandelsoft/ref:v1: failed resolving component reference ref[github.com/mandelsoft/test:v1]: component "github.com/mandelsoft/test" not found in ComponentArchive
+Error: signing: github.com/mandelsoft/ref:v1: failed resolving component reference ref[github.com/mandelsoft/test:v1]: ocm reference "github.com/mandelsoft/test:v1" not found
 `))
 		})
 
@@ -247,7 +248,40 @@ Error: signing: github.com/mandelsoft/ref:v1: failed resolving component referen
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchErrorOutput(buf).Execute("sign", "components", "-s", SIGNATURE, "-K", PRIVKEY, ARCH)).To(HaveOccurred())
 			Expect(buf.String()).To(StringEqualTrimmedWithContext(`
-Error: signing: github.com/mandelsoft/ref:v1: failed resolving component reference ref[github.com/mandelsoft/test:v1]: component "github.com/mandelsoft/test" not found in ComponentArchive
+Error: signing: github.com/mandelsoft/ref:v1: failed resolving component reference ref[github.com/mandelsoft/test:v1]: ocm reference "github.com/mandelsoft/test:v1" not found
+`))
+		})
+	})
+
+	Context("component archive", func() {
+		BeforeEach(func() {
+			env.OCMCommonTransport(ARCH, accessio.FormatDirectory, func() {
+				env.Component(COMPONENTA, func() {
+					env.Version(VERSION, func() {
+						env.Provider(PROVIDER)
+						env.Resource("testdata", "", "PlainText", metav1.LocalRelation, func() {
+							env.BlobStringData(mime.MIME_TEXT, "testdata")
+						})
+					})
+				})
+			})
+
+			env.ComponentArchive(COMPARCH, accessio.FormatDirectory, COMPONENTB, VERSION, func() {
+				env.Reference("ref", COMPONENTA, VERSION)
+			})
+		})
+
+		It("signs comp arch with lookup", func() {
+			buf := bytes.NewBuffer(nil)
+
+			MustBeSuccessful(env.CatchOutput(buf).Execute("sign", "components", "-s", SIGNATURE, "-K", PRIVKEY, "--lookup", ARCH, "--repo", COMPARCH))
+			Expect(buf.String()).To(StringEqualTrimmedWithContext(`
+applying to version "github.com/mandelsoft/ref:v1"[github.com/mandelsoft/ref:v1]...
+  no digest found for "github.com/mandelsoft/test:v1"
+  applying to version "github.com/mandelsoft/test:v1"[github.com/mandelsoft/ref:v1]...
+    resource 0:  "name"="testdata": digest SHA-256:810ff2fb242a5dee4220f2cb0e6a519891fb67f2f828a6cab4ef8894633b1f50[genericBlobDigest/v1]
+  reference 0:  github.com/mandelsoft/test:v1: digest SHA-256:5923de2b3b68e904eecb58eca91727926b36623623555025dc5a8700edfa9daa[jsonNormalisation/v1]
+successfully signed github.com/mandelsoft/ref:v1 (digest SHA-256:3d1bf98adce06320809393473bed3aaaccf8696418bd1ef5b4d35fa632082d05)
 `))
 		})
 	})

--- a/pkg/common/accessobj/accessstate.go
+++ b/pkg/common/accessobj/accessstate.go
@@ -311,7 +311,7 @@ func (f *fileBasedAccess) Get() (blobaccess.BlobAccess, error) {
 		return nil, err
 	}
 	if !ok {
-		return nil, errors.ErrNotFoundWrap(vfs.ErrNotExist, "file", f.path)
+		return nil, errors.ErrNotFoundWrap(vfs.ErrNotExist, "file", f.path, f.filesystem.Name())
 	}
 	return blobaccess.ForFile(f.mimeType, f.path, f.filesystem), nil
 }

--- a/pkg/common/accessobj/check.go
+++ b/pkg/common/accessobj/check.go
@@ -40,6 +40,7 @@ func CheckFile(kind string, createHint string, forcedType bool, path string, fs 
 			return mapErr(forcedType, err)
 		}
 		defer file.Close()
+		forcedType = false
 		r, _, err := compression.AutoDecompress(file)
 		if err != nil {
 			return mapErr(forcedType, err)
@@ -63,6 +64,12 @@ func CheckFile(kind string, createHint string, forcedType bool, path string, fs 
 			}
 		}
 	} else {
+		if forcedType {
+			entries, err := vfs.ReadDir(fs, path)
+			if err == nil && len(entries) > 0 {
+				forcedType = false
+			}
+		}
 		if ok, err := vfs.FileExists(fs, filepath.Join(path, descriptorname)); !ok || err != nil {
 			if err != nil {
 				return mapErr(forcedType, err)

--- a/pkg/contexts/oci/repositories/ctf/uniform.go
+++ b/pkg/contexts/oci/repositories/ctf/uniform.go
@@ -28,6 +28,15 @@ func (h *repospechandler) MapReference(ctx cpi.Context, u *cpi.UniformRepository
 	return MapReference(ctx, u)
 }
 
+func explicit(t string) bool {
+	for _, f := range SupportedFormats() {
+		if t == string(f) {
+			return true
+		}
+	}
+	return t == Type || t == AltType
+}
+
 func MapReference(ctx cpi.Context, u *cpi.UniformRepositorySpec) (cpi.RepositorySpec, error) {
 	path := u.Info
 	if u.Info == "" {
@@ -43,7 +52,7 @@ func MapReference(ctx cpi.Context, u *cpi.UniformRepositorySpec) (cpi.Repository
 	if !u.CreateIfMissing {
 		hint = ""
 	}
-	create, ok, err := accessobj.CheckFile(Type, hint, accessio.TypeForTypeSpec(typ) == Type, path, fs, ArtifactIndexFileName)
+	create, ok, err := accessobj.CheckFile(Type, hint, explicit(accessio.TypeForTypeSpec(u.Type)), path, fs, ArtifactIndexFileName)
 	if !ok || (err != nil && typ == "") {
 		if err != nil {
 			return nil, err

--- a/pkg/contexts/ocm/interface.go
+++ b/pkg/contexts/ocm/interface.go
@@ -22,6 +22,7 @@ import (
 var ErrTempVersion = repocpi.ErrTempVersion
 
 const (
+	KIND_COMPONENT          = internal.KIND_COMPONENT
 	KIND_COMPONENTVERSION   = internal.KIND_COMPONENTVERSION
 	KIND_COMPONENTREFERENCE = "component reference"
 	KIND_RESOURCE           = internal.KIND_RESOURCE

--- a/pkg/contexts/ocm/internal/errors.go
+++ b/pkg/contexts/ocm/internal/errors.go
@@ -12,6 +12,7 @@ import (
 )
 
 const (
+	KIND_COMPONENT        = errors.KIND_COMPONENT
 	KIND_COMPONENTVERSION = "component version"
 	KIND_RESOURCE         = "component resource"
 	KIND_SOURCE           = "component source"

--- a/pkg/contexts/ocm/repositories/comparch/uniform.go
+++ b/pkg/contexts/ocm/repositories/comparch/uniform.go
@@ -11,14 +11,23 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/cpi"
 )
 
+const AltType = "ca"
+
 func init() {
 	h := &repospechandler{}
 	cpi.RegisterRepositorySpecHandler(h, "")
 	cpi.RegisterRepositorySpecHandler(h, Type)
-	cpi.RegisterRepositorySpecHandler(h, "ca")
+	cpi.RegisterRepositorySpecHandler(h, AltType)
+	for _, f := range GetFormats() {
+		cpi.RegisterRepositorySpecHandler(h, f)
+	}
 }
 
 type repospechandler struct{}
+
+func explicit(t string) bool {
+	return t == Type || t == AltType
+}
 
 func (h *repospechandler) MapReference(ctx cpi.Context, u *cpi.UniformRepositorySpec) (cpi.RepositorySpec, error) {
 	path := u.Info
@@ -35,7 +44,7 @@ func (h *repospechandler) MapReference(ctx cpi.Context, u *cpi.UniformRepository
 	if !u.CreateIfMissing {
 		hint = ""
 	}
-	create, ok, err := accessobj.CheckFile(Type, hint, accessio.TypeForTypeSpec(typ) == Type, path, fs, ComponentDescriptorFileName)
+	create, ok, err := accessobj.CheckFile(Type, hint, explicit(accessio.TypeForTypeSpec(u.Type)), path, fs, ComponentDescriptorFileName)
 	if !ok || (err != nil && typ == "") {
 		if err != nil {
 			return nil, err

--- a/pkg/contexts/ocm/resolver.go
+++ b/pkg/contexts/ocm/resolver.go
@@ -64,7 +64,7 @@ func (c *CompoundResolver) LookupComponentVersion(name string, version string) (
 		if err == nil && cv != nil {
 			return cv, nil
 		}
-		if !errors.IsErrNotFoundKind(err, KIND_COMPONENTVERSION) {
+		if !errors.IsErrNotFoundKind(err, KIND_COMPONENTVERSION) && !errors.IsErrNotFoundKind(err, KIND_COMPONENT) {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Description

Parsing a command line repository spec is improved to better distinguish CA and CTF variants.

A CTF is only enforced if the target has
- either the required descriptor file
- or if has no files

This gives spec handlers later in the list the chance to detect their type.

May be, a rework would be useful, where handlers distinguish between a default and a direct match.
So far, the first match exists the handler processing. With a default match, all handlers could be executed to look
for a direct match. A default match would only be used if no direct match is found.


Second problem is the compound resolver. If a component archive is used as resolver, if reports a not found error
for the component, instead of the requested component version. The error condition is fixed accordingly.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)
> Remove if not applicable

## Screenshots

<!-- Visual changes require screenshots -->


## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Added to documentation?

- [ ] 📜 README.md
- [ ] 🙅 no documentation needed

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
