### PR TITLE
fix maven uploader and rename mavenArtifact to mavenPackage

### DIFF
--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/maven/input_test.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/maven/input_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Test Environment", func() {
 	It("add maven from file system described by cli options", func() {
 		meta := `
 name: testdata
-type: mavenArtifact
+type: mavenPackage
 `
 		Expect(env.Execute("add", "resources", "--file", ARCH, "--resource", meta, "--inputType", "maven",
 			"--inputPath", "/maven/testdata/.m2/repository", "--groupId", "com.sap.cloud.sdk", "--artifactId", "sdk-modules-bom",
@@ -79,7 +79,7 @@ type: mavenArtifact
 	It("add maven file from file system described by cli options", func() {
 		meta := `
 name: testdata
-type: mavenArtifact
+type: mavenPackage
 `
 		Expect(env.Execute("add", "resources", "--file", ARCH, "--resource", meta, "--inputType", "maven",
 			"--inputPath", "/maven/testdata/.m2/repository", "--groupId", "com.sap.cloud.sdk", "--artifactId", "sdk-modules-bom",

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/maven/testdata/resources1.yaml
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/maven/testdata/resources1.yaml
@@ -1,5 +1,5 @@
 name: myblob
-type: mavenArtifact
+type: mavenPackage
 input:
   type: maven
   path: ../maven/testdata/.m2/repository

--- a/cmds/ocm/coretests/maven/cmd_test.go
+++ b/cmds/ocm/coretests/maven/cmd_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Test Environment", func() {
 		Expect(acc.IsLocal(env.OCMContext())).To(BeTrue())
 		Expect(acc.(*localblob.AccessSpec).ReferenceName).To(Equal(strings.Join([]string{maventest.GROUP_ID, maventest.ARTIFACT_ID, maventest.VERSION}, ":")))
 
-		Expect(env.Execute("transfer", "ctf", ARCH, DEST_ARCH, "--uploader", "ocm/mavenArtifact=file://localhost/mavenrepo")).To(Succeed())
+		Expect(env.Execute("transfer", "ctf", ARCH, DEST_ARCH, "--uploader", "ocm/mavenPackage=file://localhost/mavenrepo")).To(Succeed())
 		Expect(env.DirExists(DEST_ARCH)).To(BeTrue())
 		Expect(env.DirExists("/mavenrepo/" + coords.GavPath())).To(BeTrue())
 		mavenrepo := maven.NewFileRepository("/mavenrepo", env.FileSystem())
@@ -68,7 +68,7 @@ sdk-modules-bom-5.7.0.pom: 5`))
 
 	It("upload maven package from localblob during component composition", func() {
 		coords := maven.NewCoordinates(maventest.GROUP_ID, maventest.ARTIFACT_ID, maventest.VERSION)
-		Expect(env.Execute("add", "cv", "-fc", "--file", ARCH, "testdata/components.yaml", "--uploader", "ocm/mavenArtifact=file://localhost/mavenrepo")).To(Succeed())
+		Expect(env.Execute("add", "cv", "-fc", "--file", ARCH, "testdata/components.yaml", "--uploader", "ocm/mavenPackage=file://localhost/mavenrepo")).To(Succeed())
 		Expect(env.DirExists(ARCH)).To(BeTrue())
 		repo := Must(ctf.Open(env, ctf.ACC_READONLY, ARCH, 0, env))
 		defer Close(repo)
@@ -108,7 +108,7 @@ sdk-modules-bom-5.7.0.pom: 5`))
 				Expect(acc.IsLocal(env.OCMContext())).To(BeFalse())
 				Expect(acc.(ocm.HintProvider).GetReferenceHint(cv)).To(Equal(coords.GAV()))
 
-				Expect(env.Execute("transfer", "ctf", ARCH, DEST_ARCH, "--copy-resources", "--uploader", "ocm/mavenArtifact=file://localhost/mavenrepo")).To(Succeed())
+				Expect(env.Execute("transfer", "ctf", ARCH, DEST_ARCH, "--copy-resources", "--uploader", "ocm/mavenPackage=file://localhost/mavenrepo")).To(Succeed())
 				Expect(env.DirExists(DEST_ARCH)).To(BeTrue())
 				Expect(env.DirExists("/mavenrepo/" + coords.GavPath())).To(BeTrue())
 				mavenrepo := maven.NewFileRepository("/mavenrepo", env.FileSystem())

--- a/cmds/ocm/coretests/maven/testdata/components.yaml
+++ b/cmds/ocm/coretests/maven/testdata/components.yaml
@@ -4,8 +4,8 @@ components:
   provider:
     name: ocm.software
   resources:
-    - name: mavenartifact
-      type: mavenArtifact
+    - name: mavengav
+      type: mavenPackage
       input:
         type: maven
         path: /maven/testdata/.m2/repository

--- a/cmds/ocm/coretests/maven/testdata/components2.yaml
+++ b/cmds/ocm/coretests/maven/testdata/components2.yaml
@@ -4,8 +4,8 @@ components:
   provider:
     name: ocm.software
   resources:
-    - name: mavenartifact
-      type: mavenArtifact
+    - name: mavengav
+      type: mavenPackage
       version: "1.1"
       access:
         type: maven

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,7 @@ require (
 	github.com/klauspost/compress v1.17.8
 	github.com/klauspost/pgzip v1.2.6
 	github.com/mandelsoft/filepath v0.0.0-20240223090642-3e2777258aa3
-	github.com/mandelsoft/goutils v0.0.0-20240604075441-f06e2890eea3
+	github.com/mandelsoft/goutils v0.0.0-20240605100619-84d61423f421
 	github.com/mandelsoft/logging v0.0.0-20240201091719-67180059d6bf
 	github.com/mandelsoft/spiff v1.7.0-beta-5
 	github.com/mandelsoft/vfs v0.4.3

--- a/go.sum
+++ b/go.sum
@@ -684,6 +684,10 @@ github.com/mandelsoft/filepath v0.0.0-20240223090642-3e2777258aa3 h1:oo9nIgnyiBg
 github.com/mandelsoft/filepath v0.0.0-20240223090642-3e2777258aa3/go.mod h1:LxhqC7khDoRENwooP6f/vWvia9ivj6TqLYrR39zqkN0=
 github.com/mandelsoft/goutils v0.0.0-20240604075441-f06e2890eea3 h1:jSXyDjsOuy0DUCzDUCrZS/QMJZ2we1HQfLCpb0D7cnY=
 github.com/mandelsoft/goutils v0.0.0-20240604075441-f06e2890eea3/go.mod h1:EbNqk9JceSMq7MJuALB/vlOpoD4MAGE0TenM9TR+C0o=
+github.com/mandelsoft/goutils v0.0.0-20240605092610-3d3ecdc682ea h1:VDau62ZodJevUUdQ9xce0Q+8qNtW1Deg2FGtY6E4s/k=
+github.com/mandelsoft/goutils v0.0.0-20240605092610-3d3ecdc682ea/go.mod h1:EbNqk9JceSMq7MJuALB/vlOpoD4MAGE0TenM9TR+C0o=
+github.com/mandelsoft/goutils v0.0.0-20240605100619-84d61423f421 h1:AdG9KVK4wloCoxotPRmaPgI01P+4N9tWpIT1W0QwsJU=
+github.com/mandelsoft/goutils v0.0.0-20240605100619-84d61423f421/go.mod h1:EbNqk9JceSMq7MJuALB/vlOpoD4MAGE0TenM9TR+C0o=
 github.com/mandelsoft/logging v0.0.0-20240201091719-67180059d6bf h1:WEmgzeArDbp6Aw34jmziMIE5ygo2zpl/atXRq3D7lSw=
 github.com/mandelsoft/logging v0.0.0-20240201091719-67180059d6bf/go.mod h1:uO460C1lIB3IOOgrbXhAlz3AKsOv4T2K6ALBn3PwuSg=
 github.com/mandelsoft/spiff v1.7.0-beta-5 h1:3kC10nTviDQhL8diSxp7i4IC2iSiDg6KPbH1CAq7Lfw=

--- a/pkg/contexts/ocm/blobhandler/handlers/generic/maven/blobhandler_test.go
+++ b/pkg/contexts/ocm/blobhandler/handlers/generic/maven/blobhandler_test.go
@@ -69,7 +69,7 @@ var _ = Describe("blobhandler generic maven tests", func() {
 		ocmrepo := composition.NewRepository(env)
 		defer Close(ocmrepo)
 		cv := composition.NewComponentVersion(env, "acme.org/test", "1.0.0")
-		MustBeSuccessful(cv.SetResourceBlob(Must(elements.ResourceMeta("test", resourcetypes.MAVEN_ARTIFACT)), bacc, coords.GAV(), nil))
+		MustBeSuccessful(cv.SetResourceBlob(Must(elements.ResourceMeta("test", resourcetypes.MAVEN_PACKAGE)), bacc, coords.GAV(), nil))
 		MustBeSuccessful(ocmrepo.AddComponentVersion(cv))
 		l := sliceutils.Transform(Must(vfs.ReadDir(env.FileSystem(), "target/com/sap/cloud/sdk/sdk-modules-bom/5.7.0")),
 			func(info os.FileInfo) string {

--- a/pkg/contexts/ocm/blobhandler/handlers/generic/maven/registration.go
+++ b/pkg/contexts/ocm/blobhandler/handlers/generic/maven/registration.go
@@ -77,7 +77,7 @@ var _ cpi.BlobHandlerRegistrationHandler = (*RegistrationHandler)(nil)
 
 func (r *RegistrationHandler) RegisterByName(handler string, ctx cpi.Context, config cpi.BlobHandlerConfig, olist ...cpi.BlobHandlerOption) (bool, error) {
 	if handler != "" {
-		return true, fmt.Errorf("invalid %s handler %q", resourcetypes.MAVEN_ARTIFACT, handler)
+		return true, fmt.Errorf("invalid %s handler %q", resourcetypes.MAVEN_PACKAGE, handler)
 	}
 	if config == nil {
 		return true, fmt.Errorf("maven target specification required")
@@ -88,7 +88,7 @@ func (r *RegistrationHandler) RegisterByName(handler string, ctx cpi.Context, co
 	}
 
 	ctx.BlobHandlers().Register(NewArtifactHandler(cfg),
-		cpi.ForArtifactType(resourcetypes.MAVEN_ARTIFACT),
+		cpi.ForArtifactType(resourcetypes.MAVEN_PACKAGE),
 		cpi.ForMimeType(mime.MIME_TGZ),
 		cpi.NewBlobHandlerOptions(olist...),
 	)

--- a/pkg/contexts/ocm/elements/artifactaccess/mavenaccess/resource.go
+++ b/pkg/contexts/ocm/elements/artifactaccess/mavenaccess/resource.go
@@ -10,7 +10,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/maven"
 )
 
-const TYPE = resourcetypes.MAVEN_ARTIFACT
+const TYPE = resourcetypes.MAVEN_PACKAGE
 
 func Access[M any, P compdesc.ArtifactMetaPointer[M]](ctx ocm.Context, meta P, repoUrl, groupId, artifactId, version string, opts ...Option) cpi.ArtifactAccess[M] {
 	if meta.GetType() == "" {

--- a/pkg/contexts/ocm/elements/artifactblob/mavenblob/resource.go
+++ b/pkg/contexts/ocm/elements/artifactblob/mavenblob/resource.go
@@ -11,7 +11,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/resourcetypes"
 )
 
-const TYPE = resourcetypes.MAVEN_ARTIFACT
+const TYPE = resourcetypes.MAVEN_PACKAGE
 
 func Access[M any, P compdesc.ArtifactMetaPointer[M]](ctx ocm.Context, meta P, repo *maven.Repository, groupId, artifactId, version string, opts ...Option) cpi.ArtifactAccess[M] {
 	eff := optionutils.EvalOptions(optionutils.WithDefaults(opts, WithCredentialContext(ctx))...)

--- a/pkg/contexts/ocm/resourcetypes/const.go
+++ b/pkg/contexts/ocm/resourcetypes/const.go
@@ -16,8 +16,8 @@ const (
 	HELM_CHART = "helmChart"
 	// NPM_PACKAGE describes a Node.js (npm) package.
 	NPM_PACKAGE = "npmPackage"
-	// MAVEN_ARTIFACT describes a Maven artifact (jar).
-	MAVEN_ARTIFACT = "mavenArtifact"
+	// MAVEN_PACKAGE describes a Maven artifact (jar).
+	MAVEN_PACKAGE = "mavenPackage"
 	// BLUEPRINT describes a Gardener Landscaper blueprint which is an artifact used in its installations describing
 	// how to deploy a software component.
 	BLUEPRINT        = "landscaper.gardener.cloud/blueprint"

--- a/pkg/maven/access.go
+++ b/pkg/maven/access.go
@@ -15,6 +15,7 @@ import (
 	"github.com/mandelsoft/goutils/errors"
 	"github.com/mandelsoft/goutils/finalizer"
 	"github.com/mandelsoft/goutils/general"
+	"github.com/mandelsoft/goutils/ioutils"
 	"github.com/mandelsoft/vfs/pkg/vfs"
 	"golang.org/x/exp/maps"
 	"golang.org/x/net/html"
@@ -119,7 +120,7 @@ func (r *Repository) Download(coords *Coordinates, creds Credentials, enforceVer
 	return reader, nil
 }
 
-func (r *Repository) Upload(coords *Coordinates, reader io.ReadCloser, creds Credentials, hashes iotools.Hashes) (rerr error) {
+func (r *Repository) Upload(coords *Coordinates, reader ioutils.DupReadCloser, creds Credentials, hashes iotools.Hashes) (rerr error) {
 	finalize := finalizer.Finalizer{}
 	defer finalize.FinalizeWithErrorPropagation(&rerr)
 
@@ -150,7 +151,10 @@ func (r *Repository) Upload(coords *Coordinates, reader io.ReadCloser, creds Cre
 		}
 		return nil
 	}
-
+	reader, err := reader.Dup()
+	if rerr != nil {
+		return err
+	}
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodPut, loc.String(), reader)
 	if err != nil {
 		return err

--- a/pkg/maven/coordinates.go
+++ b/pkg/maven/coordinates.go
@@ -216,11 +216,11 @@ func (c *Coordinates) FilterFileMap(fileMap map[string]crypto.Hash) map[string]c
 	return fileMap
 }
 
-// Parse creates a Coordinates from it's serialized form (see Coordinates.String).
+// Parse creates a Coordinates from its serialized form (see Coordinates.String).
 func Parse(serializedArtifact string) (*Coordinates, error) {
 	parts := strings.Split(serializedArtifact, ":")
 	if len(parts) < 3 {
-		return nil, fmt.Errorf("invalid coordination string: %s", serializedArtifact)
+		return nil, fmt.Errorf("invalid coordination string: %q", serializedArtifact)
 	}
 	coords := NewCoordinates(parts[0], parts[1], parts[2])
 	if len(parts) >= 4 {


### PR DESCRIPTION
## Description
The resource type `mavenArtifact` was renamed to `mavenPackage` to avoid misunderstandings. Maven defines the term maven artifact as any file stored in maven (addressable by a GAVCE) while a mavenPackage describes all files stored under a particular GAV. 