### PR TITLE
Resource resolution on CD set

### DIFF
--- a/api/helper/builder/oci_artifactset.go
+++ b/api/helper/builder/oci_artifactset.go
@@ -1,9 +1,18 @@
 package builder
 
 import (
+	"fmt"
+	"slices"
+
+	"github.com/mandelsoft/vfs/pkg/vfs"
+
+	"ocm.software/ocm/api/oci"
+	"ocm.software/ocm/api/oci/cpi"
 	"ocm.software/ocm/api/oci/extensions/repositories/artifactset"
 	"ocm.software/ocm/api/utils/accessio"
 	"ocm.software/ocm/api/utils/accessobj"
+	"ocm.software/ocm/api/utils/blobaccess"
+	"ocm.software/ocm/api/utils/blobaccess/file"
 )
 
 const T_OCIARTIFACTSET = "artifact set"
@@ -17,4 +26,44 @@ func (b *Builder) ArtifactSet(path string, fmt accessio.FileFormat, f ...func())
 	b.configure(&ociNamespace{NamespaceAccess: r, kind: T_OCIARTIFACTSET, annofunc: func(name, value string) {
 		r.Annotate(name, value)
 	}}, f)
+}
+
+func (b *Builder) ArtifactSetBlob(main string, f ...func()) {
+	b.expect(b.blob, T_BLOBACCESS)
+	arch, err := vfs.TempFile(b.FileSystem(), "", "artifact-*.tgz")
+	b.failOn(err)
+	b.FileSystem().Remove(arch.Name())
+
+	r, err := artifactset.Open(accessobj.ACC_WRITABLE|accessobj.ACC_CREATE, arch.Name(), 0o777, accessio.FormatTGZ, accessio.PathFileSystem(b.FileSystem()))
+	b.failOn(err)
+
+	b.configure(&ociNamespace{NamespaceAccess: &artifactSink{b, arch.Name(), main, r, ""}, kind: T_OCIARTIFACTSET, annofunc: func(name, value string) {
+		r.Annotate(name, value)
+	}}, append(f, func() {
+		b.Annotation(artifactset.MAINARTIFACT_ANNOTATION, main)
+	}))
+}
+
+type artifactSink struct {
+	builder *Builder
+	arch    string
+	main    string
+	oci.NamespaceAccess
+	mime string
+}
+
+func (s *artifactSink) AddArtifact(art cpi.Artifact, tags ...string) (blobaccess.BlobAccess, error) {
+	if slices.Contains(tags, s.main) {
+		s.mime = art.Artifact().MimeType()
+	}
+	return s.NamespaceAccess.AddArtifact(art, tags...)
+}
+
+func (s *artifactSink) Close() error {
+	if s.mime == "" {
+		s.NamespaceAccess.Close()
+		return fmt.Errorf("main artifact not defined")
+	}
+	*s.builder.blob = blobaccess.ForTemporaryFilePath(artifactset.MediaType(s.mime), s.arch, file.WithFileSystem(s.builder.FileSystem()))
+	return s.NamespaceAccess.Close()
 }

--- a/api/helper/builder/ocm_reference.go
+++ b/api/helper/builder/ocm_reference.go
@@ -7,7 +7,7 @@ import (
 type ocmReference struct {
 	base
 
-	meta compdesc.ComponentReference
+	meta compdesc.Reference
 }
 
 const T_OCMREF = "reference"

--- a/api/oci/interface.go
+++ b/api/oci/interface.go
@@ -30,6 +30,7 @@ type (
 	IntermediateRepositorySpecAspect = internal.IntermediateRepositorySpecAspect
 	GenericRepositorySpec            = internal.GenericRepositorySpec
 	ArtifactAccess                   = internal.ArtifactAccess
+	Artifact                         = internal.Artifact
 	NamespaceLister                  = internal.NamespaceLister
 	NamespaceAccess                  = internal.NamespaceAccess
 	ManifestAccess                   = internal.ManifestAccess

--- a/api/ocm/compdesc/copy_test.go
+++ b/api/ocm/compdesc/copy_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Component Descripor Copy Test Suitet", func() {
 				},
 			}
 			cd.References = compdesc.References{
-				compdesc.ComponentReference{
+				compdesc.Reference{
 					ElementMeta:   compdesc.ElementMeta{},
 					ComponentName: "",
 					Digest:        nil,

--- a/api/ocm/compdesc/default.go
+++ b/api/ocm/compdesc/default.go
@@ -14,7 +14,7 @@ func DefaultComponent(component *ComponentDescriptor) *ComponentDescriptor {
 		component.Sources = make([]Source, 0)
 	}
 	if component.References == nil {
-		component.References = make([]ComponentReference, 0)
+		component.References = make([]Reference, 0)
 	}
 	if component.Resources == nil {
 		component.Resources = make([]Resource, 0)

--- a/api/ocm/compdesc/deprecated.go
+++ b/api/ocm/compdesc/deprecated.go
@@ -200,8 +200,8 @@ func (cd *ComponentDescriptor) GetSourcesByName(name string, selectors ...Identi
 // GetComponentReferences returns all component references that matches the given selectors.
 //
 // Deprectated: use GetReferences with appropriate selectors.
-func (cd *ComponentDescriptor) GetComponentReferences(selectors ...IdentitySelector) ([]ComponentReference, error) {
-	refs := make([]ComponentReference, 0)
+func (cd *ComponentDescriptor) GetComponentReferences(selectors ...IdentitySelector) ([]Reference, error) {
+	refs := make([]Reference, 0)
 	for _, ref := range cd.References {
 		ok, err := selector.MatchSelectors(ref.GetIdentity(cd.References), selectors...)
 		if err != nil {
@@ -220,13 +220,13 @@ func (cd *ComponentDescriptor) GetComponentReferences(selectors ...IdentitySelec
 // GetComponentReferenceIndex returns the index of a given component reference.
 // If the index is not found -1 is returned.
 // Deprecated: use GetReferenceIndex.
-func (cd *ComponentDescriptor) GetComponentReferenceIndex(ref ComponentReference) int {
+func (cd *ComponentDescriptor) GetComponentReferenceIndex(ref Reference) int {
 	return cd.GetReferenceIndex(ref.GetMeta())
 }
 
 // GetReferenceAccessByIdentity returns a pointer to the reference that matches the given identity.
 // Deprectated: use GetReferenceByIdentity.
-func (cd *ComponentDescriptor) GetReferenceAccessByIdentity(id v1.Identity) *ComponentReference {
+func (cd *ComponentDescriptor) GetReferenceAccessByIdentity(id v1.Identity) *Reference {
 	dig := id.Digest()
 	for i, ref := range cd.References {
 		if bytes.Equal(ref.GetIdentityDigest(cd.Resources), dig) {
@@ -270,7 +270,7 @@ func (cd *ComponentDescriptor) GetReferencesBySelectors(selectors []IdentitySele
 		if !ok {
 			continue
 		}
-		references = append(references, *selctx.ComponentReference)
+		references = append(references, *selctx.Reference)
 	}
 	if len(references) == 0 {
 		return references, NotFound

--- a/api/ocm/compdesc/equal_test.go
+++ b/api/ocm/compdesc/equal_test.go
@@ -487,10 +487,10 @@ var _ = Describe("equivalence", func() {
 	})
 
 	Context("reference", func() {
-		var a, b *compdesc.ComponentReference
+		var a, b *compdesc.Reference
 
 		BeforeEach(func() {
-			a = &compdesc.ComponentReference{
+			a = &compdesc.Reference{
 				ElementMeta: compdesc.ElementMeta{
 					Name:    "r1",
 					Version: "v1",
@@ -536,7 +536,7 @@ var _ = Describe("equivalence", func() {
 
 		BeforeEach(func() {
 			a = compdesc.References{
-				compdesc.ComponentReference{
+				compdesc.Reference{
 					ElementMeta: compdesc.ElementMeta{
 						Name:    "s1",
 						Version: "v1",
@@ -544,7 +544,7 @@ var _ = Describe("equivalence", func() {
 					},
 					ComponentName: "c1",
 				},
-				compdesc.ComponentReference{
+				compdesc.Reference{
 					ElementMeta: compdesc.ElementMeta{
 						Name:    "s2",
 						Version: "v1",
@@ -583,7 +583,7 @@ var _ = Describe("equivalence", func() {
 		})
 
 		It("handles additional entry", func() {
-			b = append(b, compdesc.ComponentReference{
+			b = append(b, compdesc.Reference{
 				ElementMeta: compdesc.ElementMeta{
 					Name:          "s3",
 					ExtraIdentity: compdesc.NewExtraIdentity("platform", "linux"),
@@ -596,7 +596,7 @@ var _ = Describe("equivalence", func() {
 		})
 
 		It("handles additional entry without any other metadata", func() {
-			b = append(b, compdesc.ComponentReference{
+			b = append(b, compdesc.Reference{
 				ElementMeta: compdesc.ElementMeta{
 					Name:          "s3",
 					ExtraIdentity: compdesc.NewExtraIdentity("platform", "linux"),
@@ -608,7 +608,7 @@ var _ = Describe("equivalence", func() {
 		})
 
 		It("handles additional entry without any other metadata", func() {
-			b = append(b, compdesc.ComponentReference{
+			b = append(b, compdesc.Reference{
 				ElementMeta: compdesc.ElementMeta{
 					Name:          "s3",
 					ExtraIdentity: compdesc.NewExtraIdentity("platform", "linux"),

--- a/api/ocm/compdesc/generic.go
+++ b/api/ocm/compdesc/generic.go
@@ -1,0 +1,31 @@
+package compdesc
+
+import (
+	"encoding/json"
+
+	"github.com/mandelsoft/goutils/generics"
+)
+
+type GenericComponentDescriptor ComponentDescriptor
+
+var (
+	_ json.Marshaler   = (*GenericComponentDescriptor)(nil)
+	_ json.Unmarshaler = (*GenericComponentDescriptor)(nil)
+)
+
+func (g GenericComponentDescriptor) MarshalJSON() ([]byte, error) {
+	return Encode(generics.Pointer(ComponentDescriptor(g)))
+}
+
+func (g *GenericComponentDescriptor) UnmarshalJSON(bytes []byte) error {
+	cd, err := Decode(bytes)
+	if err != nil {
+		return err
+	}
+	*g = *((*GenericComponentDescriptor)(cd))
+	return nil
+}
+
+func (g *GenericComponentDescriptor) Descriptor() *ComponentDescriptor {
+	return (*ComponentDescriptor)(g)
+}

--- a/api/ocm/compdesc/generic.go
+++ b/api/ocm/compdesc/generic.go
@@ -14,11 +14,11 @@ var (
 )
 
 func (g GenericComponentDescriptor) MarshalJSON() ([]byte, error) {
-	return Encode(generics.Pointer(ComponentDescriptor(g)))
+	return Encode(generics.Pointer(ComponentDescriptor(g)), DefaultJSONCodec)
 }
 
 func (g *GenericComponentDescriptor) UnmarshalJSON(bytes []byte) error {
-	cd, err := Decode(bytes)
+	cd, err := Decode(bytes, DefaultJSONCodec)
 	if err != nil {
 		return err
 	}

--- a/api/ocm/compdesc/helper.go
+++ b/api/ocm/compdesc/helper.go
@@ -175,24 +175,24 @@ func (cd *ComponentDescriptor) GetSourceIndex(src *SourceMeta) int {
 }
 
 // GetReferenceByIdentity returns reference that matches the given identity.
-func (cd *ComponentDescriptor) GetReferenceByIdentity(id v1.Identity) (ComponentReference, error) {
+func (cd *ComponentDescriptor) GetReferenceByIdentity(id v1.Identity) (Reference, error) {
 	dig := id.Digest()
 	for _, ref := range cd.References {
 		if bytes.Equal(ref.GetIdentityDigest(cd.Resources), dig) {
 			return ref, nil
 		}
 	}
-	return ComponentReference{}, errors.ErrNotFound(KIND_REFERENCE, id.String())
+	return Reference{}, errors.ErrNotFound(KIND_REFERENCE, id.String())
 }
 
-func (cd *ComponentDescriptor) SelectReferences(sel ...refsel.Selector) ([]ComponentReference, error) {
+func (cd *ComponentDescriptor) SelectReferences(sel ...refsel.Selector) ([]Reference, error) {
 	err := selectors.ValidateSelectors(sel...)
 	if err != nil {
 		return nil, err
 	}
 
 	list := MapToSelectorElementList(cd.References)
-	result := []ComponentReference{}
+	result := []Reference{}
 	for _, r := range cd.References {
 		if len(sel) > 0 {
 			mr := MapToSelectorReference(&r)
@@ -207,8 +207,8 @@ func (cd *ComponentDescriptor) SelectReferences(sel ...refsel.Selector) ([]Compo
 	return result, nil
 }
 
-func (cd *ComponentDescriptor) GetReferences() []ComponentReference {
-	result := []ComponentReference{}
+func (cd *ComponentDescriptor) GetReferences() []Reference {
+	result := []Reference{}
 	for _, r := range cd.References {
 		result = append(result, r)
 	}

--- a/api/ocm/compdesc/helper_test.go
+++ b/api/ocm/compdesc/helper_test.go
@@ -281,7 +281,7 @@ var _ = Describe("helper", func() {
 	Context("reference selection", func() {
 		cd := &compdesc.ComponentDescriptor{}
 
-		r1v1 := compdesc.ComponentReference{
+		r1v1 := compdesc.Reference{
 			ElementMeta: compdesc.ElementMeta{
 				Name:    "r1",
 				Version: "v1",
@@ -296,14 +296,14 @@ var _ = Describe("helper", func() {
 			},
 			ComponentName: "c1",
 		}
-		r1v2 := compdesc.ComponentReference{
+		r1v2 := compdesc.Reference{
 			ElementMeta: compdesc.ElementMeta{
 				Name:    "r1",
 				Version: "v2",
 			},
 			ComponentName: "c1",
 		}
-		r2v1 := compdesc.ComponentReference{
+		r2v1 := compdesc.Reference{
 			ElementMeta: compdesc.ElementMeta{
 				Name:    "r2",
 				Version: "v1",
@@ -318,7 +318,7 @@ var _ = Describe("helper", func() {
 			},
 			ComponentName: "c2",
 		}
-		r3v2 := compdesc.ComponentReference{
+		r3v2 := compdesc.Reference{
 			ElementMeta: compdesc.ElementMeta{
 				Name:    "r3",
 				Version: "v2",
@@ -345,7 +345,7 @@ var _ = Describe("helper", func() {
 			ComponentName: "c3",
 		}
 
-		r4v3 := compdesc.ComponentReference{
+		r4v3 := compdesc.Reference{
 			ElementMeta: compdesc.ElementMeta{
 				Name:    "r4",
 				Version: "v3",

--- a/api/ocm/compdesc/meta/v1/identity.go
+++ b/api/ocm/compdesc/meta/v1/identity.go
@@ -103,6 +103,22 @@ func (i Identity) Remove(name string) bool {
 	return false
 }
 
+// ExtraIdentity extracts the extra identity part of an identity.
+func (i Identity) ExtraIdentity() Identity {
+	if i == nil {
+		return nil
+	}
+	if _, ok := i[SystemIdentityName]; !ok {
+		return i
+	}
+	if len(i) == 1 {
+		return nil
+	}
+	r := i.Copy()
+	delete(r, SystemIdentityName)
+	return r
+}
+
 func (i Identity) String() string {
 	if i == nil {
 		return ""

--- a/api/ocm/compdesc/resolver.go
+++ b/api/ocm/compdesc/resolver.go
@@ -92,5 +92,8 @@ func (c *CompoundResolver) LookupComponentVersion(name string, version string) (
 func (c *CompoundResolver) AddResolver(r ComponentVersionResolver) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	c.resolvers = append(c.resolvers, r)
+
+	if r != nil {
+		c.resolvers = append(c.resolvers, r)
+	}
 }

--- a/api/ocm/compdesc/resolver.go
+++ b/api/ocm/compdesc/resolver.go
@@ -1,0 +1,96 @@
+package compdesc
+
+import (
+	"sync"
+
+	"github.com/mandelsoft/goutils/errors"
+
+	common "ocm.software/ocm/api/utils/misc"
+)
+
+type ComponentVersionResolver interface {
+	LookupComponentVersion(name string, version string) (*ComponentDescriptor, error)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+type ComponentVersionSet struct {
+	lock sync.RWMutex
+	cds  map[common.NameVersion]*ComponentDescriptor
+}
+
+var _ ComponentVersionResolver = (*ComponentVersionSet)(nil)
+
+func NewComponentVersionSet(cds ...*ComponentDescriptor) *ComponentVersionSet {
+	r := map[common.NameVersion]*ComponentDescriptor{}
+	for _, cd := range cds {
+		r[common.NewNameVersion(cd.Name, cd.Version)] = cd.Copy()
+	}
+	return &ComponentVersionSet{cds: r}
+}
+
+func (c *ComponentVersionSet) LookupComponentVersion(name string, version string) (*ComponentDescriptor, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	nv := common.NewNameVersion(name, version)
+
+	cd := c.cds[nv]
+	if cd == nil {
+		return nil, errors.ErrNotFound(KIND_COMPONENTVERSION, nv.String())
+	}
+	return cd, nil
+}
+
+func (c *ComponentVersionSet) AddVersion(cd *ComponentDescriptor) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	c.cds[common.NewNameVersion(cd.Name, cd.Version)] = cd.Copy()
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+type CompoundResolver struct {
+	lock      sync.RWMutex
+	resolvers []ComponentVersionResolver
+}
+
+var _ ComponentVersionResolver = (*CompoundResolver)(nil)
+
+func NewCompoundResolver(res ...ComponentVersionResolver) ComponentVersionResolver {
+	for i := 0; i < len(res); i++ {
+		if res[i] == nil {
+			res = append(res[:i], res[i+1:]...)
+			i--
+		}
+	}
+	if len(res) == 1 {
+		return res[0]
+	}
+	return &CompoundResolver{resolvers: res}
+}
+
+func (c *CompoundResolver) LookupComponentVersion(name string, version string) (*ComponentDescriptor, error) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	for _, r := range c.resolvers {
+		if r == nil {
+			continue
+		}
+		cv, err := r.LookupComponentVersion(name, version)
+		if err == nil && cv != nil {
+			return cv, nil
+		}
+		if !errors.IsErrNotFoundKind(err, KIND_COMPONENTVERSION) && !errors.IsErrNotFoundKind(err, KIND_COMPONENT) {
+			return nil, err
+		}
+	}
+	return nil, errors.ErrNotFound(KIND_REFERENCE, common.NewNameVersion(name, version).String())
+}
+
+func (c *CompoundResolver) AddResolver(r ComponentVersionResolver) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.resolvers = append(c.resolvers, r)
+}

--- a/api/ocm/compdesc/resourceref.go
+++ b/api/ocm/compdesc/resourceref.go
@@ -1,0 +1,85 @@
+package compdesc
+
+import (
+	"fmt"
+
+	"github.com/mandelsoft/goutils/errors"
+
+	metav1 "ocm.software/ocm/api/ocm/compdesc/meta/v1"
+	common "ocm.software/ocm/api/utils/misc"
+)
+
+func ResolveReferencePath(cv *ComponentDescriptor, path []metav1.Identity, resolver ComponentVersionResolver) (*ComponentDescriptor, error) {
+	if cv == nil {
+		return nil, fmt.Errorf("no component version specified")
+	}
+
+	eff := cv
+	for _, cr := range path {
+		cref, err := eff.GetReferenceByIdentity(cr)
+		if err != nil {
+			return nil, errors.Wrapf(err, "%s", common.VersionedElementKey(cv))
+		}
+
+		compoundResolver := NewCompoundResolver(NewComponentVersionSet(cv), resolver)
+		eff, err = compoundResolver.LookupComponentVersion(cref.GetComponentName(), cref.GetVersion())
+		if err != nil {
+			return nil, errors.Wrapf(err, "cannot resolve component version for reference %s", cr.String())
+		}
+		if eff == nil {
+			return nil, errors.ErrNotFound(KIND_COMPONENTVERSION, cref.String())
+		}
+	}
+	return eff, nil
+}
+
+func MatchResourceReference(cv *ComponentDescriptor, typ string, ref metav1.ResourceReference, resolver ComponentVersionResolver) (*Resource, *ComponentDescriptor, error) {
+	eff, err := ResolveReferencePath(cv, ref.ReferencePath, resolver)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(eff.Resources) == 0 && len(ref.Resource) == 0 {
+		return nil, nil, errors.ErrNotFound(KIND_RESOURCE)
+	}
+outer:
+	for i, r := range eff.Resources {
+		if r.Type != typ && typ != "" {
+			continue
+		}
+		for k, v := range ref.Resource {
+			switch k {
+			case metav1.SystemIdentityName:
+				if v != r.Name {
+					continue outer
+				}
+			case metav1.SystemIdentityVersion:
+				if v != r.Version {
+					continue outer
+				}
+			default:
+				if r.ExtraIdentity == nil || r.ExtraIdentity[k] != v {
+					continue outer
+				}
+			}
+		}
+		return &eff.Resources[i], eff, nil
+	}
+	return nil, nil, errors.ErrNotFound(KIND_RESOURCE, ref.Resource.String())
+}
+
+func ResolveResourceReference(cv *ComponentDescriptor, ref metav1.ResourceReference, resolver ComponentVersionResolver) (*Resource, *ComponentDescriptor, error) {
+	if len(ref.Resource) == 0 || len(ref.Resource["name"]) == 0 {
+		return nil, nil, errors.Newf("at least resource name must be specified for resource reference")
+	}
+
+	eff, err := ResolveReferencePath(cv, ref.ReferencePath, resolver)
+	if err != nil {
+		return nil, nil, err
+	}
+	r, err := eff.GetResourceByIdentity(ref.Resource)
+	if err != nil {
+		return nil, nil, err
+	}
+	return &r, eff, nil
+}

--- a/api/ocm/compdesc/resourceref_test.go
+++ b/api/ocm/compdesc/resourceref_test.go
@@ -1,0 +1,143 @@
+package compdesc_test
+
+import (
+	. "github.com/mandelsoft/goutils/testutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"ocm.software/ocm/api/ocm/compdesc"
+	metav1 "ocm.software/ocm/api/ocm/compdesc/meta/v1"
+)
+
+const (
+	VERSION    = "v1"
+	COMPONENT  = "github.com/mandelsoft/test"
+	COMPONENT2 = "github.com/mandelsoft/test2"
+	COMPONENT3 = "github.com/mandelsoft/test3"
+
+	EXTRA_ATTR = "platform"
+	EXTRA_VAL  = "test"
+)
+
+func CheckResourceRef(cv *compdesc.ComponentDescriptor, resolver compdesc.ComponentVersionResolver, comp string, rsc metav1.Identity, path ...metav1.Identity) {
+	ref := metav1.NewNestedResourceRef(rsc, path)
+
+	r, cd := Must2(compdesc.ResolveResourceReference(cv, ref, resolver))
+	ExpectWithOffset(1, r).NotTo(BeNil())
+	ExpectWithOffset(1, cd).NotTo(BeNil())
+
+	ExpectWithOffset(1, cd.Name).To(Equal(comp))
+	ExpectWithOffset(1, r.Name).To(Equal(rsc.Get(compdesc.SystemIdentityName)))
+	ExpectWithOffset(1, r.ExtraIdentity).To(Equal(rsc.ExtraIdentity()))
+}
+
+var _ = Describe("resolving local resource references", func() {
+	var set *compdesc.ComponentVersionSet
+
+	BeforeEach(func() {
+		set = compdesc.NewComponentVersionSet()
+
+		cd := compdesc.New(COMPONENT, VERSION)
+		cd.Resources = append(cd.Resources, compdesc.Resource{
+			ResourceMeta: compdesc.ResourceMeta{
+				ElementMeta: compdesc.ElementMeta{
+					Name:    "testata",
+					Version: "",
+				},
+				Type:     "PlainText",
+				Relation: metav1.LocalRelation,
+			},
+		})
+		set.AddVersion(cd)
+
+		cd = compdesc.New(COMPONENT2, VERSION)
+		cd.Resources = append(cd.Resources, compdesc.Resource{
+			ResourceMeta: compdesc.ResourceMeta{
+				ElementMeta: compdesc.ElementMeta{
+					Name:    "otherdata",
+					Version: "",
+				},
+				Type:     "PlainText",
+				Relation: metav1.LocalRelation,
+			},
+		})
+		cd.Resources = append(cd.Resources, compdesc.Resource{
+			ResourceMeta: compdesc.ResourceMeta{
+				ElementMeta: compdesc.ElementMeta{
+					Name:          "otherdata",
+					Version:       "",
+					ExtraIdentity: metav1.NewExtraIdentity(EXTRA_ATTR, EXTRA_VAL),
+				},
+				Type:     "PlainText",
+				Relation: metav1.LocalRelation,
+			},
+		})
+		cd.References = append(cd.References, compdesc.Reference{
+			ElementMeta: compdesc.ElementMeta{
+				Name:    "ref",
+				Version: VERSION,
+			},
+			ComponentName: COMPONENT,
+		})
+		set.AddVersion(cd)
+
+		cd = compdesc.New(COMPONENT3, VERSION)
+		cd.Resources = append(cd.Resources, compdesc.Resource{
+			ResourceMeta: compdesc.ResourceMeta{
+				ElementMeta: compdesc.ElementMeta{
+					Name:    "topdata",
+					Version: "",
+				},
+				Type:     "PlainText",
+				Relation: metav1.LocalRelation,
+			},
+		})
+		cd.References = append(cd.References, compdesc.Reference{
+			ElementMeta: compdesc.ElementMeta{
+				Name:    "nested",
+				Version: VERSION,
+			},
+			ComponentName: COMPONENT2,
+		})
+		cd.References = append(cd.References, compdesc.Reference{
+			ElementMeta: compdesc.ElementMeta{
+				Name:          "nested",
+				Version:       VERSION,
+				ExtraIdentity: metav1.NewExtraIdentity(EXTRA_ATTR, EXTRA_VAL),
+			},
+			ComponentName: COMPONENT2,
+		})
+		set.AddVersion(cd)
+	})
+
+	It("resolves a direct local resource", func() {
+		CheckResourceRef(Must(set.LookupComponentVersion(COMPONENT3, VERSION)), set, COMPONENT3, metav1.NewIdentity("topdata"))
+	})
+
+	It("resolves an indirect resource", func() {
+		CheckResourceRef(Must(set.LookupComponentVersion(COMPONENT3, VERSION)), set, COMPONENT2, metav1.NewIdentity("otherdata"), metav1.NewIdentity("nested"))
+	})
+	It("resolves an indirect resource with extra id", func() {
+		CheckResourceRef(Must(set.LookupComponentVersion(COMPONENT3, VERSION)), set, COMPONENT2, metav1.NewIdentity("otherdata", EXTRA_ATTR, EXTRA_VAL), metav1.NewIdentity("nested"))
+	})
+
+	It("fails resolving an indirect resource with non existing extra id", func() {
+		ref := metav1.NewNestedResourceRef(metav1.NewIdentity("otherdata", EXTRA_ATTR, "dummy"), []metav1.Identity{metav1.NewIdentity("nested")})
+		ExpectError(compdesc.ResolveResourceReference(Must(set.LookupComponentVersion(COMPONENT3, VERSION)), ref, set)).To(
+			MatchError("not found"))
+	})
+
+	It("skips an intermediate component version", func() {
+		CheckResourceRef(Must(set.LookupComponentVersion(COMPONENT3, VERSION)), set, COMPONENT, metav1.NewIdentity("testata"), metav1.NewIdentity("nested"), metav1.NewIdentity("ref"))
+	})
+
+	It("skips an intermediate component version with extra id", func() {
+		CheckResourceRef(Must(set.LookupComponentVersion(COMPONENT3, VERSION)), set, COMPONENT, metav1.NewIdentity("testata"), metav1.NewIdentity("nested", EXTRA_ATTR, EXTRA_VAL), metav1.NewIdentity("ref"))
+	})
+
+	It("fails resolving an indirect resource with non existing intermediate ref", func() {
+		ref := metav1.NewNestedResourceRef(metav1.NewIdentity("testdata"), []metav1.Identity{metav1.NewIdentity("nested", EXTRA_ATTR, "dummy")})
+		ExpectError(compdesc.ResolveResourceReference(Must(set.LookupComponentVersion(COMPONENT3, VERSION)), ref, set)).To(
+			MatchError("github.com/mandelsoft/test3:v1: component reference \"\"name\"=\"nested\",\"platform\"=\"dummy\"\" not found"))
+	})
+})

--- a/api/ocm/compdesc/selector.go
+++ b/api/ocm/compdesc/selector.go
@@ -49,13 +49,13 @@ func MapToSelectorSource(r *Source) accessors.SourceAccessor {
 ////////////////////////////////////////////////////////////////////////////////
 
 type refAcc struct {
-	*ComponentReference
+	*Reference
 }
 
 func (a refAcc) GetMeta() accessors.ElementMeta {
-	return a.ComponentReference.GetMeta()
+	return a.Reference.GetMeta()
 }
 
-func MapToSelectorReference(r *ComponentReference) accessors.ReferenceAccessor {
+func MapToSelectorReference(r *Reference) accessors.ReferenceAccessor {
 	return refAcc{r}
 }

--- a/api/ocm/compdesc/selectors.go
+++ b/api/ocm/compdesc/selectors.go
@@ -589,14 +589,14 @@ func (s ReferenceSelectorFunc) MatchReference(obj ReferenceSelectionContext) (bo
 }
 
 type referenceSelectionContext struct {
-	*ComponentReference
+	*Reference
 	identity
 }
 
 // Deprecated: use package selectors and its sub packages.
 func NewReferenceSelectionContext(index int, refs References) ReferenceSelectionContext {
 	return &referenceSelectionContext{
-		ComponentReference: &refs[index],
+		Reference: &refs[index],
 		identity: identity{
 			accessor: refs,
 			index:    index,

--- a/api/ocm/compdesc/versions/ocm.software/v3alpha1/version.go
+++ b/api/ocm/compdesc/versions/ocm.software/v3alpha1/version.go
@@ -91,8 +91,8 @@ func (v *DescriptorVersion) ConvertTo(obj compdesc.ComponentDescriptorVersion) (
 	return out, nil
 }
 
-func convertReferenceTo(in Reference) compdesc.ComponentReference {
-	return compdesc.ComponentReference{
+func convertReferenceTo(in Reference) compdesc.Reference {
+	return compdesc.Reference{
 		ElementMeta:   convertElementmetaTo(in.ElementMeta),
 		ComponentName: in.ComponentName,
 		Digest:        in.Digest.Copy(),
@@ -212,7 +212,7 @@ func (v *DescriptorVersion) ConvertFrom(in *compdesc.ComponentDescriptor) (compd
 	return out, nil
 }
 
-func convertReferenceFrom(in compdesc.ComponentReference) Reference {
+func convertReferenceFrom(in compdesc.Reference) Reference {
 	return Reference{
 		ElementMeta:   convertElementmetaFrom(in.ElementMeta),
 		ComponentName: in.ComponentName,
@@ -220,7 +220,7 @@ func convertReferenceFrom(in compdesc.ComponentReference) Reference {
 	}
 }
 
-func convertReferencesFrom(in []compdesc.ComponentReference) []Reference {
+func convertReferencesFrom(in []compdesc.Reference) []Reference {
 	if in == nil {
 		return nil
 	}

--- a/api/ocm/compdesc/versions/v2/version.go
+++ b/api/ocm/compdesc/versions/v2/version.go
@@ -97,8 +97,8 @@ func (v *DescriptorVersion) ConvertTo(obj compdesc.ComponentDescriptorVersion) (
 	return out, nil
 }
 
-func convertComponentReferenceTo(in ComponentReference) compdesc.ComponentReference {
-	return compdesc.ComponentReference{
+func convertComponentReferenceTo(in ComponentReference) compdesc.Reference {
+	return compdesc.Reference{
 		ElementMeta:   convertElementMetaTo(in.ElementMeta),
 		ComponentName: in.ComponentName,
 		Digest:        in.Digest.Copy(),
@@ -234,7 +234,7 @@ func (v *DescriptorVersion) ConvertFrom(in *compdesc.ComponentDescriptor) (compd
 	return out, nil
 }
 
-func convertComponentReferenceFrom(in compdesc.ComponentReference) ComponentReference {
+func convertComponentReferenceFrom(in compdesc.Reference) ComponentReference {
 	return ComponentReference{
 		ElementMeta:   convertElementMetaFrom(in.ElementMeta),
 		ComponentName: in.ComponentName,
@@ -242,7 +242,7 @@ func convertComponentReferenceFrom(in compdesc.ComponentReference) ComponentRefe
 	}
 }
 
-func convertComponentReferencesFrom(in []compdesc.ComponentReference) []ComponentReference {
+func convertComponentReferencesFrom(in []compdesc.Reference) []ComponentReference {
 	if in == nil {
 		return nil
 	}

--- a/api/ocm/cpi/repocpi/view_cv.go
+++ b/api/ocm/cpi/repocpi/view_cv.go
@@ -791,7 +791,7 @@ func (c *componentVersionAccessView) GetSources() []cpi.SourceAccess {
 	return result
 }
 
-func (c *componentVersionAccessView) SelectReferences(sel ...refsel.Selector) ([]compdesc.ComponentReference, error) {
+func (c *componentVersionAccessView) SelectReferences(sel ...refsel.Selector) ([]compdesc.Reference, error) {
 	err := selectors.ValidateSelectors(sel...)
 	if err != nil {
 		return nil, err
@@ -799,7 +799,7 @@ func (c *componentVersionAccessView) SelectReferences(sel ...refsel.Selector) ([
 	return c.GetDescriptor().SelectReferences(sel...)
 }
 
-func (c *componentVersionAccessView) GetReferences() []compdesc.ComponentReference {
+func (c *componentVersionAccessView) GetReferences() []compdesc.Reference {
 	return c.GetDescriptor().GetReferences()
 }
 
@@ -861,7 +861,7 @@ func (c *componentVersionAccessView) GetReferencesBySelectors(selectors []compde
 		if !ok {
 			continue
 		}
-		references = append(references, *selctx.ComponentReference)
+		references = append(references, *selctx.Reference)
 	}
 	if len(references) == 0 {
 		return references, compdesc.NotFound

--- a/api/ocm/elements/common.go
+++ b/api/ocm/elements/common.go
@@ -31,7 +31,7 @@ func (o commonOption) ApplyToSourceMeta(m *compdesc.SourceMeta) error {
 	return o.apply(&m.ElementMeta)
 }
 
-func (o commonOption) ApplyToReference(m *compdesc.ComponentReference) error {
+func (o commonOption) ApplyToReference(m *compdesc.Reference) error {
 	return o.apply(&m.ElementMeta)
 }
 

--- a/api/ocm/elements/digests.go
+++ b/api/ocm/elements/digests.go
@@ -14,7 +14,7 @@ type ResourceReferenceOption interface {
 
 type digest metav1.DigestSpec
 
-func (o *digest) ApplyToReference(m *compdesc.ComponentReference) error {
+func (o *digest) ApplyToReference(m *compdesc.Reference) error {
 	if !(*metav1.DigestSpec)(o).IsNone() {
 		m.Digest = (*metav1.DigestSpec)(o).Copy()
 	}

--- a/api/ocm/elements/references.go
+++ b/api/ocm/elements/references.go
@@ -7,10 +7,10 @@ import (
 )
 
 type ReferenceOption interface {
-	ApplyToReference(reference *compdesc.ComponentReference) error
+	ApplyToReference(reference *compdesc.Reference) error
 }
 
-func Reference(name, comp, vers string, opts ...ReferenceOption) (*compdesc.ComponentReference, error) {
+func Reference(name, comp, vers string, opts ...ReferenceOption) (*compdesc.Reference, error) {
 	m := compdesc.NewComponentReference(name, comp, vers, nil)
 	list := errors.ErrList()
 	for _, o := range opts {

--- a/api/ocm/internal/errors.go
+++ b/api/ocm/internal/errors.go
@@ -10,13 +10,14 @@ import (
 )
 
 const (
-	KIND_REPOSITORY       = "ocm repository"
+	KIND_REPOSITORY     = "ocm repository"
+	KIND_REPOSITORYSPEC = "repository specification"
+
 	KIND_COMPONENT        = errkind.KIND_COMPONENT
-	KIND_COMPONENTVERSION = "component version"
-	KIND_RESOURCE         = "component resource"
-	KIND_SOURCE           = "component source"
+	KIND_COMPONENTVERSION = compdesc.KIND_COMPONENTVERSION
+	KIND_RESOURCE         = compdesc.KIND_RESOURCE
+	KIND_SOURCE           = compdesc.KIND_SOURCE
 	KIND_REFERENCE        = compdesc.KIND_REFERENCE
-	KIND_REPOSITORYSPEC   = "repository specification"
 	KIND_OCM_REFERENCE    = "ocm reference"
 )
 

--- a/api/ocm/internal/repository.go
+++ b/api/ocm/internal/repository.go
@@ -109,7 +109,7 @@ type (
 	SourceAccess = ArtifactAccess[SourceMeta]
 )
 
-type ComponentReference = compdesc.ComponentReference
+type ComponentReference = compdesc.Reference
 
 type ComponentVersionAccess interface {
 	resource.ResourceView[ComponentVersionAccess]

--- a/api/ocm/testhelper/resources.go
+++ b/api/ocm/testhelper/resources.go
@@ -23,9 +23,10 @@ var Digests = testutils.Substitutions{
 	"D_OTHERDATA": D_OTHERDATA,
 }
 
-const S_TESTDATA = "testdata"
-
-const D_TESTDATA = "810ff2fb242a5dee4220f2cb0e6a519891fb67f2f828a6cab4ef8894633b1f50"
+const (
+	S_TESTDATA = "testdata"
+	D_TESTDATA = "810ff2fb242a5dee4220f2cb0e6a519891fb67f2f828a6cab4ef8894633b1f50"
+)
 
 var DS_TESTDATA = TextResourceDigestSpec(D_TESTDATA)
 
@@ -36,9 +37,10 @@ func TestDataResource(env *builder.Builder, funcs ...func()) {
 	})
 }
 
-const S_OTHERDATA = "otherdata"
-
-const D_OTHERDATA = "54b8007913ec5a907ca69001d59518acfd106f7b02f892eabf9cae3f8b2414b4"
+const (
+	S_OTHERDATA = "otherdata"
+	D_OTHERDATA = "54b8007913ec5a907ca69001d59518acfd106f7b02f892eabf9cae3f8b2414b4"
+)
 
 var DS_OTHERDATA = TextResourceDigestSpec(D_OTHERDATA)
 

--- a/api/ocm/tools/signing/digest.go
+++ b/api/ocm/tools/signing/digest.go
@@ -1,0 +1,90 @@
+package signing
+
+import (
+	"io"
+
+	"github.com/mandelsoft/goutils/errors"
+
+	"ocm.software/ocm/api/ocm"
+	"ocm.software/ocm/api/ocm/extensions/accessmethods/none"
+	"ocm.software/ocm/api/ocm/extensions/attrs/signingattr"
+)
+
+// VerifyResourceDigest verify the digest of a resource taken from a component version.
+// The data of the resources (typically after fetching the content) is given by a ocm.DataAccess.
+// The digest info is table from the resource described by a component version, which has
+// been used to retrieve the data.
+// The function returns true if the verification has been executed. If an error occurs, or
+// the verification has been failed, an appropriate error occurs.
+// If the resource is not signature relevant (false,nil) is returned.
+func VerifyResourceDigest(cv ocm.ComponentVersionAccess, i int, bacc ocm.DataAccess) (bool, error) {
+	octx := cv.GetContext()
+	cd := cv.GetDescriptor()
+	raw := &cd.Resources[i]
+
+	acc, err := octx.AccessSpecForSpec(raw.Access)
+	if err != nil {
+		return false, errors.Wrapf(err, resMsg(raw, "", "failed getting access for resource"))
+	}
+
+	if none.IsNone(acc.GetKind()) {
+		return false, nil
+	}
+	if raw.Digest == nil {
+		return false, errors.ErrNotFound("digest")
+	}
+	// special digest notation indicates to not digest the content
+	if raw.Digest.IsExcluded() {
+		return false, nil
+	}
+
+	meth, err := acc.AccessMethod(cv)
+	if err != nil {
+		return false, errors.Wrapf(err, resMsg(raw, acc.Describe(octx), "failed creating access for resource"))
+	}
+	defer meth.Close()
+
+	meth = NewRedirectedAccessMethod(meth, bacc)
+	rdigest := raw.Digest
+
+	dtype := DigesterType(rdigest)
+	req := []ocm.DigesterType{dtype}
+
+	registry := signingattr.Get(octx).HandlerRegistry()
+	hasher := registry.GetHasher(dtype.HashAlgorithm)
+	digest, err := octx.BlobDigesters().DetermineDigests(raw.Type, hasher, registry, meth, req...)
+	if err != nil {
+		return false, errors.Wrapf(err, resMsg(raw, acc.Describe(octx), "failed determining digest for resource"))
+	}
+	if len(digest) == 0 {
+		return false, errors.Newf(resMsg(raw, acc.Describe(octx), "no digester accepts resource"))
+	}
+	if !checkDigest(rdigest, &digest[0]) {
+		return true, errors.Newf(resMsg(raw, acc.Describe(octx), "calculated resource digest (%+v) mismatches existing digest (%+v) for", &digest[0], rdigest))
+	}
+	return true, nil
+}
+
+type redirectedAccessMethod struct {
+	ocm.AccessMethod
+	acc ocm.DataAccess
+}
+
+func NewRedirectedAccessMethod(m ocm.AccessMethod, bacc ocm.DataAccess) ocm.AccessMethod {
+	return &redirectedAccessMethod{m, bacc}
+}
+
+func (m *redirectedAccessMethod) Close() error {
+	list := errors.ErrList()
+	list.Add(m.acc.Close())
+	list.Add(m.AccessMethod.Close())
+	return list.Result()
+}
+
+func (m *redirectedAccessMethod) Reader() (io.ReadCloser, error) {
+	return m.acc.Reader()
+}
+
+func (m *redirectedAccessMethod) Get() ([]byte, error) {
+	return m.acc.Get()
+}

--- a/api/ocm/tools/signing/digest_test.go
+++ b/api/ocm/tools/signing/digest_test.go
@@ -1,0 +1,80 @@
+package signing_test
+
+import (
+	"strings"
+
+	. "github.com/mandelsoft/goutils/testutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "ocm.software/ocm/api/helper/builder"
+
+	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"ocm.software/ocm/api/oci/artdesc"
+	"ocm.software/ocm/api/oci/extensions/repositories/artifactset"
+	metav1 "ocm.software/ocm/api/ocm/compdesc/meta/v1"
+	resourcetypes "ocm.software/ocm/api/ocm/extensions/artifacttypes"
+	"ocm.software/ocm/api/ocm/extensions/digester/digesters/artifact"
+	"ocm.software/ocm/api/ocm/extensions/repositories/ctf"
+	"ocm.software/ocm/api/ocm/tools/signing"
+	"ocm.software/ocm/api/tech/signing/hasher/sha256"
+	"ocm.software/ocm/api/utils/accessio"
+	"ocm.software/ocm/api/utils/accessobj"
+)
+
+var _ = Describe("Digest Test Environment", func() {
+	var env *Builder
+
+	BeforeEach(func() {
+		env = NewBuilder()
+		env.OCMCommonTransport(ARCH, accessio.FormatDirectory, func() {
+			env.ComponentVersion(COMPONENTA, VERSION, func() {
+				env.Resource("image", VERSION, resourcetypes.OCI_ARTIFACT, metav1.LocalRelation, func() {
+					env.ArtifactSetBlob(VERSION, func() {
+						env.Manifest(VERSION, func() {
+							env.Config(func() {
+								env.BlobStringData(ociv1.MediaTypeImageConfig, "{}")
+							})
+							env.Layer(func() {
+								env.BlobStringData(ociv1.MediaTypeImageLayerGzip, "fake")
+							})
+						})
+					})
+				})
+			})
+		})
+	})
+
+	AfterEach(func() {
+		env.Cleanup()
+	})
+
+	It("created oci artifact", func() {
+		repo := Must(ctf.Open(env.OCMContext(), accessobj.ACC_READONLY, ARCH, 0, env))
+		defer Close(repo, "repo")
+
+		cv := Must(repo.LookupComponentVersion(COMPONENTA, VERSION))
+		defer Close(cv, "cv")
+
+		Expect(len(cv.GetDescriptor().Resources)).To(Equal(1))
+
+		rsc := Must(cv.GetResourceByIndex(0))
+
+		m := Must(rsc.AccessMethod())
+		defer Close(m, "meth")
+		Expect(m.MimeType()).To(Equal(artifactset.MediaType(artdesc.MediaTypeImageManifest)))
+
+		dig := rsc.Meta().Digest
+		Expect(dig).NotTo(BeNil())
+		Expect(dig.HashAlgorithm).To(Equal(sha256.Algorithm))
+		Expect(dig.NormalisationAlgorithm).To(Equal(artifact.OciArtifactDigestV1))
+
+		Expect(Must(signing.VerifyResourceDigest(cv, 0, m))).To(BeTrue())
+
+		orig := dig.Value
+		dig.Value = strings.Replace(dig.Value, "a", "b", -1)
+		done, err := signing.VerifyResourceDigest(cv, 0, m)
+		dig.Value = orig
+		Expect(done).To(BeTrue())
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/api/ocm/tools/signing/handle.go
+++ b/api/ocm/tools/signing/handle.go
@@ -392,7 +392,7 @@ func checkDigest(orig *metav1.DigestSpec, act *metav1.DigestSpec) bool {
 	return true
 }
 
-func refMsg(ref compdesc.ComponentReference, msg string, args ...interface{}) string {
+func refMsg(ref compdesc.Reference, msg string, args ...interface{}) string {
 	return fmt.Sprintf("%s %s", fmt.Sprintf(msg, args...), ref)
 }
 

--- a/api/ocm/tools/signing/options.go
+++ b/api/ocm/tools/signing/options.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/mandelsoft/goutils/errors"
+	"github.com/mandelsoft/goutils/general"
 	"github.com/mandelsoft/goutils/generics"
 
 	"ocm.software/ocm/api/datacontext/attrs/rootcertsattr"
@@ -431,6 +432,22 @@ func (o *tsaOpt) ApplySigningOption(opts *Options) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+type verifyedstore struct {
+	store VerifiedStore
+}
+
+// UseVerifiedStore configures a store for providing verify component decariptors.
+// If no store is given, a local store is created.
+func UseVerifiedStore(s ...VerifiedStore) Option {
+	return &verifyedstore{general.OptionalDefaulted(NewLocalVerifiedStore(), s...)}
+}
+
+func (o *verifyedstore) ApplySigningOption(opts *Options) {
+	opts.VerifiedStore = o.store
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 type Options struct {
 	Printer           common.Printer
 	Update            bool
@@ -455,6 +472,8 @@ type Options struct {
 	UseTSA            bool
 
 	effectiveRegistry signing.Registry
+
+	VerifiedStore VerifiedStore
 }
 
 var _ Option = (*Options)(nil)

--- a/api/ocm/tools/signing/signing_test.go
+++ b/api/ocm/tools/signing/signing_test.go
@@ -1232,7 +1232,67 @@ applying to version "github.com/mandelsoft/test:v1"[github.com/mandelsoft/test:v
 				RootCertificates(ca), PKIXIssuer(*issuer))
 		})
 	})
+
+	FContext("verified store", func() {
+		BeforeEach(func() {
+			env.OCMCommonTransport(ARCH, accessio.FormatDirectory, func() {
+				env.ComponentVersion(COMPONENTA, VERSION, func() {
+					env.Provider(PROVIDER)
+				})
+				env.ComponentVersion(COMPONENTB, VERSION, func() {
+					env.Provider(PROVIDER)
+					env.Reference("refa", COMPONENTA, VERSION)
+				})
+				env.ComponentVersion(COMPONENTC, VERSION, func() {
+					env.Provider(PROVIDER)
+					env.Reference("refb", COMPONENTB, VERSION)
+				})
+			})
+		})
+
+		It("rembers all indirectly signed component descriptors", func() {
+			src := Must(ctf.Open(env.OCMContext(), accessobj.ACC_WRITABLE, ARCH, 0, env))
+			defer Close(src, "ctf")
+
+			resolver := ocm.NewCompoundResolver(src)
+
+			cv := Must(resolver.LookupComponentVersion(COMPONENTC, VERSION))
+			defer Close(cv, "cv")
+
+			store := NewLocalVerifiedStore()
+			opts := NewOptions(
+				Sign(signing.DefaultHandlerRegistry().GetSigner(SIGN_ALGO), SIGNATURE),
+				Resolver(resolver),
+				VerifyDigests(),
+				UseVerifiedStore(store),
+			)
+			MustBeSuccessful(opts.Complete(env))
+
+			pr, buf := common.NewBufferedPrinter()
+			Must(Apply(pr, nil, cv, opts))
+
+			Expect(buf.String()).To(StringEqualTrimmedWithContext(`
+applying to version "github.com/mandelsoft/ref2:v1"[github.com/mandelsoft/ref2:v1]...
+  no digest found for "github.com/mandelsoft/ref:v1"
+  applying to version "github.com/mandelsoft/ref:v1"[github.com/mandelsoft/ref2:v1]...
+    no digest found for "github.com/mandelsoft/test:v1"
+    applying to version "github.com/mandelsoft/test:v1"[github.com/mandelsoft/ref2:v1]...
+    reference 0:  github.com/mandelsoft/test:v1: digest SHA-256:5ed8bb27309c3c2fff43f3b0f3ebb56a5737ad6db4bc8ace73c5455cb86faf54[jsonNormalisation/v1]
+  reference 0:  github.com/mandelsoft/ref:v1: digest SHA-256:e85e324ff16bafe26db235567d9232319c36f48ce995aa3f4957e55002207277[jsonNormalisation/v1]
+`))
+
+			CheckStore(store, cv)
+			CheckStore(store, common.NewNameVersion(COMPONENTB, VERSION))
+			CheckStore(store, common.NewNameVersion(COMPONENTA, VERSION))
+		})
+	})
 })
+
+func CheckStore(store VerifiedStore, ve common.VersionedElement) {
+	e := store.Get(ve)
+	ExpectWithOffset(1, e).NotTo(BeNil())
+	ExpectWithOffset(1, common.VersionedElementKey(e)).To(Equal(common.VersionedElementKey(ve)))
+}
 
 func HashComponent(resolver ocm.ComponentVersionResolver, name string, digest string, other ...Option) string {
 	cv, err := resolver.LookupComponentVersion(name, VERSION)

--- a/api/ocm/tools/signing/signing_test.go
+++ b/api/ocm/tools/signing/signing_test.go
@@ -1233,7 +1233,7 @@ applying to version "github.com/mandelsoft/test:v1"[github.com/mandelsoft/test:v
 		})
 	})
 
-	FContext("verified store", func() {
+	Context("verified store", func() {
 		BeforeEach(func() {
 			env.OCMCommonTransport(ARCH, accessio.FormatDirectory, func() {
 				env.ComponentVersion(COMPONENTA, VERSION, func() {

--- a/api/ocm/tools/signing/store.go
+++ b/api/ocm/tools/signing/store.go
@@ -81,7 +81,7 @@ func (v *verifiedStore) Load() error {
 	var storage StorageDescriptor
 	f, err := v.fs.Open(v.file)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
 	} else {

--- a/api/ocm/tools/signing/store.go
+++ b/api/ocm/tools/signing/store.go
@@ -1,0 +1,192 @@
+package signing
+
+import (
+	"io"
+	"os"
+	"sync"
+
+	"github.com/mandelsoft/filepath/pkg/filepath"
+	"github.com/mandelsoft/goutils/errors"
+	"github.com/mandelsoft/goutils/sliceutils"
+	"github.com/mandelsoft/vfs/pkg/vfs"
+
+	"ocm.software/ocm/api/ocm/compdesc"
+	metav1 "ocm.software/ocm/api/ocm/compdesc/meta/v1"
+	"ocm.software/ocm/api/utils"
+	common "ocm.software/ocm/api/utils/misc"
+	"ocm.software/ocm/api/utils/runtime"
+)
+
+type VerifiedStore interface {
+	Add(cd *compdesc.ComponentDescriptor, signatures ...string)
+	Remove(n common.VersionedElement)
+	Get(n common.VersionedElement) *compdesc.ComponentDescriptor
+
+	GetResourceDigest(n common.VersionedElement, id metav1.Identity) *metav1.DigestSpec
+	GetResourceDigestByIndex(n common.VersionedElement, idx int) *metav1.DigestSpec
+
+	Load() error
+	Save() error
+}
+
+type verifiedStore struct {
+	lock    sync.Mutex
+	storage *StorageDescriptor
+	fs      vfs.FileSystem
+	file    string
+}
+
+var _ VerifiedStore = (*verifiedStore)(nil)
+
+func NewLocalVerifiedStore() VerifiedStore {
+	return &verifiedStore{storage: &StorageDescriptor{}}
+}
+
+func NewVerifiedStore(path string, fss ...vfs.FileSystem) (VerifiedStore, error) {
+	eff, err := utils.ResolvePath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	fs := utils.FileSystem(fss...)
+
+	s := &verifiedStore{
+		fs:   fs,
+		file: eff,
+	}
+
+	err = s.Load()
+	if err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func (v *verifiedStore) Load() error {
+	v.lock.Lock()
+	defer v.lock.Unlock()
+	if v.fs == nil {
+		return nil
+	}
+
+	dir := filepath.Dir(v.file)
+
+	if ok, err := vfs.DirExists(v.fs, dir); !ok || err != nil {
+		if err != nil {
+			return err
+		}
+		return errors.ErrNotFound("directory", dir)
+	}
+
+	var storage StorageDescriptor
+	f, err := v.fs.Open(v.file)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	} else {
+		defer f.Close()
+		data, err := io.ReadAll(f)
+		if err != nil {
+			return err
+		}
+		err = runtime.DefaultYAMLEncoding.Unmarshal(data, &storage)
+		if err != nil {
+			return err
+		}
+	}
+	v.storage = &storage
+	return nil
+}
+
+func (v *verifiedStore) Save() error {
+	v.lock.Lock()
+	defer v.lock.Unlock()
+	if v.fs == nil {
+		return nil
+	}
+
+	data, err := runtime.DefaultYAMLEncoding.Marshal(v.storage)
+	if err != nil {
+		return err
+	}
+
+	err = vfs.WriteFile(v.fs, v.file, data, 0o600)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (v *verifiedStore) Add(cd *compdesc.ComponentDescriptor, signatures ...string) {
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
+	if v.storage == nil {
+		v.storage = &StorageDescriptor{}
+	}
+	if v.storage.ComponentVersions == nil {
+		v.storage.ComponentVersions = map[string]*StorageEntry{}
+	}
+	key := common.VersionedElementKey(cd).String()
+	old := v.storage.ComponentVersions[key]
+	if old == nil || !old.Descriptor.Descriptor().Equal(cd) {
+		old = &StorageEntry{
+			Descriptor: (*compdesc.GenericComponentDescriptor)(cd),
+		}
+	}
+	for _, e := range signatures {
+		old.Signatures = sliceutils.AppendUnique(old.Signatures, e)
+	}
+	v.storage.ComponentVersions[key] = old
+}
+
+func (v *verifiedStore) Remove(n common.VersionedElement) {
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
+	delete(v.storage.ComponentVersions, common.VersionedElementKey(n).String())
+}
+
+func (v *verifiedStore) Get(n common.VersionedElement) *compdesc.ComponentDescriptor {
+	v.lock.Lock()
+	defer v.lock.Unlock()
+
+	entry := v.storage.ComponentVersions[common.VersionedElementKey(n).String()]
+	if entry == nil {
+		return nil
+	}
+	return entry.Descriptor.Descriptor()
+}
+
+func (v *verifiedStore) GetResourceDigest(n common.VersionedElement, id metav1.Identity) *metav1.DigestSpec {
+	cd := v.Get(n)
+	if cd == nil {
+		return nil
+	}
+	r, err := cd.GetResourceByIdentity(id)
+	if err != nil {
+		return nil
+	}
+	return r.Digest
+}
+
+func (v *verifiedStore) GetResourceDigestByIndex(n common.VersionedElement, idx int) *metav1.DigestSpec {
+	cd := v.Get(n)
+	if cd == nil {
+		return nil
+	}
+	if idx < 0 || idx >= len(cd.Resources) {
+		return nil
+	}
+	return cd.Resources[idx].Digest
+}
+
+type StorageEntry struct {
+	Signatures []string                             `json:"signatures,omitempty"`
+	Descriptor *compdesc.GenericComponentDescriptor `json:"descriptor"`
+}
+
+type StorageDescriptor struct {
+	ComponentVersions map[string]*StorageEntry `json:"componentVersions,omitempty"`
+}

--- a/api/ocm/tools/signing/store.go
+++ b/api/ocm/tools/signing/store.go
@@ -18,6 +18,17 @@ import (
 	"ocm.software/ocm/api/utils/runtime"
 )
 
+// VerifiedStore is an interface for some kind of
+// memory providing information about verified
+// component versions and the digests of the verified
+// artifacts. It is used to verify downloaded resource content,
+// without requiring to verify the complete component version, again.
+// If the component version has already been marked as being verified
+// only the digest of the downloaded content has be compared with the
+// digest already marked as verified in the context of its component version.
+//
+// A typical implementation is a file based store, which stored the serialized
+// component versions (see NewVerifiedStore).
 type VerifiedStore interface {
 	Add(cd *compdesc.ComponentDescriptor, signatures ...string)
 	Remove(n common.VersionedElement)
@@ -42,10 +53,12 @@ type verifiedStore struct {
 
 var _ VerifiedStore = (*verifiedStore)(nil)
 
+// NewLocalVerifiedStore creates a memory based VerifiedStore.
 func NewLocalVerifiedStore() VerifiedStore {
 	return &verifiedStore{storage: &StorageDescriptor{}}
 }
 
+// NewVerifiedStore loads or creates a new filesystem based VerifiedStore.
 func NewVerifiedStore(path string, fss ...vfs.FileSystem) (VerifiedStore, error) {
 	eff, err := utils.ResolvePath(path)
 	if err != nil {

--- a/api/ocm/tools/signing/store_test.go
+++ b/api/ocm/tools/signing/store_test.go
@@ -6,13 +6,14 @@ import (
 	. "github.com/mandelsoft/goutils/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"ocm.software/ocm/api/ocm/compdesc"
 	metav1 "ocm.software/ocm/api/ocm/compdesc/meta/v1"
 	"ocm.software/ocm/api/ocm/compdesc/versions/ocm.software/v3alpha1"
 	v2 "ocm.software/ocm/api/ocm/compdesc/versions/v2"
-	common "ocm.software/ocm/api/utils/misc"
-
-	"ocm.software/ocm/api/ocm/compdesc"
 	"ocm.software/ocm/api/ocm/tools/signing"
+	common "ocm.software/ocm/api/utils/misc"
+	"ocm.software/ocm/api/utils/runtime"
 )
 
 var _ = Describe("Store", func() {
@@ -24,7 +25,7 @@ var _ = Describe("Store", func() {
 			store := Must(signing.NewVerifiedStore(file.Name()))
 			Expect(store).NotTo(BeNil())
 
-			cd1 := &compdesc.ComponentDescriptor{
+			cd1 := compdesc.DefaultComponent(&compdesc.ComponentDescriptor{
 				Metadata: compdesc.Metadata{
 					ConfiguredVersion: v3alpha1.SchemaVersion,
 				},
@@ -32,20 +33,26 @@ var _ = Describe("Store", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:    COMPONENTA,
 						Version: VERSION,
+						Provider: metav1.Provider{
+							Name: "acme.org",
+						},
 					},
 				},
-			}
-			cd2 := &compdesc.ComponentDescriptor{
+			})
+			cd2 := compdesc.DefaultComponent(&compdesc.ComponentDescriptor{
 				Metadata: compdesc.Metadata{
 					ConfiguredVersion: v2.SchemaVersion,
 				},
 				ComponentSpec: compdesc.ComponentSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:    COMPONENTA,
+						Name:    COMPONENTB,
 						Version: VERSION,
+						Provider: metav1.Provider{
+							Name: "acme.org",
+						},
 					},
 				},
-			}
+			})
 
 			store.Add(cd1, "a")
 			store.Add(cd2, "b")
@@ -68,7 +75,8 @@ var _ = Describe("Store", func() {
 
 			data := Must(os.ReadFile(file.Name()))
 
-			Expect(data).To(YAMLEqual(desc))
+			exp := Must(runtime.DefaultYAMLEncoding.Marshal(desc))
+			Expect(data).To(YAMLEqual(exp))
 
 			store = Must(signing.NewVerifiedStore(file.Name()))
 

--- a/api/ocm/tools/signing/store_test.go
+++ b/api/ocm/tools/signing/store_test.go
@@ -1,0 +1,83 @@
+package signing_test
+
+import (
+	"os"
+
+	. "github.com/mandelsoft/goutils/testutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "ocm.software/ocm/api/ocm/compdesc/meta/v1"
+	"ocm.software/ocm/api/ocm/compdesc/versions/ocm.software/v3alpha1"
+	v2 "ocm.software/ocm/api/ocm/compdesc/versions/v2"
+	common "ocm.software/ocm/api/utils/misc"
+
+	"ocm.software/ocm/api/ocm/compdesc"
+	"ocm.software/ocm/api/ocm/tools/signing"
+)
+
+var _ = Describe("Store", func() {
+	Context("persistence", func() {
+		It("", func() {
+			file := Must(os.CreateTemp("", "store-*"))
+
+			os.Remove(file.Name())
+			store := Must(signing.NewVerifiedStore(file.Name()))
+			Expect(store).NotTo(BeNil())
+
+			cd1 := &compdesc.ComponentDescriptor{
+				Metadata: compdesc.Metadata{
+					ConfiguredVersion: v3alpha1.SchemaVersion,
+				},
+				ComponentSpec: compdesc.ComponentSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:    COMPONENTA,
+						Version: VERSION,
+					},
+				},
+			}
+			cd2 := &compdesc.ComponentDescriptor{
+				Metadata: compdesc.Metadata{
+					ConfiguredVersion: v2.SchemaVersion,
+				},
+				ComponentSpec: compdesc.ComponentSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:    COMPONENTA,
+						Version: VERSION,
+					},
+				},
+			}
+
+			store.Add(cd1, "a")
+			store.Add(cd2, "b")
+			store.Add(cd2, "c")
+
+			MustBeSuccessful(store.Save())
+
+			desc := signing.StorageDescriptor{
+				ComponentVersions: map[string]*signing.StorageEntry{
+					common.VersionedElementKey(cd1).String(): &signing.StorageEntry{
+						Signatures: []string{"a"},
+						Descriptor: (*compdesc.GenericComponentDescriptor)(cd1),
+					},
+					common.VersionedElementKey(cd2).String(): &signing.StorageEntry{
+						Signatures: []string{"b", "c"},
+						Descriptor: (*compdesc.GenericComponentDescriptor)(cd2),
+					},
+				},
+			}
+
+			data := Must(os.ReadFile(file.Name()))
+
+			Expect(data).To(YAMLEqual(desc))
+
+			store = Must(signing.NewVerifiedStore(file.Name()))
+
+			Expect(store.Get(cd1)).To(YAMLEqual(cd1))
+			Expect(store.Get(cd1).Equal(cd1)).To(BeTrue())
+
+			Expect(store.Get(cd2)).To(YAMLEqual(cd2))
+			Expect(store.Get(cd2).Equal(cd2)).To(BeTrue())
+
+		})
+	})
+})

--- a/api/ocm/tools/transfer/merge_test.go
+++ b/api/ocm/tools/transfer/merge_test.go
@@ -204,7 +204,7 @@ var _ = Describe("basic merge operations for transport", func() {
 						},
 					},
 					References: compdesc.References{
-						compdesc.ComponentReference{
+						compdesc.Reference{
 							ElementMeta: compdesc.ElementMeta{
 								Name:    "ref1",
 								Version: "v1.0.0",

--- a/api/ocm/tools/transfer/transferhandler/spiff/handler.go
+++ b/api/ocm/tools/transfer/transferhandler/spiff/handler.go
@@ -76,7 +76,7 @@ func (h *Handler) OverwriteVersion(src ocm.ComponentVersionAccess, tgt ocm.Compo
 	return h.EvalBool("overwrite", binding, "process")
 }
 
-func (h *Handler) TransferVersion(repo ocm.Repository, src ocm.ComponentVersionAccess, meta *compdesc.ComponentReference, tgt ocm.Repository) (ocm.ComponentVersionAccess, transferhandler.TransferHandler, error) {
+func (h *Handler) TransferVersion(repo ocm.Repository, src ocm.ComponentVersionAccess, meta *compdesc.Reference, tgt ocm.Repository) (ocm.ComponentVersionAccess, transferhandler.TransferHandler, error) {
 	if src == nil || h.opts.IsRecursive() {
 		if h.opts.GetScript() == nil {
 			return h.Handler.TransferVersion(repo, src, meta, tgt)

--- a/api/ocm/tools/transfer/transferhandler/standard/handler.go
+++ b/api/ocm/tools/transfer/transferhandler/standard/handler.go
@@ -47,7 +47,7 @@ func (h *Handler) OverwriteVersion(src ocm.ComponentVersionAccess, tgt ocm.Compo
 	return h.opts.IsOverwrite(), nil
 }
 
-func (h *Handler) TransferVersion(repo ocm.Repository, src ocm.ComponentVersionAccess, meta *compdesc.ComponentReference, tgt ocm.Repository) (ocm.ComponentVersionAccess, transferhandler.TransferHandler, error) {
+func (h *Handler) TransferVersion(repo ocm.Repository, src ocm.ComponentVersionAccess, meta *compdesc.Reference, tgt ocm.Repository) (ocm.ComponentVersionAccess, transferhandler.TransferHandler, error) {
 	if src == nil || h.opts.IsRecursive() {
 		if h.opts.IsStopOnExistingVersion() && tgt != nil {
 			if found, err := tgt.ExistsComponentVersion(meta.ComponentName, meta.Version); found || err != nil {

--- a/api/ocm/tools/transfer/transferhandler/transferhandler.go
+++ b/api/ocm/tools/transfer/transferhandler/transferhandler.go
@@ -93,7 +93,7 @@ type TransferHandler interface {
 	OverwriteVersion(src ocm.ComponentVersionAccess, tgt ocm.ComponentVersionAccess) (bool, error)
 
 	// TransferVersion decides on continuing with a component version (reference).
-	TransferVersion(repo ocm.Repository, src ocm.ComponentVersionAccess, meta *compdesc.ComponentReference, tgt ocm.Repository) (ocm.ComponentVersionAccess, TransferHandler, error)
+	TransferVersion(repo ocm.Repository, src ocm.ComponentVersionAccess, meta *compdesc.Reference, tgt ocm.Repository) (ocm.ComponentVersionAccess, TransferHandler, error)
 	// TransferResource decides on the value transport of a resource.
 	TransferResource(src ocm.ComponentVersionAccess, a ocm.AccessSpec, r ocm.ResourceAccess) (bool, error)
 	// TransferSource decides on the value transport of a source.

--- a/api/ocm/utils.go
+++ b/api/ocm/utils.go
@@ -95,7 +95,7 @@ func IsIntermediate(spec RepositorySpec) bool {
 	return false
 }
 
-func ComponentRefKey(ref *compdesc.ComponentReference) common.NameVersion {
+func ComponentRefKey(ref *compdesc.Reference) common.NameVersion {
 	return common.NewNameVersion(ref.GetComponentName(), ref.GetVersion())
 }
 

--- a/cmds/ocm/commands/ocmcmds/cli/download/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/cli/download/cmd.go
@@ -9,7 +9,6 @@ import (
 	"github.com/mandelsoft/vfs/pkg/vfs"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/common/options/storeoption"
 
 	clictx "ocm.software/ocm/api/cli"
 	"ocm.software/ocm/api/ocm"
@@ -21,6 +20,7 @@ import (
 	ocmcommon "ocm.software/ocm/cmds/ocm/commands/ocmcmds/common"
 	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/common/handlers/elemhdlr"
 	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/common/options/repooption"
+	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/common/options/storeoption"
 	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/common/options/versionconstraintsoption"
 	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/names"
 	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/resources/common"

--- a/cmds/ocm/commands/ocmcmds/cli/download/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/cli/download/cmd.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mandelsoft/vfs/pkg/vfs"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/common/options/storeoption"
 
 	clictx "ocm.software/ocm/api/cli"
 	"ocm.software/ocm/api/ocm"
@@ -52,7 +53,7 @@ func NewCommand(ctx clictx.Context, names ...string) *cobra.Command {
 	return utils.SetupCommand(&Command{BaseCommand: utils.NewBaseCommand(ctx,
 		versionconstraintsoption.New(true).SetLatest(),
 		repooption.New(),
-		output.OutputOptions(output.NewOutputs(f), downloadcmd.NewOptions(true).SetUseHandlers(), destoption.New()),
+		output.OutputOptions(output.NewOutputs(f), downloadcmd.NewOptions(true).SetUseHandlers(), destoption.New(), storeoption.New("use-verified")),
 	)}, utils.Names(Names, names...)...)
 }
 

--- a/cmds/ocm/commands/ocmcmds/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/cmd.go
@@ -15,6 +15,7 @@ import (
 	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/routingslips"
 	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/sourceconfig"
 	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/sources"
+	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/verified"
 	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/versions"
 	"ocm.software/ocm/cmds/ocm/common/utils"
 	topicocmaccessmethods "ocm.software/ocm/cmds/ocm/topics/ocm/accessmethods"
@@ -40,6 +41,7 @@ func NewCommand(ctx clictx.Context) *cobra.Command {
 	cmd.AddCommand(plugins.NewCommand(ctx))
 	cmd.AddCommand(routingslips.NewCommand(ctx))
 	cmd.AddCommand(pubsub.NewCommand(ctx))
+	cmd.AddCommand(verified.NewCommand(ctx))
 
 	cmd.AddCommand(utils.DocuCommandPath(topicocmrefs.New(ctx), "ocm"))
 	cmd.AddCommand(utils.DocuCommandPath(topicocmaccessmethods.New(ctx), "ocm"))

--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/refs/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/refs/elements.go
@@ -57,7 +57,7 @@ func (h *ResourceSpecHandler) Set(v ocm.ComponentVersionAccess, r addhdlrs.Eleme
 	if vers == "" {
 		vers = v.GetVersion()
 	}
-	meta := &compdesc.ComponentReference{
+	meta := &compdesc.Reference{
 		ElementMeta: compdesc.ElementMeta{
 			Name:          spec.Name,
 			Version:       vers,

--- a/cmds/ocm/commands/ocmcmds/common/cmds/signing/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/common/cmds/signing/cmd.go
@@ -97,7 +97,14 @@ func (o *SignatureCommand) Run() (rerr error) {
 	if err != nil {
 		return err
 	}
-	return utils.HandleOutput(NewAction(o.spec.terms, o.Context.OCMContext(), common.NewPrinter(o.Context.StdOut()), sopts), handler, utils.StringElemSpecs(o.Refs...)...)
+	err = utils.HandleOutput(NewAction(o.spec.terms, o.Context.OCMContext(), common.NewPrinter(o.Context.StdOut()), sopts), handler, utils.StringElemSpecs(o.Refs...)...)
+	if err != nil {
+		return err
+	}
+	if sopts.VerifiedStore != nil {
+		return errors.Wrapf(sopts.VerifiedStore.Save(), "cannot save verified store %q", signoption.From(o).Verified.File)
+	}
+	return nil
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/cmds/ocm/commands/ocmcmds/common/handlers/elemhdlr/typehandler.go
+++ b/cmds/ocm/commands/ocmcmds/common/handlers/elemhdlr/typehandler.go
@@ -21,6 +21,7 @@ type Object struct {
 	VersionId metav1.Identity
 
 	Spec    metav1.Identity
+	Index   int
 	Id      metav1.Identity
 	Node    *common.NameVersion
 	Element compdesc.ElementMetaAccessor
@@ -150,6 +151,7 @@ func (h *TypeHandler) all(c *comphdlr.Object) ([]output.Object, error) {
 					History:   c.History.Append(common.VersionedElementKey(c.ComponentVersion)),
 					Version:   c.ComponentVersion,
 					VersionId: c.Identity,
+					Index:     i,
 					Id:        e.GetMeta().GetIdentity(elemaccess),
 					Element:   e,
 				})
@@ -161,6 +163,7 @@ func (h *TypeHandler) all(c *comphdlr.Object) ([]output.Object, error) {
 				History:   c.History.Append(common.VersionedElementKey(c.ComponentVersion)),
 				Version:   c.ComponentVersion,
 				VersionId: c.Identity,
+				Index:     -1,
 				Id:        metav1.Identity{},
 				Element:   nil,
 			})
@@ -203,6 +206,7 @@ func (h *TypeHandler) get(c *comphdlr.Object, elemspec utils.ElemSpec) ([]output
 				History:   c.History.Append(common.VersionedElementKey(c.ComponentVersion)),
 				Version:   c.ComponentVersion,
 				VersionId: c.Identity,
+				Index:     i,
 				Spec:      selector,
 				Id:        m.GetIdentity(elemaccess),
 				Element:   e,
@@ -214,6 +218,7 @@ func (h *TypeHandler) get(c *comphdlr.Object, elemspec utils.ElemSpec) ([]output
 			History:   c.History.Append(common.VersionedElementKey(c.ComponentVersion)),
 			Version:   c.ComponentVersion,
 			VersionId: c.Identity,
+			Index:     -1,
 			Id:        metav1.Identity{},
 			Element:   nil,
 		})

--- a/cmds/ocm/commands/ocmcmds/common/handlers/verifiedhdlr/typehandler.go
+++ b/cmds/ocm/commands/ocmcmds/common/handlers/verifiedhdlr/typehandler.go
@@ -1,0 +1,91 @@
+package pluginhdlr
+
+import (
+	"slices"
+
+	"github.com/mandelsoft/goutils/errors"
+	"github.com/mandelsoft/goutils/general"
+	"github.com/mandelsoft/vfs/pkg/vfs"
+
+	clictx "ocm.software/ocm/api/cli"
+	"ocm.software/ocm/api/datacontext/attrs/vfsattr"
+	"ocm.software/ocm/api/ocm"
+	"ocm.software/ocm/api/ocm/compdesc"
+	"ocm.software/ocm/api/ocm/tools/signing"
+	"ocm.software/ocm/cmds/ocm/common/output"
+	"ocm.software/ocm/cmds/ocm/common/utils"
+)
+
+func Elem(e interface{}) *Object {
+	return e.(*Object)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+type Object struct {
+	Signatures []string                      `json:"signatures,omitempty"`
+	Element    *compdesc.ComponentDescriptor `json:"descriptor"`
+}
+
+func (o *Object) AsManifest() interface{} {
+	return o
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+type TypeHandler struct {
+	octx  clictx.OCM
+	store signing.VerifiedStore
+}
+
+func NewTypeHandler(octx clictx.OCM, path string, fss ...vfs.FileSystem) (utils.TypeHandler, error) {
+	fs := general.OptionalDefaulted(vfsattr.Get(octx.Context()), fss...)
+	store, err := signing.NewVerifiedStore(path, fs)
+	if err != nil {
+		return nil, err
+	}
+	return &TypeHandler{
+		octx:  octx,
+		store: store,
+	}, nil
+}
+
+func (h *TypeHandler) Close() error {
+	return nil
+}
+
+func (h *TypeHandler) All() ([]output.Object, error) {
+	result := []output.Object{}
+
+	for _, nv := range h.store.Entries() {
+		e := h.store.GetEntry(nv)
+		result = append(result, &Object{slices.Clone(e.Signatures), e.Descriptor.Descriptor().Copy()})
+	}
+	return result, nil
+}
+
+func (h *TypeHandler) Get(elemspec utils.ElemSpec) ([]output.Object, error) {
+	comp, err := ocm.ParseComp(elemspec.String())
+	if err != nil {
+		return nil, err
+	}
+	if comp.IsVersion() {
+		e := h.store.GetEntry(comp.NameVersion())
+		if e == nil {
+			return nil, errors.ErrNotFound(ocm.KIND_COMPONENTVERSION, elemspec.String())
+		}
+		return []output.Object{&Object{slices.Clone(e.Signatures), e.Descriptor.Descriptor().Copy()}}, nil
+	}
+
+	var objs []output.Object
+	for _, nv := range h.store.Entries() {
+		if nv.GetName() == comp.Component {
+			e := h.store.GetEntry(nv)
+			objs = append(objs, &Object{slices.Clone(e.Signatures), e.Descriptor.Descriptor().Copy()})
+		}
+	}
+	if len(objs) == 0 {
+		return nil, errors.ErrNotFound(ocm.KIND_COMPONENT, elemspec.String())
+	}
+	return objs, nil
+}

--- a/cmds/ocm/commands/ocmcmds/common/options/storeoption/option.go
+++ b/cmds/ocm/commands/ocmcmds/common/options/storeoption/option.go
@@ -1,0 +1,72 @@
+package storeoption
+
+import (
+	"github.com/mandelsoft/goutils/general"
+	"github.com/spf13/pflag"
+
+	clictx "ocm.software/ocm/api/cli"
+	"ocm.software/ocm/api/datacontext/attrs/vfsattr"
+	ocmsign "ocm.software/ocm/api/ocm/tools/signing"
+	"ocm.software/ocm/cmds/ocm/common/options"
+)
+
+func From(o options.OptionSetProvider) *Option {
+	var opt *Option
+	o.AsOptionSet().Get(&opt)
+	return opt
+}
+
+var _ options.Options = (*Option)(nil)
+
+func New(name ...string) *Option {
+	return &Option{name: general.OptionalDefaulted("remember-verified", name...)}
+}
+
+type Option struct {
+	name string
+
+	// File is used to remember verify component versions.
+	File                 string
+	RememberVerification bool
+	Store                ocmsign.VerifiedStore
+}
+
+const DEFAULT_VERIFIED_FILE = "~/.ocm/verified"
+
+func (o *Option) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&o.RememberVerification, o.name, false, "enable verification store")
+	fs.StringVarP(&o.File, "verified", "", DEFAULT_VERIFIED_FILE, "file used to remember verifications for downloads")
+}
+
+func (o *Option) Configure(ctx clictx.Context) error {
+	var err error
+	if o.Store == nil && (o.RememberVerification || o.File != DEFAULT_VERIFIED_FILE) {
+		o.Store, err = ocmsign.NewVerifiedStore(o.File, vfsattr.Get(ctx))
+		if err != nil {
+			return err
+		}
+	}
+	if o.Store != nil {
+		o.RememberVerification = true
+	}
+	return nil
+}
+
+func (o *Option) Usage() string {
+	s := `
+If the verification store is enabled, resources downloaded from
+signed or verified component versions are verified against their digests
+provided by the component version.(not supported for using downloaders for the
+resource download).
+
+The usage of the verification store is enabled by <code>--` + o.name + `</code> or by
+specifying a verification file with <code>--verified</code>.
+`
+	return s
+}
+
+var _ ocmsign.Option = (*Option)(nil)
+
+func (o *Option) ApplySigningOption(opts *ocmsign.Options) {
+	opts.VerifiedStore = o.Store
+}

--- a/cmds/ocm/commands/ocmcmds/names/names.go
+++ b/cmds/ocm/commands/ocmcmds/names/names.go
@@ -16,4 +16,5 @@ var (
 	Action                 = []string{"action"}
 	RoutingSlips           = []string{"routingslips", "routingslip", "rs"}
 	PubSub                 = []string{"pubsub", "ps"}
+	Verified               = []string{"verified"}
 )

--- a/cmds/ocm/commands/ocmcmds/references/add/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/references/add/cmd_test.go
@@ -20,7 +20,7 @@ const (
 	REF     = "github.com/mandelsoft/ref"
 )
 
-func CheckReference(env *TestEnv, cd *compdesc.ComponentDescriptor, name string, add ...func(compdesc.ComponentReference)) {
+func CheckReference(env *TestEnv, cd *compdesc.ComponentDescriptor, name string, add ...func(compdesc.Reference)) {
 	rs, _ := cd.GetReferencesByName(name)
 	if len(rs) != 1 {
 		Fail(fmt.Sprintf("%d reference(s) with name %s found", len(rs), name), 1)
@@ -64,7 +64,7 @@ var _ = Describe("Add references", func() {
 		Expect(err).To(Succeed())
 		Expect(len(cd.References)).To(Equal(1))
 
-		CheckReference(env, cd, "testdata", func(r compdesc.ComponentReference) {
+		CheckReference(env, cd, "testdata", func(r compdesc.Reference) {
 			Expect(r.ExtraIdentity).To(Equal(metav1.Identity{"purpose": "test", "label": "local"}))
 		})
 	})
@@ -127,7 +127,7 @@ labels:
 
 			labels := metav1.Labels{}
 			labels.Set("test", "value")
-			CheckReference(env, cd, "testdata", func(r compdesc.ComponentReference) {
+			CheckReference(env, cd, "testdata", func(r compdesc.Reference) {
 				ExpectWithOffset(2, r.GetLabels()).To(Equal(labels))
 			})
 		})
@@ -148,7 +148,7 @@ labels:
 
 			labels := metav1.Labels{}
 			labels.Set("test", "value")
-			CheckReference(env, cd, "testdata", func(r compdesc.ComponentReference) {
+			CheckReference(env, cd, "testdata", func(r compdesc.Reference) {
 				Expect(r.GetLabels()).To(Equal(labels))
 			})
 		})
@@ -163,7 +163,7 @@ labels:
 
 			labels := metav1.Labels{}
 			labels.Set("test", "value")
-			CheckReference(env, cd, "testdata", func(r compdesc.ComponentReference) {
+			CheckReference(env, cd, "testdata", func(r compdesc.Reference) {
 				Expect(r.ExtraIdentity).To(Equal(metav1.Identity{"purpose": "test", "label": "local"}))
 			})
 		})
@@ -179,7 +179,7 @@ labels:
 			labels := metav1.Labels{}
 			labels.Set("purpose", "test", metav1.WithSigning())
 			labels.Set("label", map[string]interface{}{"local": true}, metav1.WithVersion("v1"))
-			CheckReference(env, cd, "testdata", func(r compdesc.ComponentReference) {
+			CheckReference(env, cd, "testdata", func(r compdesc.Reference) {
 				Expect(r.GetLabels()).To(Equal(labels))
 			})
 		})

--- a/cmds/ocm/commands/ocmcmds/references/common/typehandler.go
+++ b/cmds/ocm/commands/ocmcmds/references/common/typehandler.go
@@ -9,8 +9,8 @@ import (
 	"ocm.software/ocm/cmds/ocm/common/utils"
 )
 
-func Elem(e interface{}) *compdesc.ComponentReference {
-	return e.(*elemhdlr.Object).Element.(*compdesc.ComponentReference)
+func Elem(e interface{}) *compdesc.Reference {
+	return e.(*elemhdlr.Object).Element.(*compdesc.Reference)
 }
 
 var OptionsFor = elemhdlr.OptionsFor

--- a/cmds/ocm/commands/ocmcmds/resources/download/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/resources/download/cmd_test.go
@@ -2,10 +2,19 @@ package download_test
 
 import (
 	"bytes"
+	"os"
 
 	. "github.com/mandelsoft/goutils/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"ocm.software/ocm/api/datacontext"
+	"ocm.software/ocm/api/ocm"
+	"ocm.software/ocm/api/ocm/extensions/attrs/signingattr"
+	"ocm.software/ocm/api/ocm/extensions/repositories/ctf"
+	"ocm.software/ocm/api/ocm/tools/signing"
+	"ocm.software/ocm/api/tech/signing/handlers/rsa"
+	"ocm.software/ocm/api/utils/accessobj"
+	common "ocm.software/ocm/api/utils/misc"
 	. "ocm.software/ocm/cmds/ocm/testhelper"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
@@ -23,6 +32,18 @@ const (
 	PROVIDER = "mandelsoft"
 	OUT      = "/tmp/res"
 )
+
+const (
+	PUBKEY  = "/tmp/pub"
+	PRIVKEY = "/tmp/priv"
+)
+
+const (
+	SIGNATURE = "test"
+	SIGN_ALGO = rsa.Algorithm
+)
+
+const VERIFIED_FILE = "verified.yaml"
 
 var _ = Describe("Test Environment", func() {
 	var env *TestEnv
@@ -115,6 +136,105 @@ var _ = Describe("Test Environment", func() {
 			Expect(env.ReadFile(vfs.Join(env.FileSystem(), OUT, COMP2+"/"+VERSION+"/otherdata-id=test"))).To(Equal([]byte("otherdata")))
 			Expect(env.FileExists(vfs.Join(env.FileSystem(), OUT, COMP2+"/"+VERSION+"/"+COMP+"/"+VERSION+"/testdata"))).To(BeTrue())
 			Expect(env.ReadFile(vfs.Join(env.FileSystem(), OUT, COMP2+"/"+VERSION+"/"+COMP+"/"+VERSION+"/testdata"))).To(Equal([]byte("testdata")))
+		})
+	})
+
+	Context("verification", func() {
+		priv, pub, err := rsa.Handler{}.CreateKeyPair()
+		Expect(err).To(Succeed())
+
+		BeforeEach(func() {
+			env = NewTestEnv()
+			data, err := rsa.KeyData(pub)
+			Expect(err).To(Succeed())
+			Expect(vfs.WriteFile(env.FileSystem(), PUBKEY, data, os.ModePerm)).To(Succeed())
+			data, err = rsa.KeyData(priv)
+			Expect(err).To(Succeed())
+			Expect(vfs.WriteFile(env.FileSystem(), PRIVKEY, data, os.ModePerm)).To(Succeed())
+
+			env.OCMCommonTransport(ARCH, accessio.FormatDirectory, func() {
+				env.Component(COMP, func() {
+					env.Version(VERSION, func() {
+						env.Provider(PROVIDER)
+						env.Resource("testdata", "", "PlainText", metav1.LocalRelation, func() {
+							env.BlobStringData(mime.MIME_TEXT, "testdata")
+						})
+					})
+				})
+			})
+		})
+
+		Prepare := func() {
+			src := Must(ctf.Open(env.OCMContext(), accessobj.ACC_WRITABLE, ARCH, 0, env))
+			defer Close(src, "repo")
+
+			resolver := ocm.NewCompoundResolver(src)
+			cv := Must(resolver.LookupComponentVersion(COMP, VERSION))
+			defer Close(cv, "cv")
+
+			opts := signing.NewOptions(
+				signing.Sign(signingattr.Get(env.OCMContext()).GetSigner(SIGN_ALGO), SIGNATURE),
+				signing.Resolver(resolver),
+				signing.PrivateKey(SIGNATURE, priv),
+				signing.Update(), signing.VerifyDigests(),
+			)
+			Expect(opts.Complete(env.OCMContext())).To(Succeed())
+
+			Must(signing.Apply(nil, nil, cv, opts))
+		}
+
+		It("verifies download after component verification", func() {
+			buf := bytes.NewBuffer(nil)
+
+			Prepare()
+
+			session := datacontext.NewSession()
+			defer session.Close()
+
+			Expect(env.CatchOutput(buf).Execute("verify", "components", "--verified", VERIFIED_FILE, "-V", "-s", SIGNATURE, "-k", PUBKEY, "--repo", ARCH, COMP+":"+VERSION)).To(Succeed())
+
+			Expect(buf.String()).To(StringEqualTrimmedWithContext(`
+applying to version "test.de/x:v1"[test.de/x:v1]...
+  resource 0:  "name"="testdata": digest SHA-256:810ff2fb242a5dee4220f2cb0e6a519891fb67f2f828a6cab4ef8894633b1f50[genericBlobDigest/v1]
+successfully verified test.de/x:v1 (digest SHA-256:ba5b4af72fcb707a4a8ebc48b088c0d8ed772cb021995b9b1fc7a01fbac29cd2)
+`))
+
+			buf.Reset()
+			Expect(env.CatchOutput(buf).Execute("download", "resources", "--verified", VERIFIED_FILE, "-O", OUT, ARCH)).To(Succeed())
+			Expect(buf.String()).To(StringEqualTrimmedWithContext(
+				`
+/tmp/res: 8 byte(s) written
+/tmp/res: resource content verified
+`))
+			Expect(env.FileExists(OUT)).To(BeTrue())
+			Expect(env.ReadFile(OUT)).To(Equal([]byte("testdata")))
+		})
+
+		It("detects manipulated download after component verification", func() {
+			buf := bytes.NewBuffer(nil)
+
+			Prepare()
+
+			session := datacontext.NewSession()
+			defer session.Close()
+
+			Expect(env.CatchOutput(buf).Execute("verify", "components", "--verified", VERIFIED_FILE, "-V", "-s", SIGNATURE, "-k", PUBKEY, "--repo", ARCH, COMP+":"+VERSION)).To(Succeed())
+
+			Expect(buf.String()).To(StringEqualTrimmedWithContext(`
+applying to version "test.de/x:v1"[test.de/x:v1]...
+  resource 0:  "name"="testdata": digest SHA-256:810ff2fb242a5dee4220f2cb0e6a519891fb67f2f828a6cab4ef8894633b1f50[genericBlobDigest/v1]
+successfully verified test.de/x:v1 (digest SHA-256:ba5b4af72fcb707a4a8ebc48b088c0d8ed772cb021995b9b1fc7a01fbac29cd2)
+`))
+
+			store := Must(signing.NewVerifiedStore(VERIFIED_FILE, env.FileSystem()))
+
+			cd := store.Get(common.NewNameVersion(COMP, VERSION))
+
+			cd.Resources[0].Digest.Value = "b" + cd.Resources[0].Digest.Value[1:]
+			store.Add(cd)
+			MustBeSuccessful(store.Save())
+
+			ExpectError(env.Execute("download", "resources", "--verified", VERIFIED_FILE, "-O", OUT, ARCH)).To(MatchError("component version test.de/x:v1 corrupted"))
 		})
 	})
 })

--- a/cmds/ocm/commands/ocmcmds/resources/download/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/resources/download/cmd_test.go
@@ -7,21 +7,21 @@ import (
 	. "github.com/mandelsoft/goutils/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"ocm.software/ocm/api/datacontext"
-	"ocm.software/ocm/api/ocm"
-	"ocm.software/ocm/api/ocm/extensions/attrs/signingattr"
-	"ocm.software/ocm/api/ocm/extensions/repositories/ctf"
-	"ocm.software/ocm/api/ocm/tools/signing"
-	"ocm.software/ocm/api/tech/signing/handlers/rsa"
-	"ocm.software/ocm/api/utils/accessobj"
-	common "ocm.software/ocm/api/utils/misc"
 	. "ocm.software/ocm/cmds/ocm/testhelper"
 
 	"github.com/mandelsoft/vfs/pkg/vfs"
 
+	"ocm.software/ocm/api/datacontext"
+	"ocm.software/ocm/api/ocm"
 	metav1 "ocm.software/ocm/api/ocm/compdesc/meta/v1"
+	"ocm.software/ocm/api/ocm/extensions/attrs/signingattr"
+	"ocm.software/ocm/api/ocm/extensions/repositories/ctf"
+	"ocm.software/ocm/api/ocm/tools/signing"
+	"ocm.software/ocm/api/tech/signing/handlers/rsa"
 	"ocm.software/ocm/api/utils/accessio"
+	"ocm.software/ocm/api/utils/accessobj"
 	"ocm.software/ocm/api/utils/mime"
+	common "ocm.software/ocm/api/utils/misc"
 )
 
 const (

--- a/cmds/ocm/commands/ocmcmds/resources/download/options.go
+++ b/cmds/ocm/commands/ocmcmds/resources/download/options.go
@@ -20,6 +20,7 @@ func NewOptions(silent ...bool) *Option {
 type Option struct {
 	SilentOption bool
 	UseHandlers  bool
+	Verify       bool
 }
 
 func (o *Option) SetUseHandlers(ok ...bool) *Option {
@@ -31,6 +32,7 @@ func (o *Option) AddFlags(fs *pflag.FlagSet) {
 	if !o.SilentOption {
 		fs.BoolVarP(&o.UseHandlers, "download-handlers", "d", false, "use download handler if possible")
 	}
+	fs.BoolVarP(&o.Verify, "verify", "", false, "verify downloads")
 }
 
 func (o *Option) Usage() string {

--- a/cmds/ocm/commands/ocmcmds/verified/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/verified/cmd.go
@@ -1,0 +1,21 @@
+package verified
+
+import (
+	"github.com/spf13/cobra"
+
+	clictx "ocm.software/ocm/api/cli"
+	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/names"
+	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/verified/get"
+	"ocm.software/ocm/cmds/ocm/common/utils"
+)
+
+var Names = names.Verified
+
+// NewCommand creates a new command.
+func NewCommand(ctx clictx.Context) *cobra.Command {
+	cmd := utils.MassageCommand(&cobra.Command{
+		Short: "Commands acting on verified component versions",
+	}, Names...)
+	cmd.AddCommand(get.NewCommand(ctx, get.Verb))
+	return cmd
+}

--- a/cmds/ocm/commands/ocmcmds/verified/get/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/verified/get/cmd.go
@@ -41,7 +41,7 @@ func NewCommand(ctx clictx.Context, names ...string) *cobra.Command {
 func (o *Command) ForName(name string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "[<options>] {<component / version}",
-		Short: "get verfied component versions",
+		Short: "get verified component versions",
 		Long: `
 Get lists remembered verified component versions.
 `,

--- a/cmds/ocm/commands/ocmcmds/verified/get/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/verified/get/cmd.go
@@ -1,0 +1,106 @@
+package get
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	clictx "ocm.software/ocm/api/cli"
+	handler "ocm.software/ocm/cmds/ocm/commands/ocmcmds/common/handlers/verifiedhdlr"
+	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/common/options/storeoption"
+	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/names"
+	"ocm.software/ocm/cmds/ocm/commands/verbs"
+	"ocm.software/ocm/cmds/ocm/common/output"
+	"ocm.software/ocm/cmds/ocm/common/processing"
+	"ocm.software/ocm/cmds/ocm/common/utils"
+)
+
+var (
+	Names = names.Verified
+	Verb  = verbs.Get
+)
+
+type Command struct {
+	utils.BaseCommand
+
+	path  string
+	Names []string
+}
+
+// NewCommand creates a new ctf command.
+func NewCommand(ctx clictx.Context, names ...string) *cobra.Command {
+	return utils.SetupCommand(
+		&Command{
+			BaseCommand: utils.NewBaseCommand(ctx, output.OutputOptions(outputs).SortColumns("VERSION", "COMPONENT")),
+		},
+		utils.Names(Names, names...)...,
+	)
+}
+
+func (o *Command) ForName(name string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "[<options>] {<component / version}",
+		Short: "get verfied component versions",
+		Long: `
+Get lists remembered verified component versions.
+`,
+		Example: `
+$ ocm get verified
+$ ocm get verified -f verified.yaml acme.org/component -o yaml
+`,
+	}
+}
+
+func (o *Command) AddFlags(fs *pflag.FlagSet) {
+	o.BaseCommand.AddFlags(fs)
+	fs.StringVarP(&o.path, "verified", "", storeoption.DEFAULT_VERIFIED_FILE, "verified file")
+}
+
+func (o *Command) Complete(args []string) error {
+	o.Names = args
+	return nil
+}
+
+func (o *Command) Run() error {
+	hdlr, err := handler.NewTypeHandler(o.Context.OCM(), o.path)
+	if err != nil {
+		return err
+	}
+	return utils.HandleArgs(output.From(o), hdlr, o.Names...)
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+func TableOutput(opts *output.Options, mapping processing.MappingFunction, wide ...string) *output.TableOutput {
+	def := &output.TableOutput{
+		Headers: output.Fields("COMPONENT", "VERSION", wide),
+		Options: opts,
+		Mapping: mapping,
+	}
+	return def
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+var outputs = output.NewOutputs(getRegular, output.Outputs{
+	"wide": getWide,
+}).AddManifestOutputs()
+
+func getRegular(opts *output.Options) output.Output {
+	return TableOutput(opts, mapGetRegularOutput).New()
+}
+
+func getWide(opts *output.Options) output.Output {
+	return TableOutput(opts, mapGetWideOutput, "SIGNATURES").New()
+}
+
+func mapGetRegularOutput(e interface{}) interface{} {
+	p := handler.Elem(e)
+	return []string{p.Element.GetName(), p.Element.GetVersion()}
+}
+
+func mapGetWideOutput(e interface{}) interface{} {
+	p := handler.Elem(e)
+	return []string{p.Element.GetName(), p.Element.GetVersion(), strings.Join(p.Signatures, ", ")}
+}

--- a/cmds/ocm/commands/ocmcmds/verified/get/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/verified/get/cmd_test.go
@@ -1,0 +1,124 @@
+//go:build unix
+
+package get_test
+
+import (
+	"bytes"
+
+	. "github.com/mandelsoft/goutils/testutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"ocm.software/ocm/api/ocm/compdesc"
+	metav1 "ocm.software/ocm/api/ocm/compdesc/meta/v1"
+	"ocm.software/ocm/api/ocm/compdesc/versions/ocm.software/v3alpha1"
+	v2 "ocm.software/ocm/api/ocm/compdesc/versions/v2"
+	. "ocm.software/ocm/cmds/ocm/testhelper"
+
+	"ocm.software/ocm/api/ocm/tools/signing"
+)
+
+const (
+	COMPONENTA = "acme.org/compa"
+	COMPONENTB = "acme.org/compb"
+	VERSION    = "v1"
+)
+
+const VERIFIED_FILE = "verified.yaml"
+
+var _ = Describe("Test Environment", func() {
+	var env *TestEnv
+	var store signing.VerifiedStore
+
+	BeforeEach(func() {
+		env = NewTestEnv()
+
+		store = Must(signing.NewVerifiedStore(VERIFIED_FILE, env))
+
+		cd1 := compdesc.DefaultComponent(&compdesc.ComponentDescriptor{
+			Metadata: compdesc.Metadata{
+				ConfiguredVersion: v3alpha1.SchemaVersion,
+			},
+			ComponentSpec: compdesc.ComponentSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:    COMPONENTA,
+					Version: VERSION,
+					Provider: metav1.Provider{
+						Name: "acme.org",
+					},
+				},
+			},
+		})
+		cd2 := compdesc.DefaultComponent(&compdesc.ComponentDescriptor{
+			Metadata: compdesc.Metadata{
+				ConfiguredVersion: v2.SchemaVersion,
+			},
+			ComponentSpec: compdesc.ComponentSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:    COMPONENTB,
+					Version: VERSION,
+					Provider: metav1.Provider{
+						Name: "acme.org",
+					},
+				},
+			},
+		})
+
+		store.Add(cd1, "a")
+		store.Add(cd2, "b")
+		store.Add(cd2, "c")
+
+		MustBeSuccessful(store.Save())
+	})
+
+	AfterEach(func() {
+		env.Cleanup()
+	})
+
+	It("show verified components", func() {
+		var buf bytes.Buffer
+
+		Expect(env.CatchOutput(&buf).Execute("get", "verified", "--verified", VERIFIED_FILE)).To(Succeed())
+
+		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
+COMPONENT      VERSION
+acme.org/compa v1
+acme.org/compb v1
+`))
+	})
+
+	It("show verified components wide", func() {
+		var buf bytes.Buffer
+
+		Expect(env.CatchOutput(&buf).Execute("get", "verified", "--verified", VERIFIED_FILE, "-o", "wide")).To(Succeed())
+
+		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
+COMPONENT      VERSION SIGNATURES
+acme.org/compa v1      a
+acme.org/compb v1      b, c
+`))
+	})
+
+	It("show verified dedicated component manifest", func() {
+		var buf bytes.Buffer
+
+		Expect(env.CatchOutput(&buf).Execute("get", "verified", "--verified", VERIFIED_FILE, COMPONENTA, "-o", "yaml")).To(Succeed())
+
+		Expect(buf.String()).To(StringEqualTrimmedWithContext(`
+---
+descriptor:
+  component:
+    componentReferences: []
+    name: acme.org/compa
+    provider:
+      name: acme.org
+    repositoryContexts: []
+    resources: []
+    sources: []
+    version: v1
+  meta:
+    configuredSchemaVersion: ocm.software/v3alpha1
+signatures:
+- a
+`))
+	})
+})

--- a/cmds/ocm/commands/ocmcmds/verified/get/suite_test.go
+++ b/cmds/ocm/commands/ocmcmds/verified/get/suite_test.go
@@ -1,0 +1,13 @@
+package get_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OCM get verified")
+}

--- a/cmds/ocm/commands/verbs/get/cmd.go
+++ b/cmds/ocm/commands/verbs/get/cmd.go
@@ -14,6 +14,7 @@ import (
 	resources "ocm.software/ocm/cmds/ocm/commands/ocmcmds/resources/get"
 	routingslips "ocm.software/ocm/cmds/ocm/commands/ocmcmds/routingslips/get"
 	sources "ocm.software/ocm/cmds/ocm/commands/ocmcmds/sources/get"
+	verified "ocm.software/ocm/cmds/ocm/commands/ocmcmds/verified/get"
 	"ocm.software/ocm/cmds/ocm/commands/verbs"
 	"ocm.software/ocm/cmds/ocm/common/utils"
 )
@@ -33,5 +34,6 @@ func NewCommand(ctx clictx.Context) *cobra.Command {
 	cmd.AddCommand(routingslips.NewCommand(ctx))
 	cmd.AddCommand(config.NewCommand(ctx))
 	cmd.AddCommand(pubsub.NewCommand(ctx))
+	cmd.AddCommand(verified.NewCommand(ctx))
 	return cmd
 }

--- a/docs/reference/ocm_download_cli.md
+++ b/docs/reference/ocm_download_cli.md
@@ -20,6 +20,9 @@ cli, ocmcli, ocm-cli
   -O, --outfile string            output file or directory
   -p, --path                      lookup executable in PATH
       --repo string               repository name or spec
+      --use-verified              enable verification store
+      --verified string           file used to remember verifications for downloads (default "~/.ocm/verified")
+      --verify                    verify downloads
 ```
 
 ### Description
@@ -88,6 +91,15 @@ The library supports some downloads with semantics based on resource types. For 
 can be download directly as helm chart archive, even if stored as OCI artifact.
 This is handled by download handler. Their usage can be enabled with the <code>--download-handlers</code>
 option. Otherwise the resource as returned by the access method is stored.
+
+
+If the verification store is enabled, resources downloaded from
+signed or verified component versions are verified against their digests
+provided by the component version.(not supported for using downloaders for the
+resource download).
+
+The usage of the verification store is enabled by <code>--use-verified</code> or by
+specifying a verification file with <code>--verified</code>.
 
 ### SEE ALSO
 

--- a/docs/reference/ocm_download_resources.md
+++ b/docs/reference/ocm_download_resources.md
@@ -15,6 +15,7 @@ resources, resource, res, r
 ### Options
 
 ```text
+      --check-verified              enable verification store
   -c, --constraints constraints     version constraint
   -d, --download-handlers           use download handler if possible
       --downloader <name>=<value>   artifact downloader (<name>[:<artifact type>[:<media type>]]=<JSON target config) (default [])
@@ -26,6 +27,8 @@ resources, resource, res, r
   -r, --recursive                   follow component reference nesting
       --repo string                 repository name or spec
   -t, --type stringArray            resource type filter
+      --verified string             file used to remember verifications for downloads (default "~/.ocm/verified")
+      --verify                      verify downloads
 ```
 
 ### Description
@@ -221,6 +224,15 @@ determined. For *Component Archives* this is never possible, because
 it only contains a single component version. Therefore, in this scenario
 this option must always be specified to be able to follow component
 references.
+
+
+If the verification store is enabled, resources downloaded from
+signed or verified component versions are verified against their digests
+provided by the component version.(not supported for using downloaders for the
+resource download).
+
+The usage of the verification store is enabled by <code>--check-verified</code> or by
+specifying a verification file with <code>--verified</code>.
 
 ### SEE ALSO
 

--- a/docs/reference/ocm_get.md
+++ b/docs/reference/ocm_get.md
@@ -31,4 +31,5 @@ ocm get [<options>] <sub command> ...
 * [ocm get <b>resources</b>](ocm_get_resources.md)	 &mdash; get resources of a component version
 * [ocm get <b>routingslips</b>](ocm_get_routingslips.md)	 &mdash; get routings slips for a component version
 * [ocm get <b>sources</b>](ocm_get_sources.md)	 &mdash; get sources of a component version
+* [ocm get <b>verified</b>](ocm_get_verified.md)	 &mdash; get verfied component versions
 

--- a/docs/reference/ocm_get.md
+++ b/docs/reference/ocm_get.md
@@ -31,5 +31,5 @@ ocm get [<options>] <sub command> ...
 * [ocm get <b>resources</b>](ocm_get_resources.md)	 &mdash; get resources of a component version
 * [ocm get <b>routingslips</b>](ocm_get_routingslips.md)	 &mdash; get routings slips for a component version
 * [ocm get <b>sources</b>](ocm_get_sources.md)	 &mdash; get sources of a component version
-* [ocm get <b>verified</b>](ocm_get_verified.md)	 &mdash; get verfied component versions
+* [ocm get <b>verified</b>](ocm_get_verified.md)	 &mdash; get verified component versions
 

--- a/docs/reference/ocm_get_verified.md
+++ b/docs/reference/ocm_get_verified.md
@@ -1,0 +1,44 @@
+## ocm get verified &mdash; Get Verfied Component Versions
+
+### Synopsis
+
+```bash
+ocm get verified [<options>] {<component / version}
+```
+
+### Options
+
+```text
+  -h, --help               help for verified
+  -o, --output string      output mode (JSON, json, wide, yaml)
+  -s, --sort stringArray   sort fields
+      --verified string    verified file (default "~/.ocm/verified")
+```
+
+### Description
+
+Get lists remembered verified component versions.
+
+
+With the option <code>--output</code> the output mode can be selected.
+The following modes are supported:
+  - <code></code> (default)
+  - <code>JSON</code>
+  - <code>json</code>
+  - <code>wide</code>
+  - <code>yaml</code>
+
+### Examples
+
+```text
+$ ocm get verified
+$ ocm get verified -f verified.yaml acme.org/component -o yaml
+```
+
+### SEE ALSO
+
+#### Parents
+
+* [ocm get](ocm_get.md)	 &mdash; Get information about artifacts and components
+* [ocm](ocm.md)	 &mdash; Open Component Model command line client
+

--- a/docs/reference/ocm_get_verified.md
+++ b/docs/reference/ocm_get_verified.md
@@ -1,4 +1,4 @@
-## ocm get verified &mdash; Get Verfied Component Versions
+## ocm get verified &mdash; Get Verified Component Versions
 
 ### Synopsis
 

--- a/docs/reference/ocm_ocm.md
+++ b/docs/reference/ocm_ocm.md
@@ -32,6 +32,7 @@ ocm ocm [<options>] <sub command> ...
 * ocm ocm <b>routingslips</b>	 &mdash; Commands working on routing slips
 * ocm ocm <b>source-configuration</b>	 &mdash; Commands acting on component source specifications
 * ocm ocm <b>sources</b>	 &mdash; Commands acting on component sources
+* ocm ocm <b>verified</b>	 &mdash; Commands acting on verified component versions
 * ocm ocm <b>versions</b>	 &mdash; Commands acting on component version names
 
 

--- a/docs/reference/ocm_sign_componentversions.md
+++ b/docs/reference/ocm_sign_componentversions.md
@@ -15,6 +15,7 @@ componentversions, componentversion, cv, components, component, comps, comp, c
 ### Options
 
 ```text
+      --                          enable verification store
   -S, --algorithm string          signature handler (default "RSASSA-PKCS1-V1_5")
       --ca-cert stringArray       additional root certificate authorities (for signing certificates)
   -c, --constraints constraints   version constraint
@@ -33,6 +34,7 @@ componentversions, componentversion, cv, components, component, comps, comp, c
       --tsa                       use timestamp authority (default server: http://timestamp.digicert.com)
       --tsa-url string            TSA server URL
       --update                    update digest in component versions (default true)
+      --verified string           file used to remember verifications for downloads (default "~/.ocm/verified")
   -V, --verify                    verify existing digests (default true)
 ```
 
@@ -100,6 +102,14 @@ signature name specified with the option <code>--signature</code>.
 Alternatively a key can be specified as base64 encoded string if the argument
 start with the prefix <code>!</code> or as direct string with the prefix
 <code>=</code>.
+
+If the verification store is enabled, resources downloaded from
+signed or verified component versions are verified against their digests
+provided by the component version.(not supported for using downloaders for the
+resource download).
+
+The usage of the verification store is enabled by <code>--</code> or by
+specifying a verification file with <code>--verified</code>.
 
 If in signing mode a public key is specified, existing signatures for the
 given signature name will be verified, instead of recreated.

--- a/docs/reference/ocm_verify_componentversions.md
+++ b/docs/reference/ocm_verify_componentversions.md
@@ -15,6 +15,7 @@ componentversions, componentversion, cv, components, component, comps, comp, c
 ### Options
 
 ```text
+      --                          enable verification store
       --ca-cert stringArray       additional root certificate authorities (for signing certificates)
   -c, --constraints constraints   version constraint
   -h, --help                      help for componentversions
@@ -27,6 +28,7 @@ componentversions, componentversion, cv, components, component, comps, comp, c
   -k, --public-key stringArray    public key setting
       --repo string               repository name or spec
   -s, --signature stringArray     signature name
+      --verified string           file used to remember verifications for downloads (default "~/.ocm/verified")
   -V, --verify                    verify existing digests
 ```
 
@@ -97,6 +99,14 @@ signature name specified with the option <code>--signature</code>.
 Alternatively a key can be specified as base64 encoded string if the argument
 start with the prefix <code>!</code> or as direct string with the prefix
 <code>=</code>.
+
+If the verification store is enabled, resources downloaded from
+signed or verified component versions are verified against their digests
+provided by the component version.(not supported for using downloaders for the
+resource download).
+
+The usage of the verification store is enabled by <code>--</code> or by
+specifying a verification file with <code>--verified</code>.
 
 \
 If a component lookup for building a reference closure is required


### PR DESCRIPTION
#### What this PR does / why we need it:

Introduction resolution of relative resource references of the level of component descriptors.

So far, this the resolution was only possible on the level of the complete component version access abstraction.
This PR adds such a functionality on the level of plain component descriptors.
Therefore, it provides a `ComponentVersionResolver` abstraction for component descriptors, with two
implementations: a set of component descriptors and a compound resolver similar to the one for component version accesses.

To align the element names in package `compdesc`, the `ComponentReference`ans been renamed to `Reference` (like `Resource` and `Source`). The old type has been deprecated.

This functionality is required for the OCM controllers working an deep resources for a component version.

To verify the digest of the retrieved content of a resource, a new function
`signing.VerifyResourceDigest(cv, index, content)`
is provided. it uses the digesting type described by the component version to recalculate the digest of the retrieved resource and verify it against the digest described by the component version.