### PR TITLE
early CD validation for AddVersion

### DIFF
--- a/pkg/contexts/ocm/cpi/repocpi/bridge_c.go
+++ b/pkg/contexts/ocm/cpi/repocpi/bridge_c.go
@@ -134,6 +134,11 @@ func (c *componentAccessBridge) AddVersion(cv cpi.ComponentVersionAccess, opts *
 		return err
 	}
 
+	err = compdesc.Validate(cv.GetDescriptor())
+	if err != nil {
+		return err
+	}
+
 	forcestore := c.IsOwned(cv)
 	if !forcestore {
 		eff, err := c.NewVersion(cv.GetVersion(), optionutils.AsValue(opts.Overwrite))

--- a/pkg/contexts/ocm/repositories/composition/repository_test.go
+++ b/pkg/contexts/ocm/repositories/composition/repository_test.go
@@ -130,4 +130,10 @@ var _ = Describe("repository", func() {
 		cv.GetDescriptor().Provider.Name = "acme.org"
 		ExpectError(cl.Close()).To(MatchError(accessobj.ErrReadOnly))
 	})
+
+	It("provides early error", func() {
+		repo := me.NewRepository(ctx)
+		cv := me.NewComponentVersion(ctx, "a", "1.0")
+		ExpectError(repo.AddComponentVersion(cv)).To(MatchError("component.name: Does not match pattern '^[a-z][-a-z0-9]*([.][a-z][-a-z0-9]*)*[.][a-z]{2,}(/[a-z][-a-z0-9_]*([.][a-z][-a-z0-9_]*)*)+$'"))
+	})
 })


### PR DESCRIPTION
## Description

When adding a CV to a component, the CD validation is done deep in the call chain when updating the CV on the persistence layer. This typically happens during closing a CV which provides strange error messages.

To provider a better error message the validation is now done directly in the add call.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🎇 Restructuring
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->
- Related Issue # (issue)
- Closes # (issue)
- Fixes # (issue)
> Remove if not applicable

## Screenshots

<!-- Visual changes require screenshots -->


## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help
- [ ] Separate ticket for tests # (issue/pr)

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


## Added to documentation?

- [ ] 📜 README.md
- [ ] 🙅 no documentation needed

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
