### PR TITLE
Custom Unmarshaler for Consumer Identity

### DIFF
--- a/api/credentials/internal/identity.go
+++ b/api/credentials/internal/identity.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
+
+	"ocm.software/ocm/api/utils/runtime"
 )
 
 func init() {
@@ -90,6 +92,26 @@ func orMatcher(list []IdentityMatcher) IdentityMatcher {
 
 // ConsumerIdentity describes the identity of a credential consumer.
 type ConsumerIdentity map[string]string
+
+func (c *ConsumerIdentity) UnmarshalJSON(data []byte) error {
+	m := map[string]interface{}{}
+	err := runtime.DefaultJSONEncoding.Unmarshal(data, &m)
+	if err != nil {
+		return err
+	}
+
+	*c = make(map[string]string, len(m))
+	for k, v := range m {
+		switch v.(type) {
+		case map[string]interface{}:
+			return fmt.Errorf("cannot unmarshal complex type into consumer identity")
+		case []interface{}:
+			return fmt.Errorf("cannot unmarshal complex type into consumer identity")
+		}
+		(*c)[k] = fmt.Sprintf("%v", v)
+	}
+	return nil
+}
 
 func NewConsumerIdentity(typ string, attrs ...string) ConsumerIdentity {
 	r := map[string]string{}

--- a/api/credentials/internal/identity_test.go
+++ b/api/credentials/internal/identity_test.go
@@ -1,0 +1,73 @@
+package internal_test
+
+import (
+	. "github.com/mandelsoft/goutils/testutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/yaml"
+
+	"ocm.software/ocm/api/credentials/identity/hostpath"
+	"ocm.software/ocm/api/credentials/internal"
+)
+
+var _ = Describe("unmarshal cunsomer identity", func() {
+	It("with int", func() {
+		data := `
+scheme: http
+hostname: 127.0.0.1
+port: 5001
+`
+		cid := internal.ConsumerIdentity{}
+		MustBeSuccessful(yaml.Unmarshal([]byte(data), &cid))
+		Expect(cid[hostpath.ID_SCHEME]).To(Equal("http"))
+		Expect(cid[hostpath.ID_HOSTNAME]).To(Equal("127.0.0.1"))
+		Expect(cid[hostpath.ID_PORT]).To(Equal("5001"))
+	})
+	It("with float", func() {
+		data := `
+scheme: http
+hostname: 127.0.0.1
+port: 3.14
+`
+		cid := internal.ConsumerIdentity{}
+		MustBeSuccessful(yaml.Unmarshal([]byte(data), &cid))
+		Expect(cid[hostpath.ID_SCHEME]).To(Equal("http"))
+		Expect(cid[hostpath.ID_HOSTNAME]).To(Equal("127.0.0.1"))
+		Expect(cid[hostpath.ID_PORT]).To(Equal("3.14"))
+	})
+	It("with bool", func() {
+		data := `
+scheme: http
+hostname: 127.0.0.1
+port: true
+`
+		cid := internal.ConsumerIdentity{}
+		MustBeSuccessful(yaml.Unmarshal([]byte(data), &cid))
+		Expect(cid[hostpath.ID_SCHEME]).To(Equal("http"))
+		Expect(cid[hostpath.ID_HOSTNAME]).To(Equal("127.0.0.1"))
+		Expect(cid[hostpath.ID_PORT]).To(Equal("true"))
+	})
+	It("with complex value", func() {
+		data := `
+scheme: http
+hostname: 127.0.0.1
+port:
+  pre: 50
+  post: 01
+`
+		cid := internal.ConsumerIdentity{}
+		Expect(yaml.Unmarshal([]byte(data), &cid)).NotTo(Succeed())
+	})
+	It("with slice value", func() {
+		data := `
+scheme: http
+hostname: 127.0.0.1
+port:
+- 50
+- 01
+`
+		cid := internal.ConsumerIdentity{}
+		Expect(yaml.Unmarshal([]byte(data), &cid)).NotTo(Succeed())
+	})
+})

--- a/api/ocm/add_test.go
+++ b/api/ocm/add_test.go
@@ -4,7 +4,6 @@ import (
 	. "github.com/mandelsoft/goutils/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"ocm.software/ocm/api/ocm/selectors"
 	. "ocm.software/ocm/api/ocm/testhelper"
 
 	"ocm.software/ocm/api/datacontext"
@@ -12,6 +11,7 @@ import (
 	metav1 "ocm.software/ocm/api/ocm/compdesc/meta/v1"
 	resourcetypes "ocm.software/ocm/api/ocm/extensions/artifacttypes"
 	"ocm.software/ocm/api/ocm/extensions/repositories/composition"
+	"ocm.software/ocm/api/ocm/selectors"
 	"ocm.software/ocm/api/utils/blobaccess"
 	"ocm.software/ocm/api/utils/mime"
 )

--- a/api/ocm/compdesc/selector_test.go
+++ b/api/ocm/compdesc/selector_test.go
@@ -4,13 +4,13 @@ import (
 	. "github.com/mandelsoft/goutils/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"ocm.software/ocm/api/ocm/selectors/labelsel"
-	"ocm.software/ocm/api/ocm/selectors/refsel"
-	"ocm.software/ocm/api/ocm/selectors/rscsel"
 
 	"ocm.software/ocm/api/ocm/compdesc"
 	v1 "ocm.software/ocm/api/ocm/compdesc/meta/v1"
 	"ocm.software/ocm/api/ocm/extensions/repositories/ocireg"
+	"ocm.software/ocm/api/ocm/selectors/labelsel"
+	"ocm.software/ocm/api/ocm/selectors/refsel"
+	"ocm.software/ocm/api/ocm/selectors/rscsel"
 )
 
 var _ = Describe("helper", func() {

--- a/api/ocm/cpi/compose_test.go
+++ b/api/ocm/cpi/compose_test.go
@@ -5,7 +5,6 @@ import (
 	. "github.com/mandelsoft/goutils/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"ocm.software/ocm/api/ocm/selectors"
 	. "ocm.software/ocm/api/ocm/testhelper"
 
 	"github.com/mandelsoft/vfs/pkg/memoryfs"
@@ -18,6 +17,7 @@ import (
 	resourcetypes "ocm.software/ocm/api/ocm/extensions/artifacttypes"
 	"ocm.software/ocm/api/ocm/extensions/attrs/compositionmodeattr"
 	"ocm.software/ocm/api/ocm/extensions/repositories/ctf"
+	"ocm.software/ocm/api/ocm/selectors"
 	"ocm.software/ocm/api/utils/accessio"
 	"ocm.software/ocm/api/utils/accessobj"
 	"ocm.software/ocm/api/utils/blobaccess"

--- a/api/ocm/extensions/repositories/comparch/comparch_test.go
+++ b/api/ocm/extensions/repositories/comparch/comparch_test.go
@@ -6,7 +6,6 @@ import (
 	. "github.com/mandelsoft/goutils/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"ocm.software/ocm/api/ocm/selectors"
 	. "ocm.software/ocm/api/ocm/testhelper"
 
 	"github.com/mandelsoft/filepath/pkg/filepath"
@@ -22,6 +21,7 @@ import (
 	resourcetypes "ocm.software/ocm/api/ocm/extensions/artifacttypes"
 	"ocm.software/ocm/api/ocm/extensions/digester/digesters/blob"
 	"ocm.software/ocm/api/ocm/extensions/repositories/comparch"
+	"ocm.software/ocm/api/ocm/selectors"
 	"ocm.software/ocm/api/tech/signing/hasher/sha256"
 	"ocm.software/ocm/api/utils/accessio"
 	"ocm.software/ocm/api/utils/accessobj"

--- a/api/ocm/extensions/repositories/composition/repository_test.go
+++ b/api/ocm/extensions/repositories/composition/repository_test.go
@@ -4,7 +4,6 @@ import (
 	. "github.com/mandelsoft/goutils/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"ocm.software/ocm/api/ocm/selectors"
 
 	"github.com/mandelsoft/goutils/finalizer"
 	"github.com/mandelsoft/vfs/pkg/memoryfs"
@@ -16,6 +15,7 @@ import (
 	resourcetypes "ocm.software/ocm/api/ocm/extensions/artifacttypes"
 	me "ocm.software/ocm/api/ocm/extensions/repositories/composition"
 	"ocm.software/ocm/api/ocm/ocmutils"
+	"ocm.software/ocm/api/ocm/selectors"
 	"ocm.software/ocm/api/utils/accessio"
 	"ocm.software/ocm/api/utils/accessobj"
 	"ocm.software/ocm/api/utils/blobaccess/blobaccess"

--- a/api/ocm/extensions/repositories/composition/version_test.go
+++ b/api/ocm/extensions/repositories/composition/version_test.go
@@ -4,7 +4,6 @@ import (
 	. "github.com/mandelsoft/goutils/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"ocm.software/ocm/api/ocm/selectors"
 
 	"github.com/mandelsoft/goutils/finalizer"
 
@@ -13,6 +12,7 @@ import (
 	resourcetypes "ocm.software/ocm/api/ocm/extensions/artifacttypes"
 	me "ocm.software/ocm/api/ocm/extensions/repositories/composition"
 	"ocm.software/ocm/api/ocm/ocmutils"
+	"ocm.software/ocm/api/ocm/selectors"
 	"ocm.software/ocm/api/utils/blobaccess"
 	"ocm.software/ocm/api/utils/blobaccess/bpi"
 	"ocm.software/ocm/api/utils/mime"

--- a/api/ocm/resolvers/component_test.go
+++ b/api/ocm/resolvers/component_test.go
@@ -1,15 +1,16 @@
 package resolvers_test
 
 import (
-	"github.com/mandelsoft/goutils/sliceutils"
 	. "github.com/mandelsoft/goutils/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "ocm.software/ocm/api/helper/builder"
-	"ocm.software/ocm/api/ocm/resolvers"
+
+	"github.com/mandelsoft/goutils/sliceutils"
 
 	"ocm.software/ocm/api/ocm"
 	"ocm.software/ocm/api/ocm/extensions/repositories/ctf"
+	"ocm.software/ocm/api/ocm/resolvers"
 	"ocm.software/ocm/api/utils/accessio"
 	"ocm.software/ocm/api/utils/accessobj"
 )

--- a/cmds/ocm/commands/ocmcmds/references/add/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/references/add/cmd_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"ocm.software/ocm/api/ocm/selectors/refsel"
 	. "ocm.software/ocm/cmds/ocm/testhelper"
 
 	"github.com/mandelsoft/goutils/testutils"
@@ -13,6 +12,7 @@ import (
 	"ocm.software/ocm/api/ocm/compdesc"
 	metav1 "ocm.software/ocm/api/ocm/compdesc/meta/v1"
 	"ocm.software/ocm/api/ocm/extensions/repositories/comparch"
+	"ocm.software/ocm/api/ocm/selectors/refsel"
 )
 
 const (

--- a/examples/lib/comparison-scenario/09-localize.go
+++ b/examples/lib/comparison-scenario/09-localize.go
@@ -8,7 +8,6 @@ import (
 	"github.com/mandelsoft/vfs/pkg/memoryfs"
 	"github.com/mandelsoft/vfs/pkg/vfs"
 	"helm.sh/helm/v3/pkg/chart"
-	"ocm.software/ocm/api/ocm/selectors/rscsel"
 	"sigs.k8s.io/yaml"
 
 	"ocm.software/ocm/api/ocm"
@@ -17,6 +16,7 @@ import (
 	"ocm.software/ocm/api/ocm/ocmutils"
 	"ocm.software/ocm/api/ocm/ocmutils/localize"
 	"ocm.software/ocm/api/ocm/resourcerefs"
+	"ocm.software/ocm/api/ocm/selectors/rscsel"
 	"ocm.software/ocm/api/tech/helm/loader"
 	"ocm.software/ocm/api/utils"
 	"ocm.software/ocm/api/utils/runtime"

--- a/examples/lib/tour/03-working-with-credentials/02-basic-credential-management.go
+++ b/examples/lib/tour/03-working-with-credentials/02-basic-credential-management.go
@@ -6,12 +6,12 @@ import (
 	"os"
 
 	"github.com/mandelsoft/goutils/errors"
-	"ocm.software/ocm/api/ocm/selectors"
 
 	"ocm.software/ocm/api/credentials"
 	"ocm.software/ocm/api/oci"
 	"ocm.software/ocm/api/ocm"
 	"ocm.software/ocm/api/ocm/extensions/repositories/ocireg"
+	"ocm.software/ocm/api/ocm/selectors"
 	"ocm.software/ocm/api/tech/oci/identity"
 	"ocm.software/ocm/examples/lib/helper"
 )


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
This PR adds a custom unmarshaler to the consumer identity type.

Adding this custom unmarshaler to the consumer identity allows a yaml specification containing a data type other string, e.g. a hostpath spec with a port. Previously, it would error if the user specified `port: 5000` and instead, the user had to specify `port: "5000"`.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
