### PR TITLE
align package names with folder names

### DIFF
--- a/api/cli/builder.go
+++ b/api/cli/builder.go
@@ -1,4 +1,4 @@
-package clictx
+package cli
 
 import (
 	"context"

--- a/api/cli/interface.go
+++ b/api/cli/interface.go
@@ -1,4 +1,4 @@
-package clictx
+package cli
 
 import (
 	"ocm.software/ocm/api/cli/internal"

--- a/api/oci/types/interface.go
+++ b/api/oci/types/interface.go
@@ -1,4 +1,4 @@
-package cpi
+package types
 
 // This is the Context Provider Interface for credential providers
 

--- a/api/ocm/compdesc/normalizations/init.go
+++ b/api/ocm/compdesc/normalizations/init.go
@@ -1,4 +1,4 @@
-package versions
+package normalizations
 
 import (
 	_ "ocm.software/ocm/api/ocm/compdesc/normalizations/jsonv1"

--- a/api/ocm/elements/artifactaccess/ociblobaccess/options.go
+++ b/api/ocm/elements/artifactaccess/ociblobaccess/options.go
@@ -1,4 +1,4 @@
-package github
+package ociblobaccess
 
 import (
 	"github.com/mandelsoft/goutils/optionutils"

--- a/api/ocm/elements/artifactaccess/ociblobaccess/resource.go
+++ b/api/ocm/elements/artifactaccess/ociblobaccess/resource.go
@@ -1,4 +1,4 @@
-package github
+package ociblobaccess
 
 import (
 	"github.com/mandelsoft/goutils/optionutils"

--- a/api/ocm/elements/artifactaccess/s3access/options.go
+++ b/api/ocm/elements/artifactaccess/s3access/options.go
@@ -1,4 +1,4 @@
-package github
+package s3access
 
 import (
 	"github.com/mandelsoft/goutils/optionutils"

--- a/api/ocm/elements/artifactaccess/s3access/resource.go
+++ b/api/ocm/elements/artifactaccess/s3access/resource.go
@@ -1,4 +1,4 @@
-package github
+package s3access
 
 import (
 	"github.com/mandelsoft/goutils/optionutils"

--- a/api/ocm/extensions/artifacttypes/const.go
+++ b/api/ocm/extensions/artifacttypes/const.go
@@ -1,4 +1,4 @@
-package resourcetypes
+package artifacttypes
 
 const (
 	KIND_ARTIFACT_TYPE = "artifact type"

--- a/api/ocm/ocmutils/configure.go
+++ b/api/ocm/ocmutils/configure.go
@@ -1,4 +1,4 @@
-package utils
+package ocmutils
 
 import (
 	"fmt"

--- a/api/ocm/ocmutils/resource.go
+++ b/api/ocm/ocmutils/resource.go
@@ -1,4 +1,4 @@
-package utils
+package ocmutils
 
 import (
 	"io"

--- a/api/ocm/ocmutils/resourceref.go
+++ b/api/ocm/ocmutils/resourceref.go
@@ -1,4 +1,4 @@
-package utils
+package ocmutils
 
 import (
 	"fmt"

--- a/api/ocm/ocmutils/resourceref_test.go
+++ b/api/ocm/ocmutils/resourceref_test.go
@@ -1,4 +1,4 @@
-package utils_test
+package ocmutils_test
 
 import (
 	"io"

--- a/api/ocm/ocmutils/suite_test.go
+++ b/api/ocm/ocmutils/suite_test.go
@@ -1,4 +1,4 @@
-package utils_test
+package ocmutils_test
 
 import (
 	"testing"

--- a/api/ocm/ocmutils/utils.go
+++ b/api/ocm/ocmutils/utils.go
@@ -1,4 +1,4 @@
-package utils
+package ocmutils
 
 import (
 	"github.com/mandelsoft/goutils/errors"

--- a/api/ocm/ocmutils/walk.go
+++ b/api/ocm/ocmutils/walk.go
@@ -1,4 +1,4 @@
-package utils
+package ocmutils
 
 import (
 	"github.com/mandelsoft/goutils/errors"

--- a/api/ocm/tools/transfer/transferhandler/config/config.go
+++ b/api/ocm/tools/transfer/transferhandler/config/config.go
@@ -1,4 +1,4 @@
-package scriptoption
+package config
 
 import (
 	cfgcpi "ocm.software/ocm/api/config/cpi"

--- a/api/ocm/types/interface.go
+++ b/api/ocm/types/interface.go
@@ -1,4 +1,4 @@
-package context
+package types
 
 import (
 	"ocm.software/ocm/api/ocm/internal"

--- a/api/utils/misc/const.go
+++ b/api/utils/misc/const.go
@@ -1,3 +1,3 @@
-package common
+package misc
 
 const OCM_TYPE_GROUP_SUFFIX = ".ocm.software"

--- a/api/utils/misc/history.go
+++ b/api/utils/misc/history.go
@@ -1,4 +1,4 @@
-package common
+package misc
 
 import (
 	"fmt"

--- a/api/utils/misc/history_test.go
+++ b/api/utils/misc/history_test.go
@@ -1,4 +1,4 @@
-package common_test
+package misc_test
 
 import (
 	. "github.com/onsi/ginkgo/v2"

--- a/api/utils/misc/printer.go
+++ b/api/utils/misc/printer.go
@@ -1,4 +1,4 @@
-package common
+package misc
 
 import (
 	"bytes"

--- a/api/utils/misc/printer_test.go
+++ b/api/utils/misc/printer_test.go
@@ -1,4 +1,4 @@
-package common
+package misc
 
 import (
 	"bytes"

--- a/api/utils/misc/properties.go
+++ b/api/utils/misc/properties.go
@@ -1,4 +1,4 @@
-package common
+package misc
 
 import (
 	"encoding/json"

--- a/api/utils/misc/suite_test.go
+++ b/api/utils/misc/suite_test.go
@@ -1,4 +1,4 @@
-package common_test
+package misc_test
 
 import (
 	"testing"

--- a/api/utils/misc/types.go
+++ b/api/utils/misc/types.go
@@ -1,4 +1,4 @@
-package common
+package misc
 
 import (
 	"encoding/json"

--- a/api/utils/misc/utils.go
+++ b/api/utils/misc/utils.go
@@ -1,4 +1,4 @@
-package common
+package misc
 
 import (
 	"reflect"

--- a/api/utils/misc/walk.go
+++ b/api/utils/misc/walk.go
@@ -1,4 +1,4 @@
-package common
+package misc
 
 import (
 	"github.com/mandelsoft/logging"

--- a/cmds/ocm/commands/misccmds/config/cmd.go
+++ b/cmds/ocm/commands/misccmds/config/cmd.go
@@ -1,4 +1,4 @@
-package credentials
+package config
 
 import (
 	"github.com/spf13/cobra"

--- a/cmds/ocm/commands/misccmds/hash/cmd.go
+++ b/cmds/ocm/commands/misccmds/hash/cmd.go
@@ -1,4 +1,4 @@
-package credentials
+package hash
 
 import (
 	"github.com/spf13/cobra"

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/init.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/init.go
@@ -1,4 +1,4 @@
-package handlers
+package types
 
 import (
 	_ "ocm.software/ocm/cmds/ocm/commands/ocmcmds/common/inputs/types/binary"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Because of an error in the migration script some package renames resulted in a mismatch of the folder name
of the package and its name.

This PR fixes this, and also aligns some packages which had the wrong names even before the migration.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
