### PR TITLE
rework source info access for plugin clients

### DIFF
--- a/cmds/ocm/commands/ocmcmds/plugins/describe/describe.go
+++ b/cmds/ocm/commands/ocmcmds/plugins/describe/describe.go
@@ -19,7 +19,7 @@ func DescribePlugin(p plugin.Plugin, out common.Printer) {
 	}
 	out.Printf("Status:           %s\n", "valid")
 	d := p.GetDescriptor()
-	src := p.GetInstallationInfo()
+	src := p.GetSourceInfo()
 	if src != nil && src.HasSourceInfo() {
 		out.Printf("Source:\n")
 		out.Printf("  Component:       %s\n", src.Component)

--- a/cmds/ocm/commands/ocmcmds/plugins/get/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/plugins/get/cmd.go
@@ -93,7 +93,7 @@ func getWide(opts *output.Options) output.Output {
 
 func mapGetRegularOutput(e interface{}) interface{} {
 	p := handler.Elem(e)
-	loc := p.GetInstallationInfo().GetInstallationSourceDescription()
+	loc := p.GetSourceInfo().GetDescription()
 
 	features := p.GetDescriptor().Capabilities()
 	return []string{p.Name(), p.Version(), loc, p.Message(), strings.Join(features, ",")}

--- a/cmds/subcmdplugin/cmds/cmd_test.go
+++ b/cmds/subcmdplugin/cmds/cmd_test.go
@@ -69,7 +69,8 @@ Synopsis:
   ocm group demo <options> [flags]
 
 Flags:
-  -h, --help   help for demo
+  -h, --help             help for demo
+      --version string   some overloaded option
 
 Description:
   a demo command in a provided command group
@@ -111,7 +112,8 @@ Synopsis:
   ocm group demo <options> [flags]
 
 Flags:
-  -h, --help   help for demo
+  -h, --help             help for demo
+      --version string   some overloaded option
 
 Description:
   a demo command in a provided command group

--- a/cmds/subcmdplugin/cmds/demo/cmd.go
+++ b/cmds/subcmdplugin/cmds/demo/cmd.go
@@ -19,12 +19,16 @@ func New() *cobra.Command {
 		Long:  "a demo command in a provided command group",
 		RunE:  cmd.Run,
 	}
+
+	c.Flags().StringVarP(&cmd.version, "version", "", "", "some overloaded option")
 	return c
 }
 
-type command struct{}
+type command struct {
+	version string
+}
 
 func (c *command) Run(cmd *cobra.Command, args []string) error {
-	fmt.Printf("demo command called with arguments %v\n", args)
+	fmt.Printf("demo command called with arguments %v (and version option %s)\n", args, c.version)
 	return nil
 }

--- a/docs/command-plugins.md
+++ b/docs/command-plugins.md
@@ -41,18 +41,33 @@ func init() {
 
 #### CLI Commands
 
-CLI commands are simple configured `cobra.Command` objects.
-They are registered at the plugin object with
+CLI commands are provided by the registratuon interface `ppi.Command`. It
+provides some command metadata and a `cobra.Command` object.
 
-```
-        cmd, err := clicmd.NewCLICommand(NewCommand(), clicmd.WithCLIConfig(), clicmd.WithVerb("check"))
-	if err != nil {
-		os.Exit(1)
-	}
-	p.RegisterCommand(NewCommand())
+Commands are then registered at the plugin object with
+
+```go
+    p.RegisterCommand(cmd)
 ```
 
-with coding similar to
+The plugin programming interface supports the generation of an extension command directly from a
+`cobra.command` object using the method `NewCLICommand` from the `ppi.clicmd` package.
+It takes some options to specify the command embedding and extracts the other command attributes
+directly from the preconfigured cobra command.
+
+Otherwise, the `ppi.Command` interface  can be implemented without requiring a cobra command..
+
+A sample code could look like this:
+
+```go
+    cmd, err := clicmd.NewCLICommand(NewCommand(), clicmd.WithCLIConfig(), clicmd.WithVerb("check"))
+    if err != nil {
+        os.Exit(1)
+    }
+    p.RegisterCommand(cmd)
+```
+
+with coding for the cobra command similar to
 
 ```
 
@@ -77,10 +92,6 @@ func (c *command) Run(cmd *cobra.Command, args []string) error {
    ...
 }
 ```
-
-The plugin programming interface supports the generation of an extension command directly from a
-cobra command object using the method `NewCLICommand` from the `ppi.clicmd` package.
-Otherwise the `ppi.Command` interface  can be implemented without requiring a cobra command..
 
 If the code wants to use the config framework, for example to
 - use the OCM library again

--- a/docs/command-plugins.md
+++ b/docs/command-plugins.md
@@ -44,7 +44,7 @@ func init() {
 CLI commands are provided by the registratuon interface `ppi.Command`. It
 provides some command metadata and a `cobra.Command` object.
 
-Commands are then registered at the plugin object with
+Commands are then registered at the plugin object with:
 
 ```go
     p.RegisterCommand(cmd)
@@ -55,7 +55,7 @@ The plugin programming interface supports the generation of an extension command
 It takes some options to specify the command embedding and extracts the other command attributes
 directly from the preconfigured cobra command.
 
-Otherwise, the `ppi.Command` interface  can be implemented without requiring a cobra command..
+Otherwise, the `ppi.Command` interface  can be implemented without requiring a cobra command.
 
 A sample code could look like this:
 

--- a/pkg/contexts/ocm/plugin/cache/plugin.go
+++ b/pkg/contexts/ocm/plugin/cache/plugin.go
@@ -11,7 +11,7 @@ type Plugin = *pluginImpl
 // //nolint: errname // is no error.
 type pluginImpl struct {
 	name        string
-	source      *PluginInstallationInfo
+	info        *PluginInstallationInfo
 	descriptor  *descriptor.Descriptor
 	path        string
 	error       string
@@ -36,8 +36,14 @@ func NewPlugin(name string, path string, desc *descriptor.Descriptor, errmsg str
 	return p
 }
 
-func (p *pluginImpl) GetInstallationInfo() *PluginInstallationInfo {
-	return p.source
+func (p *pluginImpl) GetSourceInfo() *PluginSourceInfo {
+	if p.info == nil {
+		return nil
+	}
+	if p.info.HasSourceInfo() {
+		return &p.info.PluginSourceInfo
+	}
+	return nil
 }
 
 func (p *pluginImpl) GetDescriptor() *descriptor.Descriptor {

--- a/pkg/contexts/ocm/plugin/cache/plugindir.go
+++ b/pkg/contexts/ocm/plugin/cache/plugindir.go
@@ -62,7 +62,7 @@ func (c *pluginDirImpl) add(name string, desc *descriptor.Descriptor, path strin
 			return
 		}
 
-		c.plugins[name].source = src
+		c.plugins[name].info = src
 	}
 	if errmsg != "" && list != nil {
 		list.Add(fmt.Errorf("%s: %s", name, errmsg))

--- a/pkg/contexts/ocm/plugin/cache/updater.go
+++ b/pkg/contexts/ocm/plugin/cache/updater.go
@@ -41,20 +41,24 @@ type PluginSourceInfo struct {
 	Resource   string                     `json:"resource,omitempty"`
 }
 
-type PluginInstallationInfo struct {
-	PluginSourceInfo `json:",inline"`
-	PluginInfo       *PluginInfo `json:"info,omitempty"`
+func (p *PluginSourceInfo) HasSourceInfo() bool {
+	return p != nil && p.Repository != nil && p.Component != "" && p.Version != "" && p.Resource != ""
 }
 
-func (p *PluginInstallationInfo) GetInstallationSourceDescription() string {
+func (p *PluginSourceInfo) GetDescription() string {
 	if p != nil && p.HasSourceInfo() {
 		return p.Component + ":" + p.Version
 	}
 	return "local"
 }
 
+type PluginInstallationInfo struct {
+	PluginSourceInfo `json:",inline"`
+	PluginInfo       *PluginInfo `json:"info,omitempty"`
+}
+
 func (p *PluginInstallationInfo) HasSourceInfo() bool {
-	return p.Repository != nil && p.Component != "" && p.Version != "" && p.Resource != ""
+	return p != nil && p.PluginSourceInfo.HasSourceInfo()
 }
 
 func (p *PluginInstallationInfo) IsValidPluginInfo(execpath string) bool {

--- a/pkg/contexts/ocm/plugin/ppi/cmds/command/cmd.go
+++ b/pkg/contexts/ocm/plugin/ppi/cmds/command/cmd.go
@@ -35,9 +35,14 @@ described by an access method descriptor (<CMD>` + p.Name() + ` descriptor</CMD>
 
 		nested := c.PreRunE
 		c.PreRunE = func(cmd *cobra.Command, args []string) error {
-			ctx, err := ConfigureFromFile(context.Background(), cliconfig)
-			if err != nil {
-				return err
+			var err error
+
+			ctx := context.Background()
+			if cliconfig != "" {
+				ctx, err = ConfigureFromFile(ctx, cliconfig)
+				if err != nil {
+					return err
+				}
 			}
 			c.SetContext(ctx)
 			if nested != nil {


### PR DESCRIPTION
#### What this PR does / why we need it:

Rework the plugin client interface to grant access to the source info without exposing the complete internal cache information.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
