### PR TITLE
Add a simpler digest verify function

### DIFF
--- a/api/ocm/compdesc/meta/v1/identity.go
+++ b/api/ocm/compdesc/meta/v1/identity.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -51,7 +53,9 @@ func (i Identity) Digest() []byte {
 		logging.Logger().LogError(err, "corrupted digest")
 	}
 
-	return data
+	hash := sha256.Sum256(data)
+
+	return []byte(hex.EncodeToString(hash[:]))
 }
 
 // Equals compares two identities.

--- a/api/ocm/tools/signing/digest.go
+++ b/api/ocm/tools/signing/digest.go
@@ -62,7 +62,7 @@ func VerifyResourceDigest(cv ocm.ComponentVersionAccess, i int, bacc ocm.DataAcc
 			if vcd.Resources[i].Digest.Equal(raw.Digest) {
 				return true, nil
 			}
-			return false, fmt.Errorf("component version %s corrupted", common.VersionedElementKey(cv))
+			return true, fmt.Errorf("component version %s corrupted", common.VersionedElementKey(cv))
 		}
 	}
 


### PR DESCRIPTION
As proposed and discussed a simpler version of `VerifyResourceDigest`.

The new name is a bit misleading and probably the name of the old function should be adjusted.

@mandelsoft What do you think? And can you please explain the behaviour of the `VerifiedStore`?