### PR TITLE
Check Command to check completeness of a component version graph

### DIFF
--- a/cmds/ocm/app/app.go
+++ b/cmds/ocm/app/app.go
@@ -35,6 +35,7 @@ import (
 	"github.com/open-component-model/ocm/cmds/ocm/commands/toicmds"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/verbs/add"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/verbs/bootstrap"
+	"github.com/open-component-model/ocm/cmds/ocm/commands/verbs/check"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/verbs/clean"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/verbs/controller"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/verbs/create"
@@ -81,7 +82,7 @@ type CLIOptions struct {
 	keyoption.Option
 
 	Completed   bool
-	Config      string
+	Config      []string
 	ConfigSets  []string
 	Credentials []string
 	Context     clictx.Context
@@ -221,6 +222,7 @@ func newCliCommand(opts *CLIOptions, mod ...func(clictx.Context, *cobra.Command)
 
 	cmd.AddCommand(NewVersionCommand(opts.Context))
 
+	cmd.AddCommand(check.NewCommand(opts.Context))
 	cmd.AddCommand(get.NewCommand(opts.Context))
 	cmd.AddCommand(create.NewCommand(opts.Context))
 	cmd.AddCommand(add.NewCommand(opts.Context))
@@ -296,7 +298,7 @@ func newCliCommand(opts *CLIOptions, mod ...func(clictx.Context, *cobra.Command)
 }
 
 func (o *CLIOptions) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVarP(&o.Config, "config", "", "", "configuration file")
+	fs.StringArrayVarP(&o.Config, "config", "", nil, "configuration file")
 	fs.StringSliceVarP(&o.ConfigSets, "config-set", "", nil, "apply configuration set")
 	fs.StringArrayVarP(&o.Credentials, "cred", "C", nil, "credential setting")
 	fs.StringArrayVarP(&o.Settings, "attribute", "X", nil, "attribute setting")
@@ -325,9 +327,18 @@ func (o *CLIOptions) Complete() error {
 	if err != nil {
 		return err
 	}
-	_, err = utils.Configure(o.Context.OCMContext(), o.Config, vfsattr.Get(o.Context))
-	if err != nil {
-		return err
+
+	if len(o.Config) == 0 {
+		_, err = utils.Configure(o.Context.OCMContext(), "", vfsattr.Get(o.Context))
+		if err != nil {
+			return err
+		}
+	}
+	for _, config := range o.Config {
+		_, err = utils.Configure(o.Context.OCMContext(), config, vfsattr.Get(o.Context))
+		if err != nil {
+			return err
+		}
 	}
 
 	err = o.Option.Configure(o.Context)

--- a/cmds/ocm/commands/common/options/failonerroroption/option.go
+++ b/cmds/ocm/commands/common/options/failonerroroption/option.go
@@ -5,6 +5,7 @@
 package failonerroroption
 
 import (
+	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/spf13/pflag"
 
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
@@ -22,10 +23,40 @@ func New() *Option {
 
 type Option struct {
 	Fail bool
+	err  error
 }
 
 func (o *Option) AddFlags(fs *pflag.FlagSet) {
-	fs.BoolVarP(&o.Fail, "fail-on-error", "", false, "fail on label validation error")
+	fs.BoolVarP(&o.Fail, "fail-on-error", "", false, "fail on validation error")
 }
 
 var _ options.Options = (*Option)(nil)
+
+func (o *Option) GetError() error {
+	return o.err
+}
+func (o *Option) SetError(err error) {
+	o.err = err
+}
+
+func (o *Option) AddError(err error) {
+	if err == nil {
+		return
+	}
+	if o.err == nil {
+		o.err = errors.ErrList().Add(err)
+	} else {
+		if l, ok := o.err.(*errors.ErrorList); ok {
+			l.Add(err)
+		} else {
+			o.err = errors.ErrList().Add(o.err, err)
+		}
+	}
+}
+
+func (o *Option) ActivatedError() error {
+	if o.Fail {
+		return o.err
+	}
+	return nil
+}

--- a/cmds/ocm/commands/ocmcmds/components/check/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/components/check/cmd.go
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package check
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	ocmcommon "github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common"
+	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/handlers/comphdlr"
+	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/common/options/repooption"
+	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/names"
+	"github.com/open-component-model/ocm/cmds/ocm/commands/verbs"
+	"github.com/open-component-model/ocm/cmds/ocm/pkg/output"
+	"github.com/open-component-model/ocm/cmds/ocm/pkg/processing"
+	"github.com/open-component-model/ocm/cmds/ocm/pkg/utils"
+	"github.com/open-component-model/ocm/pkg/common"
+	"github.com/open-component-model/ocm/pkg/contexts/clictx"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm"
+	"github.com/open-component-model/ocm/pkg/errors"
+	utils2 "github.com/open-component-model/ocm/pkg/utils"
+)
+
+var (
+	Names = names.Components
+	Verb  = verbs.Check
+)
+
+type Command struct {
+	utils.BaseCommand
+
+	Refs []string
+}
+
+// NewCommand creates a new ctf command.
+func NewCommand(ctx clictx.Context, names ...string) *cobra.Command {
+	return utils.SetupCommand(
+		&Command{
+			BaseCommand: utils.NewBaseCommand(ctx,
+				repooption.New(),
+				output.OutputOptions(outputs),
+			),
+		},
+		utils.Names(Names, names...)...,
+	)
+}
+
+func (o *Command) ForName(name string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "[<options>] {<component-reference>}",
+		Short: "check completeness of a component version in an OCM repository",
+		Long: `
+THis command checks, whether component versiuons are completely contained
+in an OCM repository with all its dependent component references.
+`,
+		Example: `
+$ ocm check componentversion ghcr.io/mandelsoft/kubelink
+$ ocm get componentversion --repo OCIRegistry::ghcr.io mandelsoft/kubelink
+`,
+	}
+}
+
+func (o *Command) Complete(args []string) error {
+	o.Refs = args
+	if len(args) == 0 && repooption.From(o).Spec == "" {
+		return fmt.Errorf("a repository or at least one argument that defines the reference is needed")
+	}
+	return nil
+}
+
+func (o *Command) Run() error {
+	session := ocm.NewSession(nil)
+	defer session.Close()
+
+	err := o.ProcessOnOptions(ocmcommon.CompleteOptionsWithSession(o, session))
+	if err != nil {
+		return err
+	}
+	handler := comphdlr.NewTypeHandler(o.Context.OCM(), session, repooption.From(o).Repository, comphdlr.OptionsFor(o))
+	return utils.HandleArgs(output.From(o), handler, o.Refs...)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+var outputs = output.NewOutputs(OutputFactory(mapRegularOutput), output.Outputs{
+	"wide": OutputFactory(mapWideOutput, "MISSING"),
+}).AddChainedManifestOutputs(CreateChain)
+
+func OutputFactory(fmt processing.MappingFunction, wide ...string) output.OutputFactory {
+	return func(opts *output.Options) output.Output {
+		return (&output.TableOutput{
+			Headers: output.Fields("COMPONENT", "VERSION", "STATUS", "ERROR", wide),
+			Options: opts,
+			Chain:   NewAction(),
+			Mapping: fmt,
+		}).New()
+	}
+}
+
+func mapRegularOutput(e interface{}) interface{} {
+	p := e.(*Entry)
+
+	err := ""
+	if p.Error != nil {
+		err = p.Error.Error()
+	}
+	if len(p.Missing) == 0 {
+		return []string{p.ComponentVersion.GetName(), p.ComponentVersion.GetVersion(), p.Status, err}
+	}
+	return []string{p.ComponentVersion.GetName(), p.ComponentVersion.GetVersion(), p.Status, err}
+}
+
+func mapWideOutput(e interface{}) interface{} {
+	p := e.(*Entry)
+
+	err := ""
+	if p.Error != nil {
+		err = p.Error.Error()
+	}
+	if len(p.Missing) == 0 {
+		return []string{p.ComponentVersion.GetName(), p.ComponentVersion.GetVersion(), p.Status, err, ""}
+	}
+	missing := map[string]string{}
+	for id, m := range p.Missing {
+		sep := "["
+		d := ""
+		for _, id := range m[:len(m)-1] {
+			d = d + sep + id.String()
+			sep = "->"
+		}
+		missing[id.String()] = d + "]"
+	}
+	msg := ""
+	sep := ""
+	for _, k := range utils2.StringMapKeys(missing) {
+		msg += sep + k + missing[k]
+		sep = ", "
+	}
+	return []string{p.ComponentVersion.GetName(), p.ComponentVersion.GetVersion(), p.Status, err, msg}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+type Missing map[common.NameVersion]common.History
+type Entry struct {
+	Status           string             `json:"status"`
+	ComponentVersion common.NameVersion `json:"componentVersion"`
+	Missing          Missing            `json:"missing,omitempty"`
+	Error            error              `json:"error,omitempty"`
+}
+
+func (n Missing) MarshalJSON() ([]byte, error) {
+	m := map[string]common.History{}
+	for k, v := range n {
+		m[k.String()] = v
+	}
+	return json.Marshal(m)
+}
+
+func CreateChain(options *output.Options) processing.ProcessChain {
+	// opts are not required by action so far.
+	return NewAction()
+}
+
+type action struct {
+	cache map[common.NameVersion]map[common.NameVersion]common.History
+}
+
+func NewAction() processing.ProcessChain {
+	return comphdlr.Sort.Map((&action{}).Map)
+}
+
+func (a *action) Map(in interface{}) interface{} {
+	a.cache = map[common.NameVersion]map[common.NameVersion]common.History{}
+
+	i := in.(*comphdlr.Object)
+	o := &Entry{
+		Status:           "OK",
+		ComponentVersion: common.VersionedElementKey(i.ComponentVersion),
+	}
+	o.Missing, o.Error = a.handle(i.ComponentVersion, common.History{common.VersionedElementKey(i.ComponentVersion)})
+	if o.Error != nil {
+		o.Status = "Error"
+	}
+	if len(o.Missing) > 0 {
+		o.Status = "Incomplete"
+	}
+	return o
+}
+
+func (a *action) getMissing(repo ocm.Repository, id common.NameVersion, h common.History) (Missing, error) {
+	if r, ok := a.cache[id]; ok {
+		return r, nil
+	}
+
+	err := h.Add(ocm.KIND_COMPONENTVERSION, id)
+	if err != nil {
+		return nil, err
+	}
+	cv, err := repo.LookupComponentVersion(id.GetName(), id.GetVersion())
+	if err != nil {
+		if !errors.IsErrNotFound(err) {
+			return nil, err
+		}
+	}
+	if cv == nil {
+		return map[common.NameVersion]common.History{id: h}, nil
+	} else {
+		return a.handle(cv, h)
+	}
+}
+
+func (a *action) handle(cv ocm.ComponentVersionAccess, h common.History) (Missing, error) {
+	var missing Missing
+	for _, r := range cv.GetDescriptor().References {
+		id := common.NewNameVersion(r.ComponentName, r.Version)
+		n, err := a.getMissing(cv.Repository(), id, h)
+		if err != nil {
+			return missing, err
+		}
+		if len(n) > 0 {
+			if missing == nil {
+				missing = Missing{}
+			}
+			for k, v := range n {
+				missing[k] = v
+			}
+		}
+	}
+	return missing, nil
+}

--- a/cmds/ocm/commands/ocmcmds/components/check/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/components/check/cmd.go
@@ -57,7 +57,7 @@ func (o *Command) ForName(name string) *cobra.Command {
 		Use:   "[<options>] {<component-reference>}",
 		Short: "check completeness of a component version in an OCM repository",
 		Long: `
-THis command checks, whether component versiuons are completely contained
+This command checks, whether component versiuons are completely contained
 in an OCM repository with all its dependent component references.
 `,
 		Example: `
@@ -124,12 +124,9 @@ func mapRegularOutput(e interface{}) interface{} {
 func mapWideOutput(e interface{}) interface{} {
 	p := e.(*Entry)
 
-	err := ""
-	if p.Error != nil {
-		err = p.Error.Error()
-	}
+	line := mapRegularOutput(e).([]string)
 	if len(p.Missing) == 0 {
-		return []string{p.ComponentVersion.GetName(), p.ComponentVersion.GetVersion(), p.Status, err, ""}
+		return append(line, "")
 	}
 	missing := map[string]string{}
 	for id, m := range p.Missing {
@@ -147,7 +144,7 @@ func mapWideOutput(e interface{}) interface{} {
 		msg += sep + k + missing[k]
 		sep = ", "
 	}
-	return []string{p.ComponentVersion.GetName(), p.ComponentVersion.GetVersion(), p.Status, err, msg}
+	return append(line, msg)
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cmds/ocm/commands/ocmcmds/components/check/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/components/check/cmd.go
@@ -58,7 +58,7 @@ func NewCommand(ctx clictx.Context, names ...string) *cobra.Command {
 func (o *Command) ForName(name string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "[<options>] {<component-reference>}",
-		Short: "check completeness of a component version in an OCM repository",
+		Short: "Check completeness of a component version in an OCM repository",
 		Long: `
 This command checks, whether component versions are completely contained
 in an OCM repository with all its dependent component references.

--- a/cmds/ocm/commands/ocmcmds/components/check/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/check/cmd_test.go
@@ -75,6 +75,16 @@ test.de/x v1      Incomplete
 `))
 		})
 
+		It("outputs wide table", func() {
+			buf := bytes.NewBuffer(nil)
+			Expect(env.CatchOutput(buf).Execute("check", "components", ARCH+"//"+COMP, "-o", "wide")).To(Succeed())
+			Expect(buf.String()).To(StringEqualTrimmedWithContext(
+				`
+COMPONENT VERSION STATUS     ERROR MISSING
+test.de/x v1      Incomplete       test.de/z:v1[test.de/x:v1]
+`))
+		})
+
 		It("outputs json", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("check", "components", ARCH+"//"+COMP, "-o", "json")).To(Succeed())

--- a/cmds/ocm/commands/ocmcmds/components/check/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/check/cmd_test.go
@@ -1,0 +1,202 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package check_test
+
+import (
+	"bytes"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/open-component-model/ocm/cmds/ocm/testhelper"
+	. "github.com/open-component-model/ocm/pkg/testutils"
+
+	"github.com/open-component-model/ocm/pkg/common/accessio"
+)
+
+const ARCH = "/tmp/ca"
+const VERSION = "v1"
+const COMP = "test.de/x"
+const COMP2 = "test.de/y"
+const COMP3 = "test.de/z"
+const COMP4 = "test.de/a"
+
+var _ = Describe("Test Environment", func() {
+	var env *TestEnv
+
+	BeforeEach(func() {
+		env = NewTestEnv()
+	})
+
+	AfterEach(func() {
+		env.Cleanup()
+	})
+
+	It("get checks refereces", func() {
+		env.OCMCommonTransport(ARCH, accessio.FormatDirectory, func() {
+			env.ComponentVersion(COMP, VERSION, func() {
+				env.Reference("ref", COMP3, VERSION)
+			})
+			env.ComponentVersion(COMP2, VERSION, func() {
+				env.Reference("ref", COMP3, VERSION)
+			})
+			env.ComponentVersion(COMP3, VERSION)
+		})
+
+		buf := bytes.NewBuffer(nil)
+		Expect(env.CatchOutput(buf).Execute("check", "components", ARCH+"//"+COMP)).To(Succeed())
+		Expect(buf.String()).To(StringEqualTrimmedWithContext(
+			`
+COMPONENT VERSION STATUS ERROR
+test.de/x v1      OK
+`))
+	})
+
+	Context("finds missing", func() {
+		BeforeEach(func() {
+			env.OCMCommonTransport(ARCH, accessio.FormatDirectory, func() {
+				env.ComponentVersion(COMP, VERSION, func() {
+					env.Reference("ref", COMP3, VERSION)
+				})
+				env.ComponentVersion(COMP2, VERSION, func() {
+					env.Reference("ref", COMP3, VERSION)
+				})
+			})
+		})
+
+		It("outputs table", func() {
+			buf := bytes.NewBuffer(nil)
+			Expect(env.CatchOutput(buf).Execute("check", "components", ARCH+"//"+COMP)).To(Succeed())
+			Expect(buf.String()).To(StringEqualTrimmedWithContext(
+				`
+COMPONENT VERSION STATUS     ERROR
+test.de/x v1      Incomplete
+`))
+		})
+		It("outputs json", func() {
+			buf := bytes.NewBuffer(nil)
+			Expect(env.CatchOutput(buf).Execute("check", "components", ARCH+"//"+COMP, "-o", "json")).To(Succeed())
+			Expect(buf.String()).To(StringEqualTrimmedWithContext(
+				`
+{
+  "items": [
+    {
+      "status": "Incomplete",
+      "componentVersion": "test.de/x:v1",
+      "missing": {
+        "test.de/z:v1": [
+          "test.de/x:v1",
+          "test.de/z:v1"
+        ]
+      }
+    }
+  ]
+}
+`))
+		})
+	})
+
+	It("handles diamond", func() {
+		env.OCMCommonTransport(ARCH, accessio.FormatDirectory, func() {
+			env.ComponentVersion(COMP, VERSION, func() {
+				env.Reference("ref1", COMP2, VERSION)
+				env.Reference("ref2", COMP3, VERSION)
+			})
+			env.ComponentVersion(COMP2, VERSION, func() {
+				env.Reference("ref", COMP4, VERSION)
+			})
+			env.ComponentVersion(COMP3, VERSION, func() {
+				env.Reference("ref", COMP4, VERSION)
+			})
+			env.ComponentVersion(COMP4, VERSION, func() {
+			})
+		})
+
+		buf := bytes.NewBuffer(nil)
+		Expect(env.CatchOutput(buf).Execute("check", "components", ARCH+"//"+COMP)).To(Succeed())
+		Expect(buf.String()).To(StringEqualTrimmedWithContext(
+			`
+COMPONENT VERSION STATUS ERROR
+test.de/x v1      OK     
+`))
+	})
+	It("handles all", func() {
+		env.OCMCommonTransport(ARCH, accessio.FormatDirectory, func() {
+			env.ComponentVersion(COMP, VERSION, func() {
+				env.Reference("ref1", COMP2, VERSION)
+				env.Reference("ref2", COMP3, VERSION)
+			})
+			env.ComponentVersion(COMP2, VERSION, func() {
+				env.Reference("ref", COMP4, VERSION)
+			})
+			env.ComponentVersion(COMP3, VERSION, func() {
+				env.Reference("ref", COMP4, VERSION)
+			})
+			env.ComponentVersion(COMP4, VERSION, func() {
+			})
+		})
+
+		buf := bytes.NewBuffer(nil)
+		Expect(env.CatchOutput(buf).Execute("check", "components", ARCH)).To(Succeed())
+		Expect(buf.String()).To(StringEqualTrimmedWithContext(
+			`
+COMPONENT VERSION STATUS ERROR
+test.de/a v1      OK     
+test.de/x v1      OK     
+test.de/y v1      OK     
+test.de/z v1      OK     
+`))
+	})
+
+	It("finds cycle", func() {
+		env.OCMCommonTransport(ARCH, accessio.FormatDirectory, func() {
+			env.ComponentVersion(COMP, VERSION, func() {
+				env.Reference("ref", COMP3, VERSION)
+			})
+			env.ComponentVersion(COMP2, VERSION, func() {
+				env.Reference("ref", COMP3, VERSION)
+			})
+			env.ComponentVersion(COMP3, VERSION, func() {
+				env.Reference("ref", COMP2, VERSION)
+			})
+		})
+
+		buf := bytes.NewBuffer(nil)
+		Expect(env.CatchOutput(buf).Execute("check", "components", ARCH+"//"+COMP)).To(Succeed())
+		Expect(buf.String()).To(StringEqualTrimmedWithContext(
+			`
+COMPONENT VERSION STATUS ERROR
+test.de/x v1      Error  component version recursion: use of test.de/z:v1 for test.de/x:v1->test.de/z:v1->test.de/y:v1
+`))
+	})
+
+	It("finds all cycles", func() {
+		env.OCMCommonTransport(ARCH, accessio.FormatDirectory, func() {
+			env.ComponentVersion(COMP, VERSION, func() {
+				env.Reference("ref", COMP2, VERSION)
+				env.Reference("ref", COMP3, VERSION)
+			})
+			env.ComponentVersion(COMP2, VERSION, func() {
+				env.Reference("ref", COMP4, VERSION)
+			})
+			env.ComponentVersion(COMP3, VERSION, func() {
+				env.Reference("ref", COMP4, VERSION)
+			})
+			env.ComponentVersion(COMP4, VERSION, func() {
+				env.Reference("ref", COMP, VERSION)
+			})
+		})
+
+		buf := bytes.NewBuffer(nil)
+		Expect(env.CatchOutput(buf).Execute("check", "components", ARCH)).To(Succeed())
+		Expect(buf.String()).To(StringEqualTrimmedWithContext(
+			`
+COMPONENT VERSION STATUS ERROR
+test.de/a v1      Error  component version recursion: use of test.de/a:v1 for test.de/a:v1->test.de/x:v1->test.de/z:v1
+test.de/x v1      Error  component version recursion: use of test.de/x:v1 for test.de/x:v1->test.de/z:v1->test.de/a:v1
+test.de/y v1      Error  component version recursion: use of test.de/a:v1 for test.de/y:v1->test.de/a:v1->test.de/x:v1->test.de/z:v1
+test.de/z v1      Error  component version recursion: use of test.de/z:v1 for test.de/z:v1->test.de/a:v1->test.de/x:v1
+`))
+	})
+})

--- a/cmds/ocm/commands/ocmcmds/components/check/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/check/cmd_test.go
@@ -74,6 +74,7 @@ COMPONENT VERSION STATUS     ERROR
 test.de/x v1      Incomplete
 `))
 		})
+
 		It("outputs json", func() {
 			buf := bytes.NewBuffer(nil)
 			Expect(env.CatchOutput(buf).Execute("check", "components", ARCH+"//"+COMP, "-o", "json")).To(Succeed())
@@ -93,6 +94,17 @@ test.de/x v1      Incomplete
     }
   ]
 }
+`))
+		})
+
+		It("provides error table", func() {
+			buf := bytes.NewBuffer(nil)
+			ExpectError(env.CatchOutput(buf).Execute("check", "components", ARCH+"//"+COMP, "--fail-on-error")).
+				To(MatchError("incomplete component version test.de/x:v1"))
+			Expect(buf.String()).To(StringEqualTrimmedWithContext(
+				`
+COMPONENT VERSION STATUS     ERROR
+test.de/x v1      Incomplete
 `))
 		})
 	})

--- a/cmds/ocm/commands/ocmcmds/components/check/options.go
+++ b/cmds/ocm/commands/ocmcmds/components/check/options.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package check
+
+import (
+	"github.com/spf13/pflag"
+
+	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
+)
+
+func From(o options.OptionSetProvider) *Option {
+	var opt *Option
+	o.AsOptionSet().Get(&opt)
+	return opt
+}
+
+var _ options.Options = (*Option)(nil)
+
+type Option struct {
+	CheckLocalResources bool
+	CheckLocalSources   bool
+}
+
+func NewOption() *Option {
+	return &Option{}
+}
+
+func (o *Option) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVarP(&o.CheckLocalResources, "local-resources", "R", false, "check also for describing resources with local access method, only")
+	fs.BoolVarP(&o.CheckLocalSources, "local-sources", "S", false, "check also for describing sources with local access method, only")
+}
+
+func (o *Option) Usage() string {
+	s := `
+If the options <code>--local-resources</code> and/or <code>--local-sources</code> are given the
+the check additionally assures that all resources or sources are included into the component version.
+This means that they are using local access methods, only.
+`
+	return s
+}

--- a/cmds/ocm/commands/ocmcmds/components/check/suite_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/check/suite_test.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package check_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OCM check components")
+}

--- a/cmds/ocm/commands/ocmcmds/components/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/components/cmd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/components/add"
+	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/components/check"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/components/download"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/components/get"
 	"github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/components/hash"
@@ -38,4 +39,5 @@ func AddCommands(ctx clictx.Context, cmd *cobra.Command) {
 	cmd.AddCommand(transfer.NewCommand(ctx, transfer.Verb))
 	cmd.AddCommand(verify.NewCommand(ctx, verify.Verb))
 	cmd.AddCommand(download.NewCommand(ctx, download.Verb))
+	cmd.AddCommand(check.NewCommand(ctx, check.Verb))
 }

--- a/cmds/ocm/commands/verbs/add/cmd.go
+++ b/cmds/ocm/commands/verbs/add/cmd.go
@@ -22,7 +22,7 @@ import (
 // NewCommand creates a new command.
 func NewCommand(ctx clictx.Context) *cobra.Command {
 	cmd := utils.MassageCommand(&cobra.Command{
-		Short: "Add resources or sources to a component archive",
+		Short: "Add elements to a component repository or component version",
 	}, verbs.Add)
 	cmd.AddCommand(resourceconfig.NewCommand(ctx))
 	cmd.AddCommand(sourceconfig.NewCommand(ctx))

--- a/cmds/ocm/commands/verbs/check/cmd.go
+++ b/cmds/ocm/commands/verbs/check/cmd.go
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package check
+
+import (
+	"github.com/open-component-model/ocm/cmds/ocm/commands/verbs"
+	"github.com/open-component-model/ocm/cmds/ocm/pkg/utils"
+	"github.com/open-component-model/ocm/pkg/contexts/clictx"
+	"github.com/spf13/cobra"
+
+	components "github.com/open-component-model/ocm/cmds/ocm/commands/ocmcmds/components/check"
+)
+
+// NewCommand creates a new command.
+func NewCommand(ctx clictx.Context) *cobra.Command {
+	cmd := utils.MassageCommand(&cobra.Command{
+		Short: "check components in OCM repository",
+	}, verbs.Check)
+	cmd.AddCommand(components.NewCommand(ctx))
+	return cmd
+}

--- a/cmds/ocm/commands/verbs/verbs.go
+++ b/cmds/ocm/commands/verbs/verbs.go
@@ -6,6 +6,7 @@ package verbs
 
 const (
 	Get       = "get"
+	Check     = "check"
 	Describe  = "describe"
 	Hash      = "hash"
 	Add       = "add"

--- a/docs/reference/ocm.md
+++ b/docs/reference/ocm.md
@@ -11,7 +11,7 @@ ocm [<options>] <sub command> ...
 ```
   -X, --attribute stringArray     attribute setting
       --ca-cert stringArray       additional root certificate authorities
-      --config string             configuration file
+      --config stringArray        configuration file
       --config-set strings        apply configuration set
   -C, --cred stringArray          credential setting
   -h, --help                      help for ocm
@@ -225,6 +225,28 @@ The value can be a simple type or a JSON/YAML string for complex values
 
   Directory to look for OCM plugin executables.
 
+- <code>github.com/mandelsoft/ocm/rootcerts</code>: *JSON*
+
+  General root certificate settings given as JSON document with the following
+  format:
+
+  <pre>
+  {
+    "rootCertificates"": [
+       {
+         "data": ""&lt;base64>"
+       },
+       {
+         "path": ""&lt;file path>"
+       }
+    ],
+  </pre>
+
+  One of following data fields are possible:
+  - <code>data</code>:       base64 encoded binary data
+  - <code>stringdata</code>: plain text data
+  - <code>path</code>:       a file path to read the data from
+
 - <code>github.com/mandelsoft/ocm/signing</code>: *JSON*
 
   Public and private Key settings given as JSON document with the following
@@ -318,8 +340,9 @@ by a certificate delivered with the signature.
 
 ##### Sub Commands
 
-* [ocm <b>add</b>](ocm_add.md)	 &mdash; Add resources or sources to a component archive
+* [ocm <b>add</b>](ocm_add.md)	 &mdash; Add elements to a component repository or component version
 * [ocm <b>bootstrap</b>](ocm_bootstrap.md)	 &mdash; bootstrap components
+* [ocm <b>check</b>](ocm_check.md)	 &mdash; check components in OCM repository
 * [ocm <b>clean</b>](ocm_clean.md)	 &mdash; Cleanup/re-organize elements
 * [ocm <b>controller</b>](ocm_controller.md)	 &mdash; Commands acting on the ocm-controller
 * [ocm <b>create</b>](ocm_create.md)	 &mdash; Create transport or component archive

--- a/docs/reference/ocm_add.md
+++ b/docs/reference/ocm_add.md
@@ -1,4 +1,4 @@
-## ocm add &mdash; Add Resources Or Sources To A Component Archive
+## ocm add &mdash; Add Elements To A Component Repository Or Component Version
 
 ### Synopsis
 

--- a/docs/reference/ocm_add_componentversions.md
+++ b/docs/reference/ocm_add_componentversions.md
@@ -191,7 +191,7 @@ next to the description file.
 
 ##### Parents
 
-* [ocm add](ocm_add.md)	 &mdash; Add resources or sources to a component archive
+* [ocm add](ocm_add.md)	 &mdash; Add elements to a component repository or component version
 * [ocm](ocm.md)	 &mdash; Open Component Model command line client
 
 

--- a/docs/reference/ocm_add_componentversions_ocm-labels.md
+++ b/docs/reference/ocm_add_componentversions_ocm-labels.md
@@ -177,6 +177,6 @@ The following label assignments are configured:
 ##### Parents
 
 * [ocm add componentversions](ocm_add_componentversions.md)	 &mdash; add component version(s) to a (new) transport archive
-* [ocm add](ocm_add.md)	 &mdash; Add resources or sources to a component archive
+* [ocm add](ocm_add.md)	 &mdash; Add elements to a component repository or component version
 * [ocm](ocm.md)	 &mdash; Open Component Model command line client
 

--- a/docs/reference/ocm_add_references.md
+++ b/docs/reference/ocm_add_references.md
@@ -183,6 +183,6 @@ $ ocm add references  path/to/ca  references.yaml VERSION=1.0.0
 
 ##### Parents
 
-* [ocm add](ocm_add.md)	 &mdash; Add resources or sources to a component archive
+* [ocm add](ocm_add.md)	 &mdash; Add elements to a component repository or component version
 * [ocm](ocm.md)	 &mdash; Open Component Model command line client
 

--- a/docs/reference/ocm_add_resource-configuration.md
+++ b/docs/reference/ocm_add_resource-configuration.md
@@ -809,7 +809,7 @@ $ ocm add resource-config resources.yaml --name myresource --type PlainText --in
 
 ##### Parents
 
-* [ocm add](ocm_add.md)	 &mdash; Add resources or sources to a component archive
+* [ocm add](ocm_add.md)	 &mdash; Add elements to a component repository or component version
 * [ocm](ocm.md)	 &mdash; Open Component Model command line client
 
 

--- a/docs/reference/ocm_add_resources.md
+++ b/docs/reference/ocm_add_resources.md
@@ -846,7 +846,7 @@ $ ocm add resources &dash;&dash;file path/to/ca  resources.yaml VERSION=1.0.0
 
 ##### Parents
 
-* [ocm add](ocm_add.md)	 &mdash; Add resources or sources to a component archive
+* [ocm add](ocm_add.md)	 &mdash; Add elements to a component repository or component version
 * [ocm](ocm.md)	 &mdash; Open Component Model command line client
 
 

--- a/docs/reference/ocm_add_routingslips.md
+++ b/docs/reference/ocm_add_routingslips.md
@@ -125,6 +125,6 @@ $ ocm add routingslip ghcr.io/mandelsoft/ocm//ocmdemoinstaller:0.0.1-dev mandels
 
 ##### Parents
 
-* [ocm add](ocm_add.md)	 &mdash; Add resources or sources to a component archive
+* [ocm add](ocm_add.md)	 &mdash; Add elements to a component repository or component version
 * [ocm](ocm.md)	 &mdash; Open Component Model command line client
 

--- a/docs/reference/ocm_add_source-configuration.md
+++ b/docs/reference/ocm_add_source-configuration.md
@@ -809,7 +809,7 @@ $ ocm add source-config sources.yaml --name sources --type filesystem --access '
 
 ##### Parents
 
-* [ocm add](ocm_add.md)	 &mdash; Add resources or sources to a component archive
+* [ocm add](ocm_add.md)	 &mdash; Add elements to a component repository or component version
 * [ocm](ocm.md)	 &mdash; Open Component Model command line client
 
 

--- a/docs/reference/ocm_add_sources.md
+++ b/docs/reference/ocm_add_sources.md
@@ -816,7 +816,7 @@ $ ocm add sources --file path/to/cafile sources.yaml
 
 ##### Parents
 
-* [ocm add](ocm_add.md)	 &mdash; Add resources or sources to a component archive
+* [ocm add](ocm_add.md)	 &mdash; Add elements to a component repository or component version
 * [ocm](ocm.md)	 &mdash; Open Component Model command line client
 
 

--- a/docs/reference/ocm_attributes.md
+++ b/docs/reference/ocm_attributes.md
@@ -133,6 +133,28 @@ OCM library:
 
   Directory to look for OCM plugin executables.
 
+- <code>github.com/mandelsoft/ocm/rootcerts</code>: *JSON*
+
+  General root certificate settings given as JSON document with the following
+  format:
+
+  <pre>
+  {
+    "rootCertificates"": [
+       {
+         "data": ""&lt;base64>"
+       },
+       {
+         "path": ""&lt;file path>"
+       }
+    ],
+  </pre>
+
+  One of following data fields are possible:
+  - <code>data</code>:       base64 encoded binary data
+  - <code>stringdata</code>: plain text data
+  - <code>path</code>:       a file path to read the data from
+
 - <code>github.com/mandelsoft/ocm/signing</code>: *JSON*
 
   Public and private Key settings given as JSON document with the following

--- a/docs/reference/ocm_check.md
+++ b/docs/reference/ocm_check.md
@@ -21,5 +21,5 @@ ocm check [<options>] <sub command> ...
 
 ##### Sub Commands
 
-* [ocm check <b>componentversions</b>](ocm_check_componentversions.md)	 &mdash; check completeness of a component version in an OCM repository
+* [ocm check <b>componentversions</b>](ocm_check_componentversions.md)	 &mdash; Check completeness of a component version in an OCM repository
 

--- a/docs/reference/ocm_check.md
+++ b/docs/reference/ocm_check.md
@@ -1,0 +1,25 @@
+## ocm check &mdash; Check Components In OCM Repository
+
+### Synopsis
+
+```
+ocm check [<options>] <sub command> ...
+```
+
+### Options
+
+```
+  -h, --help   help for check
+```
+
+### SEE ALSO
+
+##### Parents
+
+* [ocm](ocm.md)	 &mdash; Open Component Model command line client
+
+
+##### Sub Commands
+
+* [ocm check <b>componentversions</b>](ocm_check_componentversions.md)	 &mdash; check completeness of a component version in an OCM repository
+

--- a/docs/reference/ocm_check_componentversions.md
+++ b/docs/reference/ocm_check_componentversions.md
@@ -15,6 +15,7 @@ componentversions, componentversion, cv, components, component, comps, comp, c
 ### Options
 
 ```
+      --fail-on-error      fail on validation error
   -h, --help               help for componentversions
   -o, --output string      output mode (JSON, json, wide, yaml)
       --repo string        repository name or spec

--- a/docs/reference/ocm_check_componentversions.md
+++ b/docs/reference/ocm_check_componentversions.md
@@ -17,6 +17,8 @@ componentversions, componentversion, cv, components, component, comps, comp, c
 ```
       --fail-on-error      fail on validation error
   -h, --help               help for componentversions
+  -R, --local-resources    check also for describing resources with local access method, only
+  -S, --local-sources      check also for describing sources with local access method, only
   -o, --output string      output mode (JSON, json, wide, yaml)
       --repo string        repository name or spec
   -s, --sort stringArray   sort fields
@@ -25,7 +27,7 @@ componentversions, componentversion, cv, components, component, comps, comp, c
 ### Description
 
 
-THis command checks, whether component versiuons are completely contained
+This command checks, whether component versions are completely contained
 in an OCM repository with all its dependent component references.
 
 
@@ -71,6 +73,11 @@ OCI Repository types (using standard component repository to OCI mapping):
   - <code>oci</code>: v1
   - <code>ociRegistry</code>
 
+
+
+If the options <code>--local-resources</code> and/or <code>--local-sources</code> are given the
+the check additionally assures that all resources or sources are included into the component version.
+This means that they are using local access methods, only.
 
 With the option <code>--output</code> the output mode can be selected.
 The following modes are supported:

--- a/docs/reference/ocm_check_componentversions.md
+++ b/docs/reference/ocm_check_componentversions.md
@@ -1,0 +1,96 @@
+## ocm check componentversions &mdash; Check Completeness Of A Component Version In An OCM Repository
+
+### Synopsis
+
+```
+ocm check componentversions [<options>] {<component-reference>}
+```
+
+##### Aliases
+
+```
+componentversions, componentversion, cv, components, component, comps, comp, c
+```
+
+### Options
+
+```
+  -h, --help               help for componentversions
+  -o, --output string      output mode (JSON, json, wide, yaml)
+      --repo string        repository name or spec
+  -s, --sort stringArray   sort fields
+```
+
+### Description
+
+
+THis command checks, whether component versiuons are completely contained
+in an OCM repository with all its dependent component references.
+
+
+If the <code>--repo</code> option is specified, the given names are interpreted
+relative to the specified repository using the syntax
+
+<center>
+    <pre>&lt;component>[:&lt;version>]</pre>
+</center>
+
+If no <code>--repo</code> option is specified the given names are interpreted
+as located OCM component version references:
+
+<center>
+    <pre>[&lt;repo type>::]&lt;host>[:&lt;port>][/&lt;base path>]//&lt;component>[:&lt;version>]</pre>
+</center>
+
+Additionally there is a variant to denote common transport archives
+and general repository specifications
+
+<center>
+    <pre>[&lt;repo type>::]&lt;filepath>|&lt;spec json>[//&lt;component>[:&lt;version>]]</pre>
+</center>
+
+The <code>--repo</code> option takes an OCM repository specification:
+
+<center>
+    <pre>[&lt;repo type>::]&lt;configured name>|&lt;file path>|&lt;spec json></pre>
+</center>
+
+For the *Common Transport Format* the types <code>directory</code>,
+<code>tar</code> or <code>tgz</code> is possible.
+
+Using the JSON variant any repository types supported by the
+linked library can be used:
+
+Dedicated OCM repository types:
+  - <code>ComponentArchive</code>: v1
+
+OCI Repository types (using standard component repository to OCI mapping):
+  - <code>CommonTransportFormat</code>: v1
+  - <code>OCIRegistry</code>: v1
+  - <code>oci</code>: v1
+  - <code>ociRegistry</code>
+
+
+With the option <code>--output</code> the output mode can be selected.
+The following modes are supported:
+  - <code></code> (default)
+  - <code>JSON</code>
+  - <code>json</code>
+  - <code>wide</code>
+  - <code>yaml</code>
+
+
+### Examples
+
+```
+$ ocm check componentversion ghcr.io/mandelsoft/kubelink
+$ ocm get componentversion --repo OCIRegistry::ghcr.io mandelsoft/kubelink
+```
+
+### SEE ALSO
+
+##### Parents
+
+* [ocm check](ocm_check.md)	 &mdash; check components in OCM repository
+* [ocm](ocm.md)	 &mdash; Open Component Model command line client
+

--- a/docs/reference/ocm_configfile.md
+++ b/docs/reference/ocm_configfile.md
@@ -264,6 +264,17 @@ The following configuration types are supported:
       config: &lt;arbitrary configuration structure>
       disableAutoRegistration: &lt;boolean flag to disable auto registration for up- and download handlers>
   </pre>
+- <code>rootcerts.config.ocm.software</code>
+  The config type <code>rootcerts.config.ocm.software</code> can be used to define
+  general root certificates. A certificate value might be given by one of the fields:
+  - <code>path</code>: path of file with key data
+  - <code>data</code>: base64 encoded binary data
+  - <code>stringdata</code>: data a string parsed by key handler
+
+  <pre>
+      rootCertificates:
+        - path: &lt;file path>
+  </pre>
 - <code>scripts.ocm.config.ocm.software</code>
   The config type <code>scripts.ocm.config.ocm.software</code> can be used to define transfer scripts:
 

--- a/docs/reference/ocm_get_credentials.md
+++ b/docs/reference/ocm_get_credentials.md
@@ -17,6 +17,7 @@ credentials, creds, cred
 ```
   -h, --help             help for credentials
   -m, --matcher string   matcher type override
+  -s, --sloppy           sloppy matching of consumer type
 ```
 
 ### Description

--- a/docs/reference/ocm_get_routingslips.md
+++ b/docs/reference/ocm_get_routingslips.md
@@ -17,7 +17,7 @@ routingslips, routingslip, rs
 ```
       --all-columns               show all table columns
   -c, --constraints constraints   version constraint
-      --fail-on-error             fail on label validation error
+      --fail-on-error             fail on validation error
   -h, --help                      help for routingslips
       --latest                    restrict component versions to latest
       --lookup stringArray        repository name or spec for closure lookup fallback

--- a/docs/reference/ocm_logging.md
+++ b/docs/reference/ocm_logging.md
@@ -19,6 +19,7 @@ The following *realms* are used by the command line tool:
   - <code>ocm</code>: general realm used for the ocm go library.
   - <code>ocm/accessmethod/ociartifact</code>: access method ociArtifact
   - <code>ocm/compdesc</code>: component descriptor handling
+  - <code>ocm/config</code>: configuration management
   - <code>ocm/context</code>: context lifecycle
   - <code>ocm/credentials/dockerconfig</code>: docker config handling as credential repository
   - <code>ocm/credentials/vault</code>: HashiCorp Vault Access

--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,7 @@ require (
 	github.com/distribution/reference v0.5.0
 	github.com/imdario/mergo v0.3.16
 	github.com/mandelsoft/vfs v0.4.0
+	github.com/texttheater/golang-levenshtein/levenshtein v0.0.0-20200805054039-cae8b0eaed6c
 	k8s.io/client-go v0.28.4
 )
 

--- a/go.sum
+++ b/go.sum
@@ -2279,6 +2279,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDd
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/tchap/go-patricia v2.2.6+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
 github.com/tchap/go-patricia v2.3.0+incompatible/go.mod h1:bmLyhP68RS6kStMGxByiQ23RP/odRBOTVjwp2cDyi6I=
+github.com/texttheater/golang-levenshtein/levenshtein v0.0.0-20200805054039-cae8b0eaed6c h1:HelZ2kAFadG0La9d+4htN4HzQ68Bm2iM9qKMSMES6xg=
+github.com/texttheater/golang-levenshtein/levenshtein v0.0.0-20200805054039-cae8b0eaed6c/go.mod h1:JlzghshsemAMDGZLytTFY8C1JQxQPhnatWqNwUXjggo=
 github.com/thales-e-security/pool v0.0.2 h1:RAPs4q2EbWsTit6tpzuvTFlgFRJ3S8Evf5gtvVDbmPg=
 github.com/thales-e-security/pool v0.0.2/go.mod h1:qtpMm2+thHtqhLzTwgDBj/OuNnMpupY8mv0Phz0gjhU=
 github.com/theupdateframework/go-tuf v0.6.1 h1:6J89fGjQf7s0mLmTG7p7pO/MbKOg+bIXhaLyQdmbKuE=

--- a/pkg/common/history.go
+++ b/pkg/common/history.go
@@ -117,6 +117,15 @@ func (h History) Compare2(o History) (int, bool) {
 	return len(h) - len(o), false
 }
 
+func (h History) Cycle(nv NameVersion) (History, History) {
+	for i, e := range h {
+		if e == nv {
+			return h[:i], h[i:].Append(nv)
+		}
+	}
+	return nil, nil
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 type HistoryElement interface {

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -25,7 +25,10 @@ type NameVersion struct {
 	version string
 }
 
-var _ VersionedElement = (*NameVersion)(nil)
+var (
+	_ json.Marshaler   = (*NameVersion)(nil)
+	_ VersionedElement = (*NameVersion)(nil)
+)
 
 func NewNameVersion(name, version string) NameVersion {
 	return NameVersion{name, version}

--- a/pkg/contexts/credentials/utils.go
+++ b/pkg/contexts/credentials/utils.go
@@ -5,6 +5,10 @@
 package credentials
 
 import (
+	"strings"
+
+	"github.com/texttheater/golang-levenshtein/levenshtein"
+
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/utils"
 )
@@ -27,4 +31,64 @@ func CredentialsFor(ctx ContextProvider, obj interface{}, uctx ...UsageContext) 
 		return nil, errors.ErrNotSupported(KIND_CONSUMER)
 	}
 	return CredentialsForConsumer(ctx, id)
+}
+
+func GuessConsumerType(ctxp ContextProvider, spec string) string {
+	matchers := ctxp.CredentialsContext().ConsumerIdentityMatchers()
+	lspec := strings.ToLower(spec)
+
+	if matchers.Get(spec) == nil {
+		fix := ""
+		for _, i := range matchers.List() {
+			idx := strings.Index(i.Type, ".")
+			if idx > 0 && i.Type[:idx] == spec {
+				fix = i.Type
+				break
+			}
+		}
+		if fix == "" {
+			for _, i := range matchers.List() {
+				if strings.ToLower(i.Type) == lspec {
+					fix = i.Type
+					break
+				}
+			}
+		}
+		if fix == "" {
+			for _, i := range matchers.List() {
+				idx := strings.Index(i.Type, ".")
+				if idx > 0 && strings.ToLower(i.Type[:idx]) == lspec {
+					fix = i.Type
+					break
+				}
+			}
+		}
+		if fix == "" {
+			min := -1
+			for _, i := range matchers.List() {
+				idx := strings.Index(i.Type, ".")
+				if idx > 0 {
+					d := levenshtein.DistanceForStrings([]rune(lspec), []rune(strings.ToLower(i.Type[:idx])), levenshtein.DefaultOptions)
+					if d < 5 && fix == "" || min > d {
+						fix = i.Type
+						min = d
+					}
+				}
+			}
+		}
+		if fix == "" {
+			min := -1
+			for _, i := range matchers.List() {
+				d := levenshtein.DistanceForStrings([]rune(lspec), []rune(strings.ToLower(i.Type)), levenshtein.DefaultOptions)
+				if d < 5 && fix == "" || min > d {
+					fix = i.Type
+					min = d
+				}
+			}
+		}
+		if fix != "" {
+			return fix
+		}
+	}
+	return spec
 }

--- a/pkg/errors/errprop.go
+++ b/pkg/errors/errprop.go
@@ -4,6 +4,10 @@
 
 package errors
 
+import (
+	"github.com/mandelsoft/logging"
+)
+
 type ErrorFunction func() error
 
 // PropagateError propagates a deferred error to the named return value
@@ -20,5 +24,12 @@ func PropagateErrorf(errp *error, f ErrorFunction, msg string, args ...interface
 		*errp = ErrListf(msg, args...).Add(*errp).Result()
 	} else {
 		*errp = ErrListf(msg, args...).Add(*errp, f()).Result()
+	}
+}
+
+func LogError(log logging.Logger, f ErrorFunction, msg string, keypair ...interface{}) {
+	err := f()
+	if err != nil {
+		log.LogError(err, msg, keypair...)
 	}
 }


### PR DESCRIPTION
### ## Description

The new command `ocm check componentversion` checks component versions in an OCM
repository to be complete. All directly or indirectly references versions must also be 
available in the repository of the initially checked one.

Additionally, it checks for cycles and may be more consistency conditions in the future.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [x] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)
> Remove if not applicable

## Screenshots

<!-- Visual changes require screenshots -->


## Added tests?

- [x] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Added to documentation?

- [ ] 📜 README.md
- [ ] 🙅 no documentation needed

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
