### PR TITLE
Revert "Bump goreleaser/goreleaser-action from 5 to 6 in the ci group…

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -225,7 +225,7 @@ jobs:
         git push origin ${{ env.RELEASE_VERSION }}
 
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v6
+      uses: goreleaser/goreleaser-action@v5
       with:
         distribution: goreleaser
         version: latest


### PR DESCRIPTION
… (#802)"

This reverts commit 87aa3425be7224d8ecd048dd50fb02b8143856b3.

which introduced a breaking change and currently blocks the release creation