### PR TITLE
Adjust workflow: check diff

### DIFF
--- a/.github/workflows/check_diff_action.yaml
+++ b/.github/workflows/check_diff_action.yaml
@@ -31,4 +31,11 @@ jobs:
         go mod tidy
     - name: Check for diff
       run: |
-        git diff --exit-code --shortstat
+        gitStatus="$(git status --porcelain)"
+
+        if [[ -z "${gitStatus}" ]]; then
+            exit 0
+        fi
+
+        echo "${gitStatus}"
+        exit 1


### PR DESCRIPTION
`git diff --exit-code --shortstat` only displays the amount of files that diff, but not which one and it also ignores untracked files.

`git status --porcelain` returns a "script-useable" output (only displaying the files changed, without any info-text), like:
```sh
git status --porcelain
 M .github/workflows/check_diff_action.yaml (Modified)
 D README.md (Deleted)
?? asd (Untracked file)
```
