### PR TITLE
fix: typo + missing bin directory

### DIFF
--- a/api/credentials/builtin/oci/identity/identity.go
+++ b/api/credentials/builtin/oci/identity/identity.go
@@ -6,7 +6,7 @@ import (
 	"ocm.software/ocm/api/utils/listformat"
 )
 
-// CONSUMER_TYPE is the OCT registry type.
+// CONSUMER_TYPE is the OCI registry type.
 const CONSUMER_TYPE = "OCIRegistry"
 
 // used identity properties.
@@ -28,7 +28,7 @@ const (
 
 func init() {
 	attrs := listformat.FormatListElements("", listformat.StringElementDescriptionList{
-		ATTR_USERNAME, "the basic auth user name",
+		ATTR_USERNAME, "the basic auth username",
 		ATTR_PASSWORD, "the basic auth password",
 		ATTR_IDENTITY_TOKEN, "the bearer token used for non-basic auth authorization",
 		ATTR_CERTIFICATE_AUTHORITY, "the certificate authority certificate used to verify certificates",

--- a/docs/reference/ocm_credential-handling.md
+++ b/docs/reference/ocm_credential-handling.md
@@ -191,7 +191,7 @@ The following credential consumer types are used/supported:
 
     Credential consumers of the consumer type OCIRegistry evaluate the following credential properties:
 
-      - <code>username</code>: the basic auth user name
+      - <code>username</code>: the basic auth username
       - <code>password</code>: the basic auth password
       - <code>identityToken</code>: the bearer token used for non-basic auth authorization
       - <code>certificateAuthority</code>: the certificate authority certificate used to verify certificates

--- a/docs/reference/ocm_get_credentials.md
+++ b/docs/reference/ocm_get_credentials.md
@@ -117,7 +117,7 @@ Matchers exist for the following usage contexts or consumer types:
 
     Credential consumers of the consumer type OCIRegistry evaluate the following credential properties:
 
-      - <code>username</code>: the basic auth user name
+      - <code>username</code>: the basic auth username
       - <code>password</code>: the basic auth password
       - <code>identityToken</code>: the bearer token used for non-basic auth authorization
       - <code>certificateAuthority</code>: the certificate authority certificate used to verify certificates

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -65,7 +65,7 @@ ifneq ($(OCI_REGISTRY), $(OCI_REGISTRY_VERSION))
 endif
 
 .PHONY: install-requirements
-install-requirements: $(deps) $(GOPATH)/bin/goimports mkbin mdref
+install-requirements: mkbin $(deps) $(GOPATH)/bin/goimports mdref
 
 .PHONY: mkbin
 mkbin:

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -65,7 +65,11 @@ ifneq ($(OCI_REGISTRY), $(OCI_REGISTRY_VERSION))
 endif
 
 .PHONY: install-requirements
-install-requirements: $(deps) $(GOPATH)/bin/goimports mdref
+install-requirements: $(deps) $(GOPATH)/bin/goimports mkbin mdref
+
+.PHONY: mkbin
+mkbin:
+	mkdir -p $(LOCALBIN)
 
 .PHONY: gci
 gci:

--- a/hack/Makefile
+++ b/hack/Makefile
@@ -67,7 +67,6 @@ endif
 .PHONY: install-requirements
 install-requirements: mkbin $(deps) $(GOPATH)/bin/goimports mdref
 
-.PHONY: mkbin
 mkbin:
 	mkdir -p $(LOCALBIN)
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
This PR fixes typos.
Additionally, it fixes the Make target `make install-requirements` because of missing `bin` directory.
