### PR TITLE
Chore: setup-go@v4 does caching automatically

### DIFF
--- a/.github/workflows/buildcomponents.yaml
+++ b/.github/workflows/buildcomponents.yaml
@@ -23,8 +23,6 @@ jobs:
         
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/buildcomponents.yaml
+++ b/.github/workflows/buildcomponents.yaml
@@ -9,13 +9,7 @@ on:
         default: false
 
 jobs:
-#  lint-and-test:
-#    uses: ./.github/workflows/lint_and_test.yaml
-#    permissions:
-#      contents: read
-#      pull-requests: read
   components:
-#    needs: lint-and-test
     name: Trigger component build
     runs-on: large_runner
     permissions:
@@ -36,16 +30,6 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: '${{ github.workspace }}/go.mod'
-
-      - name: Cache go-build and mod
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build/
-            ~/go/pkg/mod/
-          key: go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-
 
       - name: Push OCM Components
         if: inputs.ocm_push == true

--- a/.github/workflows/check_diff_action.yaml
+++ b/.github/workflows/check_diff_action.yaml
@@ -16,13 +16,6 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version-file: '${{ github.workspace }}/go.mod'
-    - name: Restore Go cache
-      uses: actions/cache@v4
-      with:
-        path: /home/runner/work/_temp/_github_home/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
     - name: Make generate and deepcopy
       run: |
         make -f hack/Makefile mdref && make -f hack/Makefile go-bindata && make generate && make generate-deepcopy

--- a/.github/workflows/check_diff_action.yaml
+++ b/.github/workflows/check_diff_action.yaml
@@ -10,8 +10,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
     - name: Setup Go
       uses: actions/setup-go@v5
       with:
@@ -25,10 +23,8 @@ jobs:
     - name: Check for diff
       run: |
         gitStatus="$(git status --porcelain)"
-
         if [[ -z "${gitStatus}" ]]; then
             exit 0
         fi
-
         echo "${gitStatus}"
         exit 1

--- a/.github/workflows/components.yaml
+++ b/.github/workflows/components.yaml
@@ -22,15 +22,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - name: Cache go-build and mod
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build/
-            ~/go/pkg/mod/
-          key: go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -49,15 +40,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - name: Cache go-build and mod
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build/
-            ~/go/pkg/mod/
-          key: go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -76,15 +58,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - name: Cache go-build and mod
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build/
-            ~/go/pkg/mod/
-          key: go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -103,15 +76,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - name: Cache go-build and mod
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build/
-            ~/go/pkg/mod/
-          key: go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -133,15 +97,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - name: Cache go-build and mod
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build/
-            ~/go/pkg/mod/
-          key: go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/components.yaml
+++ b/.github/workflows/components.yaml
@@ -19,9 +19,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -37,9 +34,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -55,9 +49,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -73,9 +64,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -94,9 +82,6 @@ jobs:
         
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -22,15 +22,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - name: Cache go-build and mod
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build/
-            ~/go/pkg/mod/
-          key: go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -48,15 +39,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - name: Cache go-build and mod
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build/
-            ~/go/pkg/mod/
-          key: go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -83,15 +65,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - name: Cache go-build and mod
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build/
-            ~/go/pkg/mod/
-          key: go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-
       - name: Setup Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -52,26 +52,3 @@ jobs:
       - name: Lint
         run: |
           PATH=$PATH:$(go env GOPATH)/bin make check
-
-  generate:
-    name: DeepCopy verification
-    runs-on: large_runner
-    steps:
-      - name: Self Hosted Runner Post Job Cleanup Action
-        uses: TooMuch4U/actions-clean@v2.2
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: '${{ github.workspace }}/go.mod'
-      - name: Generate DeepCopy
-        run: |
-          PATH=$PATH:$(go env GOPATH)/bin make generate-deepcopy
-      - name: Check for diff
-        run: |
-          git diff --exit-code --shortstat

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -19,9 +19,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -36,9 +33,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
       - name: Setup Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/push_ocm.yaml
+++ b/.github/workflows/push_ocm.yaml
@@ -25,7 +25,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}
 
       - name: Set up QEMU

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,6 +100,13 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+  diff-check-manifests:
+    name: Check for diff after go mod tidy and generated targets
+    uses: ./.github/workflows/check_diff_action.yaml
+    needs: check
+    permissions:
+      contents: read
+      pull-requests: read
 
   release:
     needs:


### PR DESCRIPTION
#### What this PR does / why we need it

Speed up the executed github actions.

There is no need to cache manually in most cases.
And there is normally no need to fetch the complete git history.
