### PR TITLE
introduce optional repository interface for resolvers

### DIFF
--- a/api/ocm/cpi/dummy.go
+++ b/api/ocm/cpi/dummy.go
@@ -7,7 +7,6 @@ import (
 
 	"ocm.software/ocm/api/ocm/compdesc"
 	metav1 "ocm.software/ocm/api/ocm/compdesc/meta/v1"
-	"ocm.software/ocm/api/ocm/internal"
 	"ocm.software/ocm/api/ocm/selectors/refsel"
 	"ocm.software/ocm/api/ocm/selectors/rscsel"
 	"ocm.software/ocm/api/ocm/selectors/srcsel"
@@ -50,7 +49,7 @@ func (d *DummyComponentVersionAccess) SetProvider(p *compdesc.Provider) error {
 	return errors.ErrNotSupported()
 }
 
-func (d *DummyComponentVersionAccess) AdjustSourceAccess(meta *internal.SourceMeta, acc compdesc.AccessSpec) error {
+func (d *DummyComponentVersionAccess) AdjustSourceAccess(meta *SourceMeta, acc compdesc.AccessSpec) error {
 	return errors.ErrNotSupported()
 }
 
@@ -163,7 +162,7 @@ func (d *DummyComponentVersionAccess) SetResourceBlob(meta *ResourceMeta, blob B
 	return errors.ErrNotSupported("adding blobs")
 }
 
-func (d *DummyComponentVersionAccess) AdjustResourceAccess(meta *internal.ResourceMeta, acc compdesc.AccessSpec, opts ...ModificationOption) error {
+func (d *DummyComponentVersionAccess) AdjustResourceAccess(meta *ResourceMeta, acc compdesc.AccessSpec, opts ...ModificationOption) error {
 	return errors.ErrNotSupported("resource modification")
 }
 
@@ -203,12 +202,12 @@ func (d *DummyComponentVersionAccess) UseDirectAccess() bool {
 }
 
 // Deprecated: use GetResources.
-func (d *DummyComponentVersionAccess) GetResourcesByIdentitySelectors(selectors ...compdesc.IdentitySelector) ([]internal.ResourceAccess, error) {
+func (d *DummyComponentVersionAccess) GetResourcesByIdentitySelectors(selectors ...compdesc.IdentitySelector) ([]ResourceAccess, error) {
 	return nil, nil
 }
 
 // Deprecated: use GetResources.
-func (d *DummyComponentVersionAccess) GetResourcesByResourceSelectors(selectors ...compdesc.ResourceSelector) ([]internal.ResourceAccess, error) {
+func (d *DummyComponentVersionAccess) GetResourcesByResourceSelectors(selectors ...compdesc.ResourceSelector) ([]ResourceAccess, error) {
 	return nil, nil
 }
 

--- a/api/ocm/cpi/interface.go
+++ b/api/ocm/cpi/interface.go
@@ -36,6 +36,8 @@ type (
 	LocalContextProvider             = internal.LocalContextProvider
 	ComponentVersionResolver         = internal.ComponentVersionResolver
 	ComponentResolver                = internal.ComponentResolver
+	ResolvedComponentProvider        = internal.ResolvedComponentProvider
+	ResolvedComponentVersionProvider = internal.ResolvedComponentVersionProvider
 	Repository                       = internal.Repository
 	RepositoryTypeProvider           = internal.RepositoryTypeProvider
 	RepositoryTypeScheme             = internal.RepositoryTypeScheme
@@ -43,7 +45,7 @@ type (
 	RepositoryPriorityDecoder        = internal.PriorityDecoder[Context, RepositorySpec]
 	RepositorySpecHandlers           = internal.RepositorySpecHandlers
 	RepositorySpecHandler            = internal.RepositorySpecHandler
-	RepositoryProvider               = internal.RepositoryProvider
+	RepositoryProvider               = internal.ResolvedComponentProvider
 	UniformRepositorySpec            = internal.UniformRepositorySpec
 	ComponentLister                  = internal.ComponentLister
 	ComponentAccess                  = internal.ComponentAccess

--- a/api/ocm/cpi/interface.go
+++ b/api/ocm/cpi/interface.go
@@ -35,6 +35,7 @@ type (
 	ContextProvider                  = internal.ContextProvider
 	LocalContextProvider             = internal.LocalContextProvider
 	ComponentVersionResolver         = internal.ComponentVersionResolver
+	ComponentResolver                = internal.ComponentResolver
 	Repository                       = internal.Repository
 	RepositoryTypeProvider           = internal.RepositoryTypeProvider
 	RepositoryTypeScheme             = internal.RepositoryTypeScheme
@@ -42,6 +43,7 @@ type (
 	RepositoryPriorityDecoder        = internal.PriorityDecoder[Context, RepositorySpec]
 	RepositorySpecHandlers           = internal.RepositorySpecHandlers
 	RepositorySpecHandler            = internal.RepositorySpecHandler
+	RepositoryProvider               = internal.RepositoryProvider
 	UniformRepositorySpec            = internal.UniformRepositorySpec
 	ComponentLister                  = internal.ComponentLister
 	ComponentAccess                  = internal.ComponentAccess

--- a/api/ocm/cpi/modopts.go
+++ b/api/ocm/cpi/modopts.go
@@ -26,6 +26,12 @@ type (
 	AddVersionOptions = internal.AddVersionOptions
 )
 
+func NewTargetOptions(list ...TargetOption) *TargetOptions {
+	var m TargetOptions
+	m.ApplyTargetOptions(list...)
+	return &m
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 
 func NewAddVersionOptions(list ...AddVersionOption) *AddVersionOptions {

--- a/api/ocm/cpi/repocpi/interface.go
+++ b/api/ocm/cpi/repocpi/interface.go
@@ -4,4 +4,7 @@ import (
 	"ocm.software/ocm/api/ocm/internal"
 )
 
-type Repository = internal.Repository
+type (
+	Context    = internal.Context
+	Repository = internal.Repository
+)

--- a/api/ocm/cpi/repocpi/view_cv.go
+++ b/api/ocm/cpi/repocpi/view_cv.go
@@ -160,7 +160,7 @@ func (c *componentVersionAccessView) Repository() cpi.Repository {
 	return c.bridge.Repository()
 }
 
-func (c *componentVersionAccessView) GetContext() internal.Context {
+func (c *componentVersionAccessView) GetContext() cpi.Context {
 	return c.bridge.GetContext()
 }
 
@@ -218,7 +218,7 @@ func (c *componentVersionAccessView) Update() error {
 	})
 }
 
-func (c *componentVersionAccessView) AddBlob(blob cpi.BlobAccess, artType, refName string, global cpi.AccessSpec, opts ...internal.BlobUploadOption) (cpi.AccessSpec, error) {
+func (c *componentVersionAccessView) AddBlob(blob cpi.BlobAccess, artType, refName string, global cpi.AccessSpec, opts ...cpi.BlobUploadOption) (cpi.AccessSpec, error) {
 	var spec cpi.AccessSpec
 	eff := cpi.NewBlobUploadOptions(opts...)
 	err := c.Execute(func() error {
@@ -230,7 +230,7 @@ func (c *componentVersionAccessView) AddBlob(blob cpi.BlobAccess, artType, refNa
 	return spec, err
 }
 
-func (c *componentVersionAccessView) AdjustResourceAccess(meta *cpi.ResourceMeta, acc compdesc.AccessSpec, opts ...internal.ModificationOption) error {
+func (c *componentVersionAccessView) AdjustResourceAccess(meta *cpi.ResourceMeta, acc compdesc.AccessSpec, opts ...cpi.ModificationOption) error {
 	cd := c.GetDescriptor()
 	if idx := cd.GetResourceIndex(meta); idx >= 0 {
 		return c.SetResource(&cd.Resources[idx].ResourceMeta, acc, opts...)
@@ -239,7 +239,7 @@ func (c *componentVersionAccessView) AdjustResourceAccess(meta *cpi.ResourceMeta
 }
 
 // SetResourceBlob adds a blob resource to the component version.
-func (c *componentVersionAccessView) SetResourceBlob(meta *cpi.ResourceMeta, blob cpi.BlobAccess, refName string, global cpi.AccessSpec, opts ...internal.BlobModificationOption) error {
+func (c *componentVersionAccessView) SetResourceBlob(meta *cpi.ResourceMeta, blob cpi.BlobAccess, refName string, global cpi.AccessSpec, opts ...cpi.BlobModificationOption) error {
 	cpi.Logger(c).Debug("adding resource blob", "resource", meta.Name)
 	if err := utils.ValidateObject(blob); err != nil {
 		return err
@@ -265,7 +265,7 @@ func (c *componentVersionAccessView) AdjustSourceAccess(meta *cpi.SourceMeta, ac
 	return errors.ErrUnknown(cpi.KIND_RESOURCE, meta.GetIdentity(cd.Resources).String())
 }
 
-func (c *componentVersionAccessView) SetSourceBlob(meta *cpi.SourceMeta, blob cpi.BlobAccess, refName string, global cpi.AccessSpec, modopts ...internal.TargetOption) error {
+func (c *componentVersionAccessView) SetSourceBlob(meta *cpi.SourceMeta, blob cpi.BlobAccess, refName string, global cpi.AccessSpec, modopts ...cpi.TargetOption) error {
 	cpi.Logger(c).Debug("adding source blob", "source", meta.Name)
 	if err := utils.ValidateObject(blob); err != nil {
 		return err
@@ -282,7 +282,7 @@ func (c *componentVersionAccessView) SetSourceBlob(meta *cpi.SourceMeta, blob cp
 	return nil
 }
 
-func setAccess[T any, A internal.ArtifactAccess[T]](c *componentVersionAccessView, kind string, art A,
+func setAccess[T any, A cpi.ArtifactAccess[T]](c *componentVersionAccessView, kind string, art A,
 	set func(*T, compdesc.AccessSpec) error,
 	setblob func(*T, cpi.BlobAccess, string, cpi.AccessSpec) error,
 ) error {
@@ -345,7 +345,7 @@ func (c *componentVersionAccessView) SetResourceByAccess(art cpi.ResourceAccess,
 		})
 }
 
-func (c *componentVersionAccessView) SetResource(meta *internal.ResourceMeta, acc compdesc.AccessSpec, modopts ...cpi.ModificationOption) error {
+func (c *componentVersionAccessView) SetResource(meta *cpi.ResourceMeta, acc compdesc.AccessSpec, modopts ...cpi.ModificationOption) error {
 	if c.bridge.IsReadOnly() {
 		return accessio.ErrReadOnly
 	}
@@ -356,7 +356,7 @@ func (c *componentVersionAccessView) SetResource(meta *internal.ResourceMeta, ac
 	}
 
 	ctx := c.bridge.GetContext()
-	opts := internal.NewModificationOptions(modopts...)
+	opts := cpi.NewModificationOptions(modopts...)
 	cpi.CompleteModificationOptions(ctx, opts)
 
 	spec, err := c.bridge.GetContext().AccessSpecForSpec(acc)
@@ -493,7 +493,7 @@ func (c *componentVersionAccessView) evaluateResourceDigest(res, old *compdesc.R
 	return hashAlgo, digester, value
 }
 
-func (c *componentVersionAccessView) SetSourceByAccess(art cpi.SourceAccess, optslist ...internal.TargetOption) error {
+func (c *componentVersionAccessView) SetSourceByAccess(art cpi.SourceAccess, optslist ...cpi.TargetOption) error {
 	return setAccess(c, "source", art,
 		func(meta *cpi.SourceMeta, acc compdesc.AccessSpec) error {
 			return c.SetSource(meta, acc, optslist...)
@@ -503,7 +503,7 @@ func (c *componentVersionAccessView) SetSourceByAccess(art cpi.SourceAccess, opt
 		})
 }
 
-func (c *componentVersionAccessView) SetSource(meta *cpi.SourceMeta, acc compdesc.AccessSpec, optlist ...internal.TargetOption) error {
+func (c *componentVersionAccessView) SetSource(meta *cpi.SourceMeta, acc compdesc.AccessSpec, optlist ...cpi.TargetOption) error {
 	if c.bridge.IsReadOnly() {
 		return accessio.ErrReadOnly
 	}
@@ -533,7 +533,7 @@ func (c *componentVersionAccessView) SetSource(meta *cpi.SourceMeta, acc compdes
 	})
 }
 
-func (c *componentVersionAccessView) SetReference(ref *cpi.ComponentReference, optlist ...internal.TargetOption) error {
+func (c *componentVersionAccessView) SetReference(ref *cpi.ComponentReference, optlist ...cpi.TargetOption) error {
 	return c.Execute(func() error {
 		cd := c.bridge.GetDescriptor()
 

--- a/api/ocm/cpi/utils.go
+++ b/api/ocm/cpi/utils.go
@@ -3,7 +3,6 @@ package cpi
 import (
 	"io"
 
-	"ocm.software/ocm/api/ocm/internal"
 	"ocm.software/ocm/api/utils/blobaccess/blobaccess"
 	"ocm.software/ocm/api/utils/iotools"
 )
@@ -74,7 +73,7 @@ func ArtifactNameHint(spec AccessSpec, cv ComponentVersionAccess) string {
 }
 
 func ReferenceHint(spec AccessSpec, cv ComponentVersionAccess) string {
-	if h, ok := spec.(internal.HintProvider); ok {
+	if h, ok := spec.(HintProvider); ok {
 		return h.GetReferenceHint(cv)
 	}
 	return ""

--- a/api/ocm/extensions/repositories/composition/type.go
+++ b/api/ocm/extensions/repositories/composition/type.go
@@ -3,7 +3,6 @@ package composition
 import (
 	"ocm.software/ocm/api/credentials"
 	"ocm.software/ocm/api/ocm/cpi"
-	"ocm.software/ocm/api/ocm/internal"
 	"ocm.software/ocm/api/utils/runtime"
 )
 
@@ -31,11 +30,11 @@ func NewRepositorySpec(name string) *RepositorySpec {
 	}
 }
 
-func (r RepositorySpec) AsUniformSpec(context internal.Context) *cpi.UniformRepositorySpec {
+func (r RepositorySpec) AsUniformSpec(context cpi.Context) *cpi.UniformRepositorySpec {
 	return nil
 }
 
-func (r *RepositorySpec) Repository(ctx cpi.Context, credentials credentials.Credentials) (internal.Repository, error) {
+func (r *RepositorySpec) Repository(ctx cpi.Context, credentials credentials.Credentials) (cpi.Repository, error) {
 	return NewRepository(ctx, r.Name), nil
 }
 

--- a/api/ocm/extensions/repositories/virtual/type.go
+++ b/api/ocm/extensions/repositories/virtual/type.go
@@ -3,7 +3,6 @@ package virtual
 import (
 	"ocm.software/ocm/api/credentials"
 	"ocm.software/ocm/api/ocm/cpi"
-	"ocm.software/ocm/api/ocm/internal"
 	"ocm.software/ocm/api/utils/runtime"
 )
 
@@ -24,11 +23,11 @@ func NewRepositorySpec(acc Access) *RepositorySpec {
 	}
 }
 
-func (r RepositorySpec) AsUniformSpec(context internal.Context) *cpi.UniformRepositorySpec {
+func (r RepositorySpec) AsUniformSpec(context cpi.Context) *cpi.UniformRepositorySpec {
 	return nil
 }
 
-func (r *RepositorySpec) Repository(ctx cpi.Context, credentials credentials.Credentials) (internal.Repository, error) {
+func (r *RepositorySpec) Repository(ctx cpi.Context, credentials credentials.Credentials) (cpi.Repository, error) {
 	return NewRepository(ctx, r.Access), nil
 }
 

--- a/api/ocm/interface.go
+++ b/api/ocm/interface.go
@@ -36,9 +36,11 @@ type (
 	ContextProvider                  = internal.ContextProvider
 	LocalContextProvider             = internal.LocalContextProvider
 	ComponentVersionResolver         = internal.ComponentVersionResolver
+	ComponentResolver                = internal.ComponentResolver
 	Repository                       = internal.Repository
 	RepositorySpecHandlers           = internal.RepositorySpecHandlers
 	RepositorySpecHandler            = internal.RepositorySpecHandler
+	RepositoryProvider               = internal.RepositoryProvider
 	UniformRepositorySpec            = internal.UniformRepositorySpec
 	ComponentLister                  = internal.ComponentLister
 	ComponentAccess                  = internal.ComponentAccess

--- a/api/ocm/interface.go
+++ b/api/ocm/interface.go
@@ -37,10 +37,12 @@ type (
 	LocalContextProvider             = internal.LocalContextProvider
 	ComponentVersionResolver         = internal.ComponentVersionResolver
 	ComponentResolver                = internal.ComponentResolver
+	ResolvedComponentProvider        = internal.ResolvedComponentProvider
+	ResolvedComponentVersionProvider = internal.ResolvedComponentVersionProvider
 	Repository                       = internal.Repository
 	RepositorySpecHandlers           = internal.RepositorySpecHandlers
 	RepositorySpecHandler            = internal.RepositorySpecHandler
-	RepositoryProvider               = internal.RepositoryProvider
+	RepositoryProvider               = internal.ResolvedComponentProvider
 	UniformRepositorySpec            = internal.UniformRepositorySpec
 	ComponentLister                  = internal.ComponentLister
 	ComponentAccess                  = internal.ComponentAccess

--- a/api/ocm/internal/repository.go
+++ b/api/ocm/internal/repository.go
@@ -24,40 +24,6 @@ type ReadOnlyFeature interface {
 	SetReadOnly()
 }
 
-// ComponentVersionResolver describes an object able
-// to map component version identities to a component version access,
-// the representtaion of the component version stored in a dedicated
-// OCM repository.
-// Such a resolver might optionally implement the ComponentResolver
-// interface to provide information about potential locations for
-// a particular component.
-type ComponentVersionResolver interface {
-	LookupComponentVersion(name string, version string) (ComponentVersionAccess, error)
-}
-
-type RepositoryProvider interface {
-	Repository() (Repository, error)
-}
-
-// ComponentResolver is an optional interface for a ComponentVersionResolver,
-// which can offer information about potential repositories usable to lookup
-// versions for a dedicated component.
-type ComponentResolver interface {
-	LookupRepositoriesForComponent(name string) []RepositoryProvider
-}
-
-type repositoryProvider struct {
-	repo Repository
-}
-
-func (p *repositoryProvider) Repository() (Repository, error) {
-	return p.repo.Dup()
-}
-
-func RepositoryProviderForRepository(r Repository) RepositoryProvider {
-	return &repositoryProvider{r}
-}
-
 type RepositoryImpl interface {
 	GetContext() Context
 

--- a/api/ocm/internal/repository.go
+++ b/api/ocm/internal/repository.go
@@ -24,8 +24,38 @@ type ReadOnlyFeature interface {
 	SetReadOnly()
 }
 
+// ComponentVersionResolver describes an object able
+// to map component version identities to a component version access,
+// the representtaion of the component version stored in a dedicated
+// OCM repository.
+// Such a resolver might optionally implement the ComponentResolver
+// interface to provide information about potential locations for
+// a particular component.
 type ComponentVersionResolver interface {
 	LookupComponentVersion(name string, version string) (ComponentVersionAccess, error)
+}
+
+type RepositoryProvider interface {
+	Repository() (Repository, error)
+}
+
+// ComponentResolver is an optional interface for a ComponentVersionResolver,
+// which can offer information about potential repositories usable to lookup
+// versions for a dedicated component.
+type ComponentResolver interface {
+	LookupRepositoriesForComponent(name string) []RepositoryProvider
+}
+
+type repositoryProvider struct {
+	repo Repository
+}
+
+func (p *repositoryProvider) Repository() (Repository, error) {
+	return p.repo.Dup()
+}
+
+func RepositoryProviderForRepository(r Repository) RepositoryProvider {
+	return &repositoryProvider{r}
 }
 
 type RepositoryImpl interface {

--- a/api/ocm/resolver_test.go
+++ b/api/ocm/resolver_test.go
@@ -8,11 +8,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "ocm.software/ocm/api/helper/builder"
+	"ocm.software/ocm/api/ocm/internal"
 
 	"ocm.software/ocm/api/ocm"
 	"ocm.software/ocm/api/ocm/extensions/repositories/ctf"
 	"ocm.software/ocm/api/ocm/extensions/repositories/ocireg"
-	"ocm.software/ocm/api/ocm/internal"
 	"ocm.software/ocm/api/utils/accessio"
 	"ocm.software/ocm/api/utils/accessobj"
 )
@@ -96,13 +96,13 @@ var _ = Describe("resolver", func() {
 	})
 })
 
-func Check(r *internal.ResolverRule, prefix string, spec ocm.RepositorySpec, prio int) {
+func Check(r ocm.ResolverRule, prefix string, spec ocm.RepositorySpec, prio int) {
 	ExpectWithOffset(1, r.GetPrefix()).To(Equal(prefix))
 	ExpectWithOffset(1, r.GetPriority()).To(Equal(prio))
 	ExpectWithOffset(1, r.GetSpecification()).To(BeIdenticalTo(spec))
 }
 
-func Print(rules []*internal.ResolverRule) {
+func Print(rules []ocm.ResolverRule) {
 	list := []string{}
 	for _, r := range rules {
 		list = append(list, fmt.Sprintf("[%d]%s", r.GetPriority(), r.GetPrefix()))

--- a/api/ocm/types/interface.go
+++ b/api/ocm/types/interface.go
@@ -11,7 +11,7 @@ type (
 	ComponentVersionResolver         = internal.ComponentVersionResolver
 	ComponentResolver                = internal.ComponentResolver
 	ResolvedComponentProvider        = internal.ResolvedComponentProvider
-	ResolvedomponentVersionProvider  = internal.ResolvedComponentVersionProvider
+	ResolvedComponentVersionProvider = internal.ResolvedComponentVersionProvider
 	Repository                       = internal.Repository
 	RepositorySpecHandlers           = internal.RepositorySpecHandlers
 	RepositorySpecHandler            = internal.RepositorySpecHandler

--- a/api/ocm/types/interface.go
+++ b/api/ocm/types/interface.go
@@ -9,9 +9,11 @@ type (
 	ContextProvider                  = internal.ContextProvider
 	LocalContextProvider             = internal.LocalContextProvider
 	ComponentVersionResolver         = internal.ComponentVersionResolver
+	ComponentResolver                = internal.ComponentResolver
 	Repository                       = internal.Repository
 	RepositorySpecHandlers           = internal.RepositorySpecHandlers
 	RepositorySpecHandler            = internal.RepositorySpecHandler
+	RepositoryProvider               = internal.RepositoryProvider
 	UniformRepositorySpec            = internal.UniformRepositorySpec
 	ComponentLister                  = internal.ComponentLister
 	ComponentAccess                  = internal.ComponentAccess

--- a/api/ocm/types/interface.go
+++ b/api/ocm/types/interface.go
@@ -10,10 +10,12 @@ type (
 	LocalContextProvider             = internal.LocalContextProvider
 	ComponentVersionResolver         = internal.ComponentVersionResolver
 	ComponentResolver                = internal.ComponentResolver
+	ResolvedComponentProvider        = internal.ResolvedComponentProvider
+	ResolvedomponentVersionProvider  = internal.ResolvedComponentVersionProvider
 	Repository                       = internal.Repository
 	RepositorySpecHandlers           = internal.RepositorySpecHandlers
 	RepositorySpecHandler            = internal.RepositorySpecHandler
-	RepositoryProvider               = internal.RepositoryProvider
+	RepositoryProvider               = internal.ResolvedComponentProvider
 	UniformRepositorySpec            = internal.UniformRepositorySpec
 	ComponentLister                  = internal.ComponentLister
 	ComponentAccess                  = internal.ComponentAccess

--- a/cmds/ocm/commands/ocmcmds/common/handlers/vershdlr/suite_test.go
+++ b/cmds/ocm/commands/ocmcmds/common/handlers/vershdlr/suite_test.go
@@ -1,0 +1,13 @@
+package vershdlr_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Version handler Test Suite")
+}

--- a/cmds/ocm/commands/ocmcmds/common/handlers/vershdlr/typehandler.go
+++ b/cmds/ocm/commands/ocmcmds/common/handlers/vershdlr/typehandler.go
@@ -133,7 +133,7 @@ func (h *TypeHandler) filterVersions(vers []string) ([]string, error) {
 	return vers, nil
 }
 
-func (h *TypeHandler) getVersions(repo ocm.Repository, component ocm.ComponentAccess, spec ocm.RefSpec) ([]output.Object, error) {
+func (h *TypeHandler) getVersions(repo ocm.Repository, component ocm.ResolvedComponentVersionProvider, spec ocm.RefSpec) ([]output.Object, error) {
 	var result []output.Object
 	if component == nil {
 		return h.all(repo)
@@ -195,15 +195,12 @@ func (h *TypeHandler) get(repo ocm.Repository, elemspec utils.ElemSpec) ([]outpu
 						if r, ok := h.resolver.(ocm.ComponentResolver); ok {
 							spec = evaluated.Ref
 							spec.Component = comp.Component
-							for _, p := range r.LookupRepositoriesForComponent(comp.Component) {
-								repo, err := p.Repository()
+							for _, p := range r.LookupComponentProviders(comp.Component) {
+								c, err := p.LookupComponent(name)
 								if err != nil {
 									continue
 								}
-								c, err := repo.LookupComponent(comp.Component)
-								if err != nil {
-									continue
-								}
+
 								list, err := h.getVersions(repo, c, spec)
 								if err != nil {
 									return nil, err

--- a/cmds/ocm/commands/ocmcmds/common/handlers/vershdlr/typehandler_test.go
+++ b/cmds/ocm/commands/ocmcmds/common/handlers/vershdlr/typehandler_test.go
@@ -1,0 +1,72 @@
+package vershdlr_test
+
+import (
+	"bytes"
+
+	. "github.com/mandelsoft/goutils/testutils"
+	"github.com/mandelsoft/vfs/pkg/vfs"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"ocm.software/ocm/api/utils/accessio"
+	. "ocm.software/ocm/cmds/ocm/testhelper"
+
+	"ocm.software/ocm/api/ocm/extensions/repositories/ctf"
+	"ocm.software/ocm/api/utils/accessobj"
+)
+
+const ARCH = "ctf"
+const COMP = "acme.org/comp1"
+const VERS1 = "1.0.0"
+const VERS2 = "2.0.0"
+
+var _ = Describe("version handler", func() {
+
+	var env *TestEnv
+
+	BeforeEach(func() {
+		env = NewTestEnv()
+
+		env.OCMCommonTransport(ARCH, accessio.FormatDirectory, func() {
+			env.Component(COMP, func() {
+				env.Version(VERS1)
+				env.Version(VERS2)
+			})
+		})
+
+		env.OCMContext().AddResolverRule(COMP, Must(ctf.NewRepositorySpec(accessobj.ACC_READONLY, ARCH, env)))
+	})
+
+	AfterEach(func() {
+		vfs.Cleanup(env)
+	})
+
+	Context("using resolvers", func() {
+		It("resolves versions", func() {
+			var buf bytes.Buffer
+			MustBeSuccessful(env.CatchOutput(&buf).Execute("list", "cv", COMP))
+			Expect(buf.String()).To(StringEqualTrimmedWithContext(`
+COMPONENT      VERSION MESSAGE
+acme.org/comp1 1.0.0   
+acme.org/comp1 2.0.0   
+`))
+		})
+
+		It("provides error for non-matching resolver", func() {
+			var buf bytes.Buffer
+			MustBeSuccessful(env.CatchOutput(&buf).Execute("list", "cv", "acme.org/dummy"))
+			Expect(buf.String()).To(StringEqualTrimmedWithContext(`
+COMPONENT      VERSION MESSAGE
+acme.org/dummy         <unknown component version>
+`))
+		})
+
+		It("provides error for non-matching component", func() {
+			var buf bytes.Buffer
+			MustBeSuccessful(env.CatchOutput(&buf).Execute("list", "cv", COMP+"/"+"dummy"))
+			Expect(buf.String()).To(StringEqualTrimmedWithContext(`
+COMPONENT            VERSION MESSAGE
+acme.org/comp1/dummy         <unknown component version>
+`))
+		})
+	})
+})

--- a/cmds/ocm/commands/ocmcmds/common/handlers/vershdlr/typehandler_test.go
+++ b/cmds/ocm/commands/ocmcmds/common/handlers/vershdlr/typehandler_test.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 
 	. "github.com/mandelsoft/goutils/testutils"
-	"github.com/mandelsoft/vfs/pkg/vfs"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"ocm.software/ocm/api/utils/accessio"
 	. "ocm.software/ocm/cmds/ocm/testhelper"
 
+	"github.com/mandelsoft/vfs/pkg/vfs"
+
 	"ocm.software/ocm/api/ocm/extensions/repositories/ctf"
+	"ocm.software/ocm/api/utils/accessio"
 	"ocm.software/ocm/api/utils/accessobj"
 )
 

--- a/cmds/ocm/commands/ocmcmds/common/options/lookupoption/option.go
+++ b/cmds/ocm/commands/ocmcmds/common/options/lookupoption/option.go
@@ -91,10 +91,10 @@ func (o *Option) LookupComponentVersion(name string, vers string) (ocm.Component
 	return cv, err
 }
 
-func (o *Option) LookupRepositoriesForComponent(name string) []ocm.RepositoryProvider {
+func (o *Option) LookupComponentProviders(name string) []ocm.ResolvedComponentProvider {
 	if o != nil && o.Resolver != nil {
 		if c, ok := o.Resolver.(ocm.ComponentResolver); ok {
-			return c.LookupRepositoriesForComponent(name)
+			return c.LookupComponentProviders(name)
 		}
 	}
 	return nil

--- a/cmds/ocm/commands/ocmcmds/common/options/lookupoption/option.go
+++ b/cmds/ocm/commands/ocmcmds/common/options/lookupoption/option.go
@@ -26,7 +26,11 @@ type Option struct {
 	Resolver  ocm.ComponentVersionResolver
 }
 
-var _ transferhandler.TransferOption = (*Option)(nil)
+var (
+	_ transferhandler.TransferOption = (*Option)(nil)
+	_ ocm.ComponentVersionResolver   = (*Option)(nil)
+	_ ocm.ComponentResolver          = (*Option)(nil)
+)
 
 func (o *Option) AddFlags(fs *pflag.FlagSet) {
 	fs.StringArrayVarP(&o.RepoSpecs, "lookup", "", nil, "repository name or spec for closure lookup fallback")
@@ -85,6 +89,15 @@ func (o *Option) LookupComponentVersion(name string, vers string) (ocm.Component
 		return nil, err
 	}
 	return cv, err
+}
+
+func (o *Option) LookupRepositoriesForComponent(name string) []ocm.RepositoryProvider {
+	if o != nil && o.Resolver != nil {
+		if c, ok := o.Resolver.(ocm.ComponentResolver); ok {
+			return c.LookupRepositoriesForComponent(name)
+		}
+	}
+	return nil
 }
 
 func (o *Option) ApplyTransferOption(opts transferhandler.TransferOptions) error {


### PR DESCRIPTION
#### What this PR does / why we need it:

CLI command `ocm list componentversions` dumps if only a component is specified together with a resolver (either as part of the config or as option).

This PR fixes this dump.

The resolvers are only able to resolve component versions. Therefore, after the fix the provided list does not show any version for the given component. The expected behaviour would surely be to get the list of versions resolvable by the given resolvers.

Not all resolvers are able to provide repositories offering a version list method. Therefore an optional interface is introduced for
resolvers, which provide potential repositories for a given component. This interface offers the possibility to return repositories or abstract component providers which can be used to get versions or version lists.

This is then checked by the list handling to gather versions provided by all found repositories.

#### Which issue(s) this PR fixes:
Fixes: #864
