### PR TITLE
fix cli docu generation

### DIFF
--- a/api/utils/cobrautils/links.go
+++ b/api/utils/cobrautils/links.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mandelsoft/goutils/sliceutils"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +40,7 @@ func SubstituteCommandLinks(desc string, linkformat func(string) string) ([]stri
 			panic("missing </CMD> in:\n" + desc)
 		}
 		path := desc[link+5 : end]
-		links = append(links, path)
+		links = sliceutils.AppendUnique(links, path)
 		desc = desc[:link] + linkformat(path) + desc[end+6:]
 	}
 }

--- a/cmds/ocm/commands/ocicmds/cmd.go
+++ b/cmds/ocm/commands/ocicmds/cmd.go
@@ -20,6 +20,6 @@ func NewCommand(ctx clictx.Context) *cobra.Command {
 	cmd.AddCommand(ctf.NewCommand(ctx))
 	cmd.AddCommand(tags.NewCommand(ctx))
 
-	cmd.AddCommand(topicocirefs.New(ctx))
+	cmd.AddCommand(utils.DocuCommandPath(topicocirefs.New(ctx), "ocm"))
 	return cmd
 }

--- a/cmds/ocm/commands/ocmcmds/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/cmd.go
@@ -41,10 +41,10 @@ func NewCommand(ctx clictx.Context) *cobra.Command {
 	cmd.AddCommand(routingslips.NewCommand(ctx))
 	cmd.AddCommand(pubsub.NewCommand(ctx))
 
-	cmd.AddCommand(topicocmrefs.New(ctx))
-	cmd.AddCommand(topicocmaccessmethods.New(ctx))
-	cmd.AddCommand(topicocmuploaders.New(ctx))
-	cmd.AddCommand(topicocmdownloaders.New(ctx))
+	cmd.AddCommand(utils.DocuCommandPath(topicocmrefs.New(ctx), "ocm"))
+	cmd.AddCommand(utils.DocuCommandPath(topicocmaccessmethods.New(ctx), "ocm"))
+	cmd.AddCommand(utils.DocuCommandPath(topicocmuploaders.New(ctx), "ocm"))
+	cmd.AddCommand(utils.DocuCommandPath(topicocmdownloaders.New(ctx), "ocm"))
 
 	return cmd
 }

--- a/cmds/ocm/commands/toicmds/config/bootstrap/cmd.go
+++ b/cmds/ocm/commands/toicmds/config/bootstrap/cmd.go
@@ -80,7 +80,7 @@ If no credentials file name is provided (option -c) the file
 <code>` + DEFAULT_CREDENTIALS_FILE + `</code> is used. If no parameter file name is
 provided (option -p) the file <code>` + DEFAULT_PARAMETER_FILE + `</code> is used.
 
-For more details about those files see <CMD> ocm bootstrap package</CMD>.
+For more details about those files see <CMD>ocm bootstrap package</CMD>.
 `,
 		Example: `
 $ ocm toi bootstrap config ghcr.io/mandelsoft/ocm//ocmdemoinstaller:0.0.1-dev

--- a/cmds/ocm/common/utils/command.go
+++ b/cmds/ocm/common/utils/command.go
@@ -110,6 +110,14 @@ func OverviewCommand(cmd *cobra.Command) *cobra.Command {
 	return cmd
 }
 
+func DocuCommandPath(cmd *cobra.Command, path string) *cobra.Command {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations["commandPath"] = path + " " + cmd.Name()
+	return cmd
+}
+
 func MassageCommand(cmd *cobra.Command, names ...string) *cobra.Command {
 	cmd.Use = addCommand(names, cmd.Use)
 	if len(names) > 1 {

--- a/cmds/ocm/topics/toi/bootstrapping/topic.go
+++ b/cmds/ocm/topics/toi/bootstrapping/topic.go
@@ -158,7 +158,7 @@ It has the following format:
   - **<code>configFile</code>**: an example template for a parameter file
   - **<code>credentialsFile</code>**: an example template for a credentials file
 
-  Those templates can be downloaded with <CMD>ocm bootstrap config</CMD>.
+  Those templates can be downloaded with <CMD>ocm bootstrap configuration</CMD>.
 
 #### *ExecutorSpecification*
 

--- a/docs/reference/ocm_bootstrap_configuration.md
+++ b/docs/reference/ocm_bootstrap_configuration.md
@@ -40,7 +40,7 @@ If no credentials file name is provided (option -c) the file
 <code>TOICredentials</code> is used. If no parameter file name is
 provided (option -p) the file <code>TOIParameters</code> is used.
 
-For more details about those files see [ ocm bootstrap package](_ocm_bootstrap_package.md).
+For more details about those files see [ocm bootstrap package](ocm_bootstrap_package.md).
 
 
 If the <code>--repo</code> option is specified, the given names are interpreted
@@ -119,5 +119,5 @@ $ ocm toi bootstrap config ghcr.io/mandelsoft/ocm//ocmdemoinstaller:0.0.1-dev
 ##### Additional Links
 
 * [<b>ocm toi-bootstrapping</b>](ocm_toi-bootstrapping.md)	 &mdash; Tiny OCM Installer based on component versions
-* [<b> ocm bootstrap package</b>](_ocm_bootstrap_package.md)
+* [<b>ocm bootstrap package</b>](ocm_bootstrap_package.md)	 &mdash; bootstrap component version
 

--- a/docs/reference/ocm_bootstrap_configuration_toi-bootstrapping.md
+++ b/docs/reference/ocm_bootstrap_configuration_toi-bootstrapping.md
@@ -101,7 +101,7 @@ It has the following format:
   - **<code>configFile</code>**: an example template for a parameter file
   - **<code>credentialsFile</code>**: an example template for a credentials file
 
-  Those templates can be downloaded with [ocm bootstrap config](ocm_bootstrap_config.md).
+  Those templates can be downloaded with [ocm bootstrap configuration](ocm_bootstrap_configuration.md).
 
 #### *ExecutorSpecification*
 
@@ -463,7 +463,5 @@ additionalResources:
 ##### Additional Links
 
 * [<b>ocm bootstrap package</b>](ocm_bootstrap_package.md)	 &mdash; bootstrap component version
-* [<b>ocm bootstrap package</b>](ocm_bootstrap_package.md)	 &mdash; bootstrap component version
-* [<b>ocm bootstrap config</b>](ocm_bootstrap_config.md)
 * [<b>ocm configfile</b>](ocm_configfile.md)	 &mdash; configuration file
 

--- a/docs/reference/ocm_bootstrap_package.md
+++ b/docs/reference/ocm_bootstrap_package.md
@@ -201,5 +201,4 @@ $ ocm toi bootstrap package ghcr.io/mandelsoft/ocm//ocmdemoinstaller:0.0.1-dev
 
 * [<b>ocm toi-bootstrapping</b>](ocm_toi-bootstrapping.md)	 &mdash; Tiny OCM Installer based on component versions
 * [<b>ocm bootstrap configuration</b>](ocm_bootstrap_configuration.md)	 &mdash; bootstrap TOI configuration files
-* [<b>ocm toi-bootstrapping</b>](ocm_toi-bootstrapping.md)	 &mdash; Tiny OCM Installer based on component versions
 

--- a/docs/reference/ocm_bootstrap_package_toi-bootstrapping.md
+++ b/docs/reference/ocm_bootstrap_package_toi-bootstrapping.md
@@ -101,7 +101,7 @@ It has the following format:
   - **<code>configFile</code>**: an example template for a parameter file
   - **<code>credentialsFile</code>**: an example template for a credentials file
 
-  Those templates can be downloaded with [ocm bootstrap config](ocm_bootstrap_config.md).
+  Those templates can be downloaded with [ocm bootstrap configuration](ocm_bootstrap_configuration.md).
 
 #### *ExecutorSpecification*
 
@@ -462,6 +462,6 @@ additionalResources:
 
 ##### Additional Links
 
-* [<b>ocm bootstrap config</b>](ocm_bootstrap_config.md)
+* [<b>ocm bootstrap configuration</b>](ocm_bootstrap_configuration.md)	 &mdash; bootstrap TOI configuration files
 * [<b>ocm configfile</b>](ocm_configfile.md)	 &mdash; configuration file
 

--- a/docs/reference/ocm_configfile.md
+++ b/docs/reference/ocm_configfile.md
@@ -359,5 +359,4 @@ configurations:
 ##### Additional Links
 
 * [<b>ocm ocm-downloadhandlers</b>](ocm_ocm-downloadhandlers.md)	 &mdash; List of all available download handlers
-* [<b>ocm ocm-downloadhandlers</b>](ocm_ocm-downloadhandlers.md)	 &mdash; List of all available download handlers
 

--- a/docs/reference/ocm_describe_package_toi-bootstrapping.md
+++ b/docs/reference/ocm_describe_package_toi-bootstrapping.md
@@ -101,7 +101,7 @@ It has the following format:
   - **<code>configFile</code>**: an example template for a parameter file
   - **<code>credentialsFile</code>**: an example template for a credentials file
 
-  Those templates can be downloaded with [ocm bootstrap config](ocm_bootstrap_config.md).
+  Those templates can be downloaded with [ocm bootstrap configuration](ocm_bootstrap_configuration.md).
 
 #### *ExecutorSpecification*
 
@@ -463,7 +463,6 @@ additionalResources:
 ##### Additional Links
 
 * [<b>ocm bootstrap package</b>](ocm_bootstrap_package.md)	 &mdash; bootstrap component version
-* [<b>ocm bootstrap package</b>](ocm_bootstrap_package.md)	 &mdash; bootstrap component version
-* [<b>ocm bootstrap config</b>](ocm_bootstrap_config.md)
+* [<b>ocm bootstrap configuration</b>](ocm_bootstrap_configuration.md)	 &mdash; bootstrap TOI configuration files
 * [<b>ocm configfile</b>](ocm_configfile.md)	 &mdash; configuration file
 

--- a/docs/reference/ocm_oci.md
+++ b/docs/reference/ocm_oci.md
@@ -29,4 +29,4 @@ ocm oci [<options>] <sub command> ...
 
 ##### Additional Help Topics
 
-* [ocm oci <b>oci-references</b>](ocm_oci_oci-references.md)	 &mdash; notation for OCI references
+* [ocm <b>oci-references</b>](ocm_oci-references.md)	 &mdash; notation for OCI references

--- a/docs/reference/ocm_ocm.md
+++ b/docs/reference/ocm_ocm.md
@@ -38,7 +38,7 @@ ocm ocm [<options>] <sub command> ...
 
 ##### Additional Help Topics
 
-* [ocm ocm <b>ocm-accessmethods</b>](ocm_ocm_ocm-accessmethods.md)	 &mdash; List of all supported access methods
-* [ocm ocm <b>ocm-downloadhandlers</b>](ocm_ocm_ocm-downloadhandlers.md)	 &mdash; List of all available download handlers
-* [ocm ocm <b>ocm-references</b>](ocm_ocm_ocm-references.md)	 &mdash; notation for OCM references
-* [ocm ocm <b>ocm-uploadhandlers</b>](ocm_ocm_ocm-uploadhandlers.md)	 &mdash; List of all available upload handlers
+* [ocm <b>ocm-accessmethods</b>](ocm_ocm-accessmethods.md)	 &mdash; List of all supported access methods
+* [ocm <b>ocm-downloadhandlers</b>](ocm_ocm-downloadhandlers.md)	 &mdash; List of all available download handlers
+* [ocm <b>ocm-references</b>](ocm_ocm-references.md)	 &mdash; notation for OCM references
+* [ocm <b>ocm-uploadhandlers</b>](ocm_ocm-uploadhandlers.md)	 &mdash; List of all available upload handlers

--- a/docs/reference/ocm_toi-bootstrapping.md
+++ b/docs/reference/ocm_toi-bootstrapping.md
@@ -101,7 +101,7 @@ It has the following format:
   - **<code>configFile</code>**: an example template for a parameter file
   - **<code>credentialsFile</code>**: an example template for a credentials file
 
-  Those templates can be downloaded with [ocm bootstrap config](ocm_bootstrap_config.md).
+  Those templates can be downloaded with [ocm bootstrap configuration](ocm_bootstrap_configuration.md).
 
 #### *ExecutorSpecification*
 
@@ -461,7 +461,6 @@ additionalResources:
 ##### Additional Links
 
 * [<b>ocm bootstrap package</b>](ocm_bootstrap_package.md)	 &mdash; bootstrap component version
-* [<b>ocm bootstrap package</b>](ocm_bootstrap_package.md)	 &mdash; bootstrap component version
-* [<b>ocm bootstrap config</b>](ocm_bootstrap_config.md)
+* [<b>ocm bootstrap configuration</b>](ocm_bootstrap_configuration.md)	 &mdash; bootstrap TOI configuration files
 * [<b>ocm configfile</b>](ocm_configfile.md)	 &mdash; configuration file
 

--- a/hack/generate-docs/cobradoc/md_docs.go
+++ b/hack/generate-docs/cobradoc/md_docs.go
@@ -146,7 +146,7 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 				buf.WriteString("\n\n##### Sub Commands\n\n")
 				subheader = true
 			}
-			path := child.CommandPath()
+			path := DocuCommandPath(child)
 			cname := name + " " + "<b>" + child.Name() + "</b>"
 
 			if OverviewOnly(cmd) {
@@ -182,9 +182,9 @@ func GenMarkdownCustom(cmd *cobra.Command, w io.Writer, linkHandler func(string)
 				buf.WriteString("\n\n##### Additional Help Topics\n\n")
 				subheader = true
 			}
-			path := child.CommandPath()
+			path := DocuCommandPath(child)
 			shown_links = append(shown_links, path)
-			cname := name + " " + "<b>" + child.Name() + "</b>"
+			cname := FormattedCommandPath(child)
 			buf.WriteString(fmt.Sprintf("* [%s](%s)\t &mdash; %s\n", cname, linkHandler(path), child.Short))
 		}
 
@@ -255,6 +255,25 @@ func OverviewOnly(cmd *cobra.Command) bool {
 	}
 	_, ok := cmd.Annotations["overview"]
 	return ok
+}
+
+func DocuCommandPath(cmd *cobra.Command) string {
+	if cmd.Annotations != nil {
+		if p, ok := cmd.Annotations["commandPath"]; ok {
+			return p
+		}
+	}
+	return cmd.CommandPath()
+}
+
+func FormattedCommandPath(cmd *cobra.Command) string {
+	path := DocuCommandPath(cmd)
+
+	h := strings.Split(path, " ")
+	if h[len(h)-1] == cmd.Name() {
+		return strings.Join(h[:len(h)-1], " ") + " " + "<b>" + cmd.Name() + "</b>"
+	}
+	return path
 }
 
 // GenMarkdownTreeCustom is the same as GenMarkdownTree, but


### PR DESCRIPTION
#### What this PR does / why we need it:

Links ins CLI documentation are not working if they relate to invisible commands, because for those commands
no document is created.

This is fixed by using a new cobra annotation to declare command path mappings (`commandPath`).
It is evaluated by the CLI doc generator to adapt generated links and command path output.

Besides this new feature some wrongly defined explicit command refs are fixed.

#### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
