### PR TITLE
add metadata for hyperspace

### DIFF
--- a/components/ocmcli/metadata.yaml
+++ b/components/ocmcli/metadata.yaml
@@ -1,0 +1,32 @@
+kind: Component
+metadata:
+  name: ocm-cli
+  displayName: OCM CLI
+  description: OCM Command Line Interface
+  longDescription: |-
+    The OCM CLI can be used to interact with OCM components. It makes it easy to create component versions and embed them in software lifecyce processes.
+  labels:
+    language: go
+  tags:
+    - open-component-model
+    - ocm
+    - cli
+    - open-source
+    - inner-source
+spec:
+  type:
+    name: CLI
+    lifecycle: production
+  team:
+    name: ocm
+  logo: https://ocm.software/images/logo-image.png
+  docs:
+    techDocsLinks:
+      - name: OCM Documentation
+        url: https://ocm.software
+        icon: .sa-icon--sys-help-2
+        description: Documentation
+      - name: OCM Command Line Client
+        url: https://github.com/open-component-model/ocm/blob/main/docs/reference/ocm.md
+        icon: .sa-icon--sys-help-2
+        description: Open Component Model Command Line Client

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,24 @@
+kind: Component
+metadata:
+  name: ocm-core
+  displayName: OCM Core Library
+  description: OCM Core Library
+  labels:
+    language: go
+  tags:
+    - ocm
+    - open-source
+    - inner-source
+spec:
+  type:
+    name: Library
+    lifecycle: production
+  team:
+    name: ocm
+  logo: https://ocm.software/images/logo-image.png
+  docs:
+    techDocsLinks:
+      - name: OCM Core Library
+        url: https://github.com/open-component-model/ocm#ocm-library
+        icon: .sa-icon--sys-help-2
+        description: OCM Core Library


### PR DESCRIPTION
## Description

add metadata for Hyperspace. Until the ocm repo is split into ocm-cli and com-core, the metadata files need to placed in two different locations.