### PR TITLE
disable manual/secondary caching

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -140,6 +140,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: '${{ github.workspace }}/go.mod'
+        check-latest: false
 
     - name: Setup Syft
       uses: anchore/sbom-action/download-syft@ab9d16d4b419c9d1a02df5213fa0ebe965ca5a57 # v0.17.1
@@ -151,16 +152,6 @@ jobs:
       run: |
         git config user.name "GitHub Actions Bot"
         git config user.email "<41898282+github-actions[bot]@users.noreply.github.com>"
-
-    - name: Cache go-build and mod
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/go-build/
-          ~/go/pkg/mod/
-        key: go-${{ hashFiles('go.sum') }}
-        restore-keys: |
-          go-
 
     - name: Set Base Version
       run: |

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,0 @@
-sonar.projectKey=open-component-model_ocm_AYuv6Vm-tsYjnul795O-


### PR DESCRIPTION
#### What this PR does / why we need it

The regular setup-go has already a [caching mechanism integrated](https://github.com/actions/setup-go?tab=readme-ov-file#caching-dependency-files-and-build-outputs)

#### Which issue(s) this PR fixes

Fixes #847

