### PR TITLE
Extend version regexp to support semver

### DIFF
--- a/cmds/demoplugin/valuesets/check_test.go
+++ b/cmds/demoplugin/valuesets/check_test.go
@@ -32,7 +32,6 @@ var _ = Describe("demoplugin", func() {
 		var plugins TempPluginDir
 
 		BeforeEach(func() {
-
 			env = NewBuilder(TestData())
 			plugins = Must(ConfigureTestPlugins(env, "testdata"))
 

--- a/pkg/cobrautils/logopts/options_test.go
+++ b/pkg/cobrautils/logopts/options_test.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 
 	. "github.com/mandelsoft/goutils/testutils"
-	"github.com/mandelsoft/logging"
-	"github.com/mandelsoft/logging/config"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/mandelsoft/logging"
+	"github.com/mandelsoft/logging/config"
 	"sigs.k8s.io/yaml"
 
 	"github.com/open-component-model/ocm/pkg/contexts/clictx"

--- a/pkg/contexts/ocm/accessmethods/plugin/cmd_test.go
+++ b/pkg/contexts/ocm/accessmethods/plugin/cmd_test.go
@@ -4,7 +4,6 @@ import (
 	. "github.com/mandelsoft/goutils/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/plugins"
 	. "github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/testutils"
 	. "github.com/open-component-model/ocm/pkg/env"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/open-component-model/ocm/pkg/cobrautils/flagsets"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/accessmethods/options"
+	"github.com/open-component-model/ocm/pkg/contexts/ocm/plugin/plugins"
 	"github.com/open-component-model/ocm/pkg/contexts/ocm/registration"
 )
 

--- a/pkg/contexts/ocm/grammar/grammar.go
+++ b/pkg/contexts/ocm/grammar/grammar.go
@@ -20,7 +20,7 @@ var (
 
 	VersionRegexp = Sequence(Optional(Literal("v")), Numeric, Repetition(0, 2, Literal("."), Numeric),
 		Optional(Literal("-"), Repeated(CharSet("0-9A-Za-z-")), OptionalRepeated(Literal("."), Repeated(CharSet("0-9A-Za-z-")))),
-		Optional(Literal("+"), Repeated(CharSet("0-9A-Za-z-"))),
+		Optional(Literal("+"), Repeated(CharSet("0-9A-Za-z-"))), OptionalRepeated(Literal("."), Repeated(CharSet("0-9A-Za-z-"))),
 	)
 
 	// AnchoredRepositoryRegexp parses a uniform repository spec.

--- a/pkg/contexts/ocm/grammar/grammar_test.go
+++ b/pkg/contexts/ocm/grammar/grammar_test.go
@@ -79,7 +79,7 @@ var _ = Describe("ref matching", func() {
 		})
 	})
 
-	Context("versions", func() {
+	FContext("versions", func() {
 		It("matches versions", func() {
 			Expect(VersionRegexp.MatchString("v1.1.1")).To(BeTrue())
 			Expect(VersionRegexp.MatchString("v1")).To(BeTrue())
@@ -90,6 +90,14 @@ var _ = Describe("ref matching", func() {
 			Expect(VersionRegexp.MatchString("v1.1.1-rc.1")).To(BeTrue())
 			Expect(VersionRegexp.MatchString("v1-rc.1")).To(BeTrue())
 			Expect(VersionRegexp.MatchString("1.1.1-rc.1")).To(BeTrue())
+		})
+
+		It("matches complex semver", func() {
+			Expect(VersionRegexp.MatchString("0.2.3+2024.T06b")).To(BeTrue())
+		})
+
+		It("matches complex semver with v prefix", func() {
+			Expect(VersionRegexp.MatchString("v0.2.3+2024.T06b")).To(BeTrue())
 		})
 	})
 

--- a/pkg/contexts/ocm/grammar/grammar_test.go
+++ b/pkg/contexts/ocm/grammar/grammar_test.go
@@ -79,7 +79,7 @@ var _ = Describe("ref matching", func() {
 		})
 	})
 
-	FContext("versions", func() {
+	Context("versions", func() {
 		It("matches versions", func() {
 			Expect(VersionRegexp.MatchString("v1.1.1")).To(BeTrue())
 			Expect(VersionRegexp.MatchString("v1")).To(BeTrue())

--- a/pkg/contexts/ocm/grammar/grammar_test.go
+++ b/pkg/contexts/ocm/grammar/grammar_test.go
@@ -1,19 +1,16 @@
 package grammar
 
 import (
+	"fmt"
 	"regexp"
-	"testing"
 
+	. "github.com/mandelsoft/goutils/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/Masterminds/semver/v3"
 	gr "github.com/mandelsoft/goutils/regexutils"
 )
-
-func TestConfig(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "OCI Test Suite")
-}
 
 func CheckRef(ref string, parts ...string) {
 	CheckWithOffset(1, ref, AnchoredReferenceRegexp, parts...)
@@ -99,6 +96,23 @@ var _ = Describe("ref matching", func() {
 		It("matches complex semver with v prefix", func() {
 			Expect(VersionRegexp.MatchString("v0.2.3+2024.T06b")).To(BeTrue())
 		})
+
+		for _, pre := range []string{"", "alpha1", "alpha.1.2", "alpha-1"} {
+			for _, build := range []string{"", "2024", "2024.1.T2b", "2024.1-T2b"} {
+				suf := ""
+				if pre != "" {
+					suf += "-" + pre
+				}
+				if build != "" {
+					suf += "+" + build
+				}
+				It(fmt.Sprintf("handles semver %s", suf), func() {
+					v := "v0.2.3" + suf
+					Must(semver.NewVersion(v))
+					Expect(VersionRegexp.MatchString(v)).To(BeTrue())
+				})
+			}
+		}
 	})
 
 	Context("complete refs", func() {

--- a/pkg/contexts/ocm/grammar/suite_test.go
+++ b/pkg/contexts/ocm/grammar/suite_test.go
@@ -1,0 +1,13 @@
+package grammar
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OCM grammar Test Suite")
+}

--- a/pkg/filelock/lock_test.go
+++ b/pkg/filelock/lock_test.go
@@ -8,12 +8,12 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/mandelsoft/filepath/pkg/filepath"
+
 	"github.com/open-component-model/ocm/pkg/filelock"
 )
 
 var _ = Describe("lock identity", func() {
 	It("identity", func() {
-
 		l1 := Must(filelock.MutexFor("testdata/lock"))
 		l2 := Must(filelock.MutexFor("testdata/../testdata/lock"))
 		Expect(l1).To(BeIdenticalTo(l2))
@@ -32,5 +32,4 @@ var _ = Describe("lock identity", func() {
 		Expect(c).NotTo(BeNil())
 		c.Close()
 	})
-
 })


### PR DESCRIPTION
#### What this PR does / why we need it:
Users created components with complex semver versions (e.g. 0.2.3+2024.T06b). This lead to problems, for example when calling `ocm get references ./registry//github.com/acme.org/helloworld:0.2.3+2024.T06b`.

This PR extends the version regex used by ocm to also support such complex semver version numbers.
