### PR TITLE
fix duplicate command argument for plugin command execution

### DIFF
--- a/pkg/contexts/ocm/plugin/plugin.go
+++ b/pkg/contexts/ocm/plugin/plugin.go
@@ -451,7 +451,7 @@ func (p *pluginImpl) Command(name string, reader io.Reader, writer io.Writer, cm
 		if err != nil {
 			return err
 		}
-		args = append(args, "--"+command.OptCliConfig, f.Name(), name)
+		args = append(args, "--"+command.OptCliConfig, f.Name())
 	}
 	args = append(append(args, name), cmdargs...)
 


### PR DESCRIPTION
#### What this PR does / why we need it:

During execution of CLI command extensions the command name ist used twice as argument for calling the plugin.