### PR TITLE
fix: some weird maven repositories do return bad index-of listings

### DIFF
--- a/api/utils/blobaccess/maven/access_test.go
+++ b/api/utils/blobaccess/maven/access_test.go
@@ -16,7 +16,6 @@ import (
 
 const (
 	MAVEN_PATH            = "/testdata/.m2/repository"
-	FAIL_PATH             = "/testdata/.m2/fail"
 	MAVEN_CENTRAL_ADDRESS = "repo.maven.apache.org:443"
 	MAVEN_CENTRAL         = "https://repo.maven.apache.org/maven2/"
 	MAVEN_GROUP_ID        = "maven"


### PR DESCRIPTION
#### What this PR does / why we need it

Some repos do automatically redirect from 
https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.9 to https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.9.9/ (<<-- see the slash at the end)

But Sonatype Nexus Repository (OSS 3.71.0-06) don't!!!
And their returned index-of page, which should list the repository content can't be fetched, when not sending a proper 'User-Agent' header. And the listing contains absolute links instead of relative ones.
