### PR TITLE
default config handlers

### DIFF
--- a/cmds/ocm/app/app.go
+++ b/cmds/ocm/app/app.go
@@ -13,6 +13,7 @@ import (
 
 	_ "github.com/open-component-model/ocm/pkg/contexts/clictx/config"
 	_ "github.com/open-component-model/ocm/pkg/contexts/ocm/attrs"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/utils/defaultconfigregistry"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -105,6 +106,15 @@ It can be used in two ways:
   *[&lt;area>] &lt;object kind> &lt;verb/operation> &lt;arguments>*
 
 The command accepts some top level options, they can only be given before the sub commands.
+
+A configuration according to <CMD>ocm configfile</CMD> is read from a <code>.ocmconfig</code> file
+located in the <code>HOME</code> directory. With the option <code>--config</code> other
+file locations can be specified. If nothing is specified and no file is found at the default
+location a default configuration is composed according to known type specific
+configuration files.
+
+The following configuration sources are used:
+` + defaultconfigregistry.Description() + `
 
 With the option <code>--cred</code> it is possible to specify arbitrary credentials
 for various environments on the command line. Nevertheless it is always preferrable

--- a/docs/reference/ocm.md
+++ b/docs/reference/ocm.md
@@ -43,6 +43,18 @@ It can be used in two ways:
 
 The command accepts some top level options, they can only be given before the sub commands.
 
+A configuration according to [ocm configfile](ocm_configfile.md) is read from a <code>.ocmconfig</code> file
+located in the <code>HOME</code> directory. With the option <code>--config</code> other
+file locations can be specified. If nothing is specified and no file is found at the default
+location a default configuration is composed according to known type specific
+configuration files.
+
+The following configuration sources are used:
+  - The docker configuration file at <code>~/.docker/config.jaon</code> is
+    read to feed in the configured credentials for OCI registries.
+
+
+
 With the option <code>--cred</code> it is possible to specify arbitrary credentials
 for various environments on the command line. Nevertheless it is always preferrable
 to use the cli config file.
@@ -224,6 +236,28 @@ The value can be a simple type or a JSON/YAML string for complex values
 - <code>github.com/mandelsoft/ocm/plugindir</code> [<code>plugindir</code>]: *plugin directory*
 
   Directory to look for OCM plugin executables.
+
+- <code>github.com/mandelsoft/ocm/rootcerts</code>: *JSON*
+
+  General root certificate settings given as JSON document with the following
+  format:
+
+  <pre>
+  {
+    "rootCertificates"": [
+       {
+         "data": ""&lt;base64>"
+       },
+       {
+         "path": ""&lt;file path>"
+       }
+    ],
+  </pre>
+
+  One of following data fields are possible:
+  - <code>data</code>:       base64 encoded binary data
+  - <code>stringdata</code>: plain text data
+  - <code>path</code>:       a file path to read the data from
 
 - <code>github.com/mandelsoft/ocm/signing</code>: *JSON*
 

--- a/pkg/contexts/credentials/repositories/dockerconfig/default.go
+++ b/pkg/contexts/credentials/repositories/dockerconfig/default.go
@@ -17,7 +17,7 @@ import (
 )
 
 func init() {
-	defaultconfigregistry.RegisterDefaultConfigHandler(DefaultConfigHandler)
+	defaultconfigregistry.RegisterDefaultConfigHandler(DefaultConfigHandler, desc)
 }
 
 func DefaultConfigHandler(cfg config.Context) error {
@@ -33,3 +33,8 @@ func DefaultConfigHandler(cfg config.Context) error {
 	}
 	return nil
 }
+
+var desc = `
+The docker configuration file at <code>~/.docker/config.jaon</code> is
+read to feed in the configured credentials for OCI registries.
+`

--- a/pkg/contexts/credentials/repositories/dockerconfig/default.go
+++ b/pkg/contexts/credentials/repositories/dockerconfig/default.go
@@ -35,6 +35,6 @@ func DefaultConfigHandler(cfg config.Context) error {
 }
 
 var desc = `
-The docker configuration file at <code>~/.docker/config.jaon</code> is
+The docker configuration file at <code>~/.docker/config.json</code> is
 read to feed in the configured credentials for OCI registries.
 `

--- a/pkg/contexts/credentials/repositories/dockerconfig/default.go
+++ b/pkg/contexts/credentials/repositories/dockerconfig/default.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package dockerconfig
+
+import (
+	dockercli "github.com/docker/cli/cli/config"
+	"github.com/mandelsoft/filepath/pkg/filepath"
+	"github.com/mandelsoft/vfs/pkg/osfs"
+	"github.com/mandelsoft/vfs/pkg/vfs"
+
+	"github.com/open-component-model/ocm/pkg/contexts/config"
+	credcfg "github.com/open-component-model/ocm/pkg/contexts/credentials/config"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/utils/defaultconfigregistry"
+	"github.com/open-component-model/ocm/pkg/errors"
+)
+
+func init() {
+	defaultconfigregistry.RegisterDefaultConfigHandler(DefaultConfigHandler)
+}
+
+func DefaultConfigHandler(cfg config.Context) error {
+	// use docker config as default config for ocm cli
+	d := filepath.Join(dockercli.Dir(), dockercli.ConfigFileName)
+	if ok, err := vfs.FileExists(osfs.New(), d); ok && err == nil {
+		ccfg := credcfg.New()
+		ccfg.AddRepository(NewRepositorySpec(d, true))
+		err = cfg.ApplyConfig(ccfg, d)
+		if err != nil {
+			return errors.Wrapf(err, "cannot apply docker config %q", d)
+		}
+	}
+	return nil
+}

--- a/pkg/contexts/ocm/utils/configure.go
+++ b/pkg/contexts/ocm/utils/configure.go
@@ -9,17 +9,12 @@ import (
 	"os"
 	"strings"
 
-	dockercli "github.com/docker/cli/cli/config"
-	"github.com/mandelsoft/filepath/pkg/filepath"
 	"github.com/mandelsoft/spiff/features"
 	"github.com/mandelsoft/spiff/spiffing"
-	"github.com/mandelsoft/vfs/pkg/osfs"
 	"github.com/mandelsoft/vfs/pkg/vfs"
 
-	"github.com/open-component-model/ocm/pkg/contexts/config"
-	credcfg "github.com/open-component-model/ocm/pkg/contexts/credentials/config"
-	"github.com/open-component-model/ocm/pkg/contexts/credentials/repositories/dockerconfig"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/utils/defaultconfigregistry"
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/utils"
 )
@@ -68,14 +63,10 @@ func Configure(ctx ocm.Context, path string, fss ...vfs.FileSystem) (ocm.Context
 			return nil, err
 		}
 	} else {
-		// use docker config as default config for ocm cli
-		d := filepath.Join(dockercli.Dir(), dockercli.ConfigFileName)
-		if ok, err := vfs.FileExists(osfs.New(), d); ok && err == nil {
-			cfg := credcfg.New()
-			cfg.AddRepository(dockerconfig.NewRepositorySpec(d, true))
-			err = config.DefaultContext().ApplyConfig(cfg, d)
+		for _, h := range defaultconfigregistry.Get() {
+			err := h(ctx.ConfigContext())
 			if err != nil {
-				return nil, errors.Wrapf(err, "cannot apply docker config %q", d)
+				return nil, err
 			}
 		}
 	}

--- a/pkg/contexts/ocm/utils/defaultconfigregistry/configure.go
+++ b/pkg/contexts/ocm/utils/defaultconfigregistry/configure.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2022 SAP SE or an SAP affiliate company and Open Component Model contributors.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package defaultconfigregistry
+
+import (
+	"slices"
+	"sync"
+
+	"github.com/open-component-model/ocm/pkg/contexts/config"
+)
+
+type DefaultConfigHandler func(cfg config.Context) error
+
+type defaultConfigurationRegistry struct {
+	lock sync.Mutex
+
+	list []DefaultConfigHandler
+}
+
+func (r *defaultConfigurationRegistry) Register(h DefaultConfigHandler) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.list = append(r.list, h)
+}
+
+func (r *defaultConfigurationRegistry) Get() []DefaultConfigHandler {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	return slices.Clone(r.list)
+}
+
+var defaultConfigRegistry = &defaultConfigurationRegistry{}
+
+func RegisterDefaultConfigHandler(h DefaultConfigHandler) {
+	defaultConfigRegistry.Register(h)
+}
+
+func Get() []DefaultConfigHandler {
+	return defaultConfigRegistry.Get()
+}

--- a/pkg/listformat/listhelp.go
+++ b/pkg/listformat/listhelp.go
@@ -6,6 +6,8 @@ package listformat
 
 import (
 	"fmt"
+	"slices"
+	"sort"
 	"strings"
 
 	"github.com/open-component-model/ocm/pkg/utils"
@@ -93,4 +95,21 @@ func FormatListElements(def string, elems ListElements) string {
 		names += "\n"
 	}
 	return names
+}
+
+func FormatDescriptionList(def string, elems ...string) string {
+	list := slices.Clone(elems)
+	sort.Strings(list)
+
+	out := ""
+	for _, l := range list {
+		if l != "" {
+			out += "  - " + utils.IndentLines(l, "    ", true)
+			if strings.Contains(l, "\n") {
+				out += "\n"
+			}
+		}
+		out += "\n"
+	}
+	return out
 }


### PR DESCRIPTION
## Description

Introduce a handler registry to handle default configuration.
It is used to provide a default configuration for a context, if no
`.ocmconfig` is found or given.

So far, itwas hard-coded to incorporate the docker config.
With NPM we get a second source for default config.
Therefore, it is useful to replace the hard-wired solution by a registry
based one. This also reverses the dependency direction. OCM now does not have
a direct dependency to the docker implementation, anymore. Instead the docker
implementation registers itself for the default configuration handling.

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)
> Remove if not applicable

## Screenshots

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Added to documentation?

- [ ] 📜 README.md
- [ ] 🙅 no documentation needed

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
