### PR TITLE
Make ocm flake.nix ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,37 @@ The code for the CLI can be found in [package `cmds/ocm`](https://github.com/op
 The OCI and OCM support can be found in packages
 [`pkg/contexts/oci`](pkg/contexts/oci) and [`pkg/contexts/ocm`](pkg/contexts/ocm).
 
+## Installation
+
+Install the latest release via [Homebrew](https://brew.sh), [Nix](https://nixos.org), or directly from [GitHub Releases](https://github.com/open-component-model/ocm/releases).
+
+### Install using Homebrew
+
+```sh
+# Homebrew (macOS and Linux)
+brew install open-component-model/tap/ocm
+```
+
+### Install using Nix (with [Flakes](https://nixos.wiki/wiki/Flakes))
+
+```bash
+# Nix (macOS, Linux, and Windows)
+# ad hoc cmd execution
+nix run github:open-component-model/ocm -- --help
+nix run github:open-component-model/ocm#helminstaller -- --help
+
+# install development version
+nix profile install github:open-component-model/ocm
+# or release <version>
+nix profile install github:open-component-model/ocm/<version>
+
+#check installation
+nix profile list | grep ocm
+
+# optionally, open a new shell and verify that cmd completion works
+ocm --help
+```
+
 ## Examples
 An example of how to use the `ocm` CLI in a Makefile can be found in [`examples/make`](https://github.com/open-component-model/ocm/blob/main/examples/make/Makefile).
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1704420045,
+        "narHash": "sha256-C36QmoJd5tdQ5R9MC1jM7fBkZW9zBUqbUCsgwS6j4QU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c1be43e8e837b8dbee2b3665a007e761680f0c3d",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-23.11",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,17 +2,18 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704420045,
-        "narHash": "sha256-C36QmoJd5tdQ5R9MC1jM7fBkZW9zBUqbUCsgwS6j4QU=",
+        "lastModified": 1704874635,
+        "narHash": "sha256-YWuCrtsty5vVZvu+7BchAxmcYzTMfolSPP5io8+WYCg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c1be43e8e837b8dbee2b3665a007e761680f0c3d",
+        "rev": "3dc440faeee9e889fe2d1b4d25ad0f430d449356",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
+        "owner": "NixOS",
         "ref": "nixos-23.11",
-        "type": "indirect"
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 
   inputs = {
     # NixPkgs (nixos-23.11)
-    nixpkgs.url = "nixpkgs/nixos-23.11"; #"github:NixOS/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
   };
 
   outputs = { self, nixpkgs, ... }:
@@ -64,15 +64,17 @@ SPDX-License-Identifier: Apache-2.0
             nativeBuildInputs = [ pkgs.installShellFiles ];
 
             postInstall = ''
-              installShellCompletion --cmd ${pname} --zsh  <($out/bin/${pname} completion zsh)
-              installShellCompletion --cmd ${pname} --bash <($out/bin/${pname} completion bash)
-              installShellCompletion --cmd ${pname} --fish <($out/bin/${pname} completion fish)
+              installShellCompletion --cmd ${pname} \
+                  --zsh  <($out/bin/${pname} completion zsh) \
+                  --bash <($out/bin/${pname} completion bash) \
+                  --fish <($out/bin/${pname} completion fish)
             '';
 
             meta = with lib; {
               description = "Open Component Model (OCM) is an open standard to describe software bills of delivery (SBOD)";
               longDescription = ''
-                The Open Component Model (OCM) is an open standard to describe software bills of delivery (SBOD). OCM is a technology-agnostic and machine-readable format focused on the software artifacts that must be delivered for software products.
+                OCM is a technology-agnostic and machine-readable format focused on the software artifacts that must be delivered for software products.
+                The specification is also used to express metadata needed for security, compliance, and certification purpose.
               '';
               homepage = "https://ocm.software";
               license = licenses.asl20;
@@ -89,11 +91,11 @@ SPDX-License-Identifier: Apache-2.0
         {
           default = pkgs.mkShell {
             buildInputs = with pkgs; [ 
-              go_1_21 
-              gopls 
-              gotools 
-              go-tools
-              gnumake
+              go_1_21   # golang 1.21
+              gopls     # go language server
+              gotools   # go imports
+              go-tools  # static checks
+              gnumake   # standard make
             ];
           };
         });

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,125 @@
+/*
+SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+
+SPDX-License-Identifier: Apache-2.0
+*/
+{
+  description = "Nix flake for ocm";
+
+  inputs = {
+    # NixPkgs (nixos-23.11)
+    nixpkgs.url = "nixpkgs/nixos-23.11"; #"github:NixOS/nixpkgs/nixos-23.11";
+  };
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      pname = "ocm";
+
+      # System types to support.
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+
+    in
+    {
+      # Provide some binary packages for selected system types.
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+          inherit (pkgs) stdenv lib ;
+        in
+        {
+          ${pname} = pkgs.buildGo121Module rec {
+            inherit pname self;
+            version = lib.fileContents ./VERSION;
+            gitCommit = if (self ? rev) then self.rev else self.dirtyRev;
+            state = if (self ? rev) then "clean" else "dirty";
+
+            # This vendorHash represents a dervative of all go.mod dependancies and needs to be adjusted with every change
+            vendorHash = "sha256-CA3p9QNHo7mHCoXkuOojFAJen3TdieSsoQVivxPk3yw=";
+
+            src = ./.;
+
+            ldflags = [
+              "-s" "-w"
+              "-X github.com/open-component-model/ocm/pkg/version.gitVersion=${version}"
+              "-X github.com/open-component-model/ocm/pkg/version.gitTreeState=${state}"
+              "-X github.com/open-component-model/ocm/pkg/version.gitCommit=${gitCommit}"
+            # "-X github.com/open-component-model/ocm/pkg/version.buildDate=1970-01-01T0:00:00+0000"
+            ];
+
+            CGO_ENABLED = 0;
+
+            subPackages = [ 
+              "cmds/ocm" 
+              "cmds/helminstaller"
+              "cmds/demoplugin"
+              "cmds/ecrplugin"
+            ];
+
+            nativeBuildInputs = [ pkgs.installShellFiles ];
+
+            postInstall = ''
+              installShellCompletion --cmd ${pname} --zsh  <($out/bin/${pname} completion zsh)
+              installShellCompletion --cmd ${pname} --bash <($out/bin/${pname} completion bash)
+              installShellCompletion --cmd ${pname} --fish <($out/bin/${pname} completion fish)
+            '';
+
+            meta = with lib; {
+              description = "Open Component Model (OCM) is an open standard to describe software bills of delivery (SBOD)";
+              longDescription = ''
+                The Open Component Model (OCM) is an open standard to describe software bills of delivery (SBOD). OCM is a technology-agnostic and machine-readable format focused on the software artifacts that must be delivered for software products.
+              '';
+              homepage = "https://ocm.software";
+              license = licenses.asl20;
+              platforms = supportedSystems;
+            };
+          };
+        });
+      
+      # Add dependencies that are only needed for development
+      devShells = forAllSystems (system:
+        let 
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [ 
+              go_1_21 
+              gopls 
+              gotools 
+              go-tools
+              gnumake
+            ];
+          };
+        });
+
+      # The default package for 'nix build'.
+      defaultPackage = forAllSystems (system: self.packages.${system}.${pname});
+
+      # These are the apps included in the default package.
+      apps = forAllSystems (system: rec {
+        ${pname} = default;
+        default = {
+            type = "app";
+            program = self.packages.${system}.${pname} + "/bin/ocm";
+        };
+        helminstaller = {
+          type = "app";
+          program = self.packages.${system}.${pname} + "/bin/helminstaller";
+        };
+        demo = {
+          type = "app";
+          program = self.packages.${system}.${pname} + "/bin/demoplugin";
+        };
+        ecrplugin = {
+          type = "app";
+          program = self.packages.${system}.${pname} + "/bin/ecrplugin";
+        };
+      });
+    };
+}


### PR DESCRIPTION
## Description

This is a flake enablement for the repository of ocm. nix enabled environments can easily import ocm with
```
nix run github:open-component-model/ocm
nix run github:open-component-model/ocm#demo
nix run github:open-component-model/ocm#helminstaller
...
```
nix can hermetically build the package automatically on various architectures. 
With the flakes includes the the ocm repo, we can contribute our project into the nixos.org package library.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

