### PR TITLE
Add AUR as installation option for OCM-CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Install the latest release from any of
 
 - [Homebrew](https://brew.sh)
 - [Nix](https://nixos.org)
+- [AUR](https://aur.archlinux.org/packages/ocm-cli)
 - [Docker](https://www.docker.com/)
 - [Podman](https://podman.io/)
 - [GitHub Releases](https://github.com/open-component-model/ocm/releases)
@@ -91,6 +92,20 @@ nix profile list | grep ocm
 # optionally, open a new shell and verify that cmd completion works
 ocm --help
 ```
+
+### Install from AUR (Arch Linux User Repository)
+
+git-url: https://aur.archlinux.org/ocm-cli.git
+package-url: https://aur.archlinux.org/packages/ocm-cli
+
+```
+# if not using a helper util
+git clone https://aur.archlinux.org/ocm-cli.git
+cd ocm-cli
+makepkg -i
+```
+
+[AUR Documentation](https://wiki.archlinux.org/title/Arch_User_Repository)
 
 ### Usage via Docker / Podman
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,13 @@ The OCI and OCM support can be found in packages
 
 ## Installation
 
-Install the latest release via [Homebrew](https://brew.sh), [Nix](https://nixos.org), [Docker](https://www.docker.com/)/[Podman](https://podman.io/) or directly from [GitHub Releases](https://github.com/open-component-model/ocm/releases).
+Install the latest release from any of
+
+- [Homebrew](https://brew.sh)
+- [Nix](https://nixos.org)
+- [Docker](https://www.docker.com/)
+- [Podman](https://podman.io/)
+- [GitHub Releases](https://github.com/open-component-model/ocm/releases)
 
 ### Bash
 


### PR DESCRIPTION
Make OCM more convenient to consume for users of Arch Linux.

Note: there are different ways (and tools) to consume packages from AUR (hence just a reference to documentation rather than a concrete shellscript-snippet). I think it is safe to assume Arch Linux users will be able to consume packages from AUR without such help ;-)