### PR TITLE
Fix repository cache

### DIFF
--- a/cmds/ocm/commands/ocmcmds/components/check/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/components/check/cmd.go
@@ -7,8 +7,6 @@ package check
 import (
 	"fmt"
 
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/utils/check"
-	"github.com/open-component-model/ocm/pkg/optionutils"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/json"
 
@@ -24,6 +22,8 @@ import (
 	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/contexts/clictx"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/utils/check"
+	"github.com/open-component-model/ocm/pkg/optionutils"
 	utils2 "github.com/open-component-model/ocm/pkg/utils"
 )
 

--- a/cmds/ocm/commands/ocmcmds/components/check/options.go
+++ b/cmds/ocm/commands/ocmcmds/components/check/options.go
@@ -5,11 +5,11 @@
 package check
 
 import (
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/utils/check"
-	"github.com/open-component-model/ocm/pkg/optionutils"
 	"github.com/spf13/pflag"
 
 	"github.com/open-component-model/ocm/cmds/ocm/pkg/options"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/utils/check"
+	"github.com/open-component-model/ocm/pkg/optionutils"
 )
 
 func From(o options.OptionSetProvider) *Option {

--- a/pkg/contexts/ocm/internal/resolver.go
+++ b/pkg/contexts/ocm/internal/resolver.go
@@ -5,8 +5,6 @@
 package internal
 
 import (
-	"github.com/open-component-model/ocm/pkg/finalizer"
-	"github.com/open-component-model/ocm/pkg/refmgmt"
 	"strings"
 	"sync"
 
@@ -15,6 +13,8 @@ import (
 	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
 	"github.com/open-component-model/ocm/pkg/errors"
+	"github.com/open-component-model/ocm/pkg/finalizer"
+	"github.com/open-component-model/ocm/pkg/refmgmt"
 	"github.com/open-component-model/ocm/pkg/registrations"
 	"github.com/open-component-model/ocm/pkg/utils"
 )

--- a/pkg/contexts/ocm/internal/resolver.go
+++ b/pkg/contexts/ocm/internal/resolver.go
@@ -15,7 +15,6 @@ import (
 	"github.com/open-component-model/ocm/pkg/errors"
 	"github.com/open-component-model/ocm/pkg/finalizer"
 	"github.com/open-component-model/ocm/pkg/registrations"
-	"github.com/open-component-model/ocm/pkg/runtime"
 	"github.com/open-component-model/ocm/pkg/utils"
 )
 
@@ -57,13 +56,13 @@ func (c *RepositoryCache) LookupRepository(ctx Context, spec RepositorySpec) (Re
 	if err != nil {
 		return nil, err
 	}
-	data, err := runtime.DefaultJSONEncoding.Marshal(spec)
+	keyName, err := utils.Key(spec)
 	if err != nil {
 		return nil, err
 	}
 	key := datacontext.ObjectKey{
 		Object: ctx,
-		Name:   string(data),
+		Name:   keyName,
 	}
 
 	c.lock.Lock()

--- a/pkg/contexts/ocm/session.go
+++ b/pkg/contexts/ocm/session.go
@@ -6,11 +6,11 @@ package ocm
 
 import (
 	"fmt"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/internal"
 	"reflect"
 
 	"github.com/open-component-model/ocm/pkg/common"
 	"github.com/open-component-model/ocm/pkg/contexts/datacontext"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/internal"
 	"github.com/open-component-model/ocm/pkg/errors"
 )
 


### PR DESCRIPTION
## Description
The repository cache was not able to deal with repository specs that contained fields that cannot be marshalled (since the marshalled repository spec is used as key). 

This issue was already resolved in the session implementation that essentially implemented its own repository cache. To reduce code duplication and avoid such errors in the future, the session now uses the repository cache implementation. 

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)
> Remove if not applicable

## Screenshots

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Added to documentation?

- [ ] 📜 README.md
- [ ] 🙅 no documentation needed

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
