### PR TITLE
OCI: prefer digest over tag

### DIFF
--- a/api/oci/ref.go
+++ b/api/oci/ref.go
@@ -263,11 +263,11 @@ type ArtSpec struct {
 }
 
 func (r *ArtSpec) Version() string {
-	if r.Tag != nil {
-		return *r.Tag
-	}
 	if r.Digest != nil {
 		return "@" + string(*r.Digest)
+	}
+	if r.Tag != nil {
+		return *r.Tag
 	}
 	return "latest"
 }
@@ -284,14 +284,11 @@ func (r *ArtSpec) IsTagged() bool {
 	return r.Tag != nil
 }
 
-func (r *ArtSpec) Reference() string {
+func (r *ArtSpec) GetTag() string {
 	if r.Tag != nil {
 		return *r.Tag
 	}
-	if r.Digest != nil {
-		return "@" + string(*r.Digest)
-	}
-	return "latest"
+	return ""
 }
 
 func (r *ArtSpec) String() string {

--- a/api/oci/utils.go
+++ b/api/oci/utils.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"fmt"
+	"strings"
 
 	"ocm.software/ocm/api/credentials/cpi"
 	"ocm.software/ocm/api/oci/artdesc"
@@ -19,8 +20,15 @@ func AsTags(tag string) []string {
 
 func StandardOCIRef(host, repository, version string) string {
 	sep := grammar.TagSeparator
+	i := strings.Index(version, grammar.DigestSeparator)
+	if i > 1 {
+		return fmt.Sprintf("%s%s%s%s%s", host, grammar.RepositorySeparator, repository, sep, version)
+	}
 	if ok, _ := artdesc.IsDigest(version); ok {
 		sep = grammar.DigestSeparator
+		if strings.HasPrefix(version, sep) {
+			sep = ""
+		}
 	}
 	return fmt.Sprintf("%s%s%s%s%s", host, grammar.RepositorySeparator, repository, sep, version)
 }

--- a/api/ocm/cpi/repocpi/bridge_cv.go
+++ b/api/ocm/cpi/repocpi/bridge_cv.go
@@ -328,7 +328,8 @@ func (b *componentVersionAccessBridge) AddBlob(blob cpi.BlobAccess, artType, ref
 	}
 	if prov != nil {
 		storagectx := b.GetStorageContext()
-		h := prov.LookupHandler(storagectx, artType, blob.MimeType())
+		mime := blob.MimeType()
+		h := prov.LookupHandler(storagectx, artType, mime)
 		if h != nil {
 			acc, err := h.StoreBlob(blob, artType, refName, nil, storagectx)
 			if err != nil {

--- a/api/ocm/extensions/accessmethods/maven/README.md
+++ b/api/ocm/extensions/accessmethods/maven/README.md
@@ -3,7 +3,7 @@
 ## Synopsis
 
 ```yaml
-type: mvn/v1
+type: maven/v1
 ```
 
 Provided blobs use the following media type: `application/x-tgz`
@@ -21,7 +21,7 @@ Supported specification version is `v1`
 
 The type specific specification fields are:
 
-- **`repository`** *string*
+- **`repoUrl`** *string*
 
   Base URL of the Maven (mvn) repository
 

--- a/api/ocm/extensions/accessmethods/ociartifact/method.go
+++ b/api/ocm/extensions/accessmethods/ociartifact/method.go
@@ -155,6 +155,9 @@ var (
 )
 
 func NewMethod(ctx accspeccpi.ContextProvider, a accspeccpi.AccessSpec, ref string, repo ...oci.Repository) (accspeccpi.AccessMethod, error) {
+	if ref == "" {
+		return nil, errors.ErrInvalid(ocmcpi.KIND_OCM_REFERENCE, "<empty>")
+	}
 	m := &accessMethod{
 		spec:      a,
 		reference: ref,

--- a/api/ocm/extensions/accessmethods/relativeociref/transfer_test.go
+++ b/api/ocm/extensions/accessmethods/relativeociref/transfer_test.go
@@ -144,6 +144,6 @@ var _ = Describe("Transfer handler", func() {
 
 		fmt.Printf("%s\n", string(data))
 		hash := HashManifest1(artifactset.DefaultArtifactSetDescriptorFileName)
-		Expect(string(data)).To(StringEqualWithContext(fmt.Sprintf(`{"globalAccess":{"imageReference":"baseurl.io/ocm/value:v2.0","type":"ociArtifact"},"localReference":"%s","mediaType":"application/vnd.oci.image.manifest.v1+tar+gzip","referenceName":"ocm/value:v2.0","type":"localBlob"}`, hash)))
+		Expect(string(data)).To(StringEqualWithContext(fmt.Sprintf(`{"globalAccess":{"imageReference":"baseurl.io/ocm/value:v2.0@sha256:`+D_OCIMANIFEST1+`","type":"ociArtifact"},"localReference":"%s","mediaType":"application/vnd.oci.image.manifest.v1+tar+gzip","referenceName":"ocm/value:v2.0","type":"localBlob"}`, hash)))
 	})
 })

--- a/api/ocm/extensions/blobhandler/handlers/generic/ocirepo/upload_test.go
+++ b/api/ocm/extensions/blobhandler/handlers/generic/ocirepo/upload_test.go
@@ -146,7 +146,7 @@ var _ = Describe("upload", func() {
 		Expect(acc.GetKind()).To(Equal(ociartifact.Type))
 		val := Must(ctx.AccessSpecForSpec(acc))
 		// TODO: the result is invalid for ctf: better handling for ctf refs
-		Expect(val.(*ociartifact.AccessSpec).ImageReference).To(Equal("/tmp/target//copy/ocm/value:v2.0"))
+		Expect(val.(*ociartifact.AccessSpec).ImageReference).To(Equal("/tmp/target//copy/ocm/value:v2.0@sha256:" + D_OCIMANIFEST1))
 
 		attr.Close()
 		target, err := ctfoci.Open(ctx.OCIContext(), accessobj.ACC_READONLY, TARGET, 0, env)
@@ -188,7 +188,7 @@ var _ = Describe("upload", func() {
 		Expect(acc.GetKind()).To(Equal(ociartifact.Type))
 		val := Must(ctx.AccessSpecForSpec(acc))
 		// TODO: the result is invalid for ctf: better handling for ctf refs
-		Expect(val.(*ociartifact.AccessSpec).ImageReference).To(Equal("/tmp/target//copy/ocm/value:v2.0"))
+		Expect(val.(*ociartifact.AccessSpec).ImageReference).To(Equal("/tmp/target//copy/ocm/value:v2.0@sha256:" + D_OCIMANIFEST1))
 
 		// attr.Close()
 		env.OCMContext().Finalize()
@@ -232,7 +232,7 @@ var _ = Describe("upload", func() {
 		Expect(acc.GetKind()).To(Equal(ociartifact.Type))
 		val := Must(ctx.AccessSpecForSpec(acc))
 		// TODO: the result is invalid for ctf: better handling for ctf refs
-		Expect(val.(*ociartifact.AccessSpec).ImageReference).To(Equal("/tmp/target//copy/ocm/value:v2.0"))
+		Expect(val.(*ociartifact.AccessSpec).ImageReference).To(Equal("/tmp/target//copy/ocm/value:v2.0@sha256:" + D_OCIMANIFEST1))
 
 		// attr.Close()
 		env.OCMContext().Finalize()

--- a/api/ocm/extensions/blobhandler/handlers/oci/ocirepo/handler_test.go
+++ b/api/ocm/extensions/blobhandler/handlers/oci/ocirepo/handler_test.go
@@ -82,164 +82,304 @@ var _ = Describe("oci artifact transfer", func() {
 		env.Cleanup()
 	})
 
-	It("it should copy a resource by value and export the OCI image but keep the local blob", func() {
-		env.OCMContext().BlobHandlers().Register(ocirepo.NewArtifactHandler(FakeOCIRegBaseFunction),
-			cpi.ForRepo(oci.CONTEXT_TYPE, ocictf.Type), cpi.ForMimeType(artdesc.ToContentMediaType(artdesc.MediaTypeImageManifest)))
-		keepblobattr.Set(env.OCMContext(), true)
+	Context("with tag", func() {
+		BeforeEach(func() {
+			env.OCMCommonTransport(ARCH, accessio.FormatDirectory, func() {
+				env.Component(COMPONENT, func() {
+					env.Version(VERSION, func() {
+						env.Provider(PROVIDER)
+						env.Resource("testdata", "", "PlainText", metav1.LocalRelation, func() {
+							env.BlobStringData(mime.MIME_TEXT, "testdata")
+						})
+						env.Resource("artifact", "", resourcetypes.OCI_IMAGE, metav1.LocalRelation, func() {
+							env.Access(
+								ociartifact.New(oci.StandardOCIRef(OCIHOST+".alias", OCINAMESPACE, OCIVERSION)),
+							)
+						})
+					})
+				})
+			})
+		})
 
-		src := Must(ctf.Open(env.OCMContext(), accessobj.ACC_READONLY, ARCH, 0, env))
-		cv := Must(src.LookupComponentVersion(COMPONENT, VERSION))
-		tgt := Must(ctf.Create(env.OCMContext(), accessobj.ACC_WRITABLE|accessobj.ACC_CREATE, OUT, 0o700, accessio.FormatDirectory, env))
-		defer tgt.Close()
+		It("it should copy a resource by value and export the OCI image but keep the local blob", func() {
+			env.OCMContext().BlobHandlers().Register(ocirepo.NewArtifactHandler(FakeOCIRegBaseFunction),
+				cpi.ForRepo(oci.CONTEXT_TYPE, ocictf.Type), cpi.ForMimeType(artdesc.ToContentMediaType(artdesc.MediaTypeImageManifest)))
+			keepblobattr.Set(env.OCMContext(), true)
 
-		opts := &standard.Options{}
-		opts.SetResourcesByValue(true)
-		handler := standard.NewDefaultHandler(opts)
+			src := Must(ctf.Open(env.OCMContext(), accessobj.ACC_READONLY, ARCH, 0, env))
+			cv := Must(src.LookupComponentVersion(COMPONENT, VERSION))
+			tgt := Must(ctf.Create(env.OCMContext(), accessobj.ACC_WRITABLE|accessobj.ACC_CREATE, OUT, 0o700, accessio.FormatDirectory, env))
+			defer tgt.Close()
 
-		MustBeSuccessful(transfer.TransferVersion(nil, nil, cv, tgt, handler))
-		Expect(env.DirExists(OUT)).To(BeTrue())
+			opts := &standard.Options{}
+			opts.SetResourcesByValue(true)
+			handler := standard.NewDefaultHandler(opts)
 
-		list := Must(tgt.ComponentLister().GetComponents("", true))
-		Expect(list).To(Equal([]string{COMPONENT}))
-		comp := Must(tgt.LookupComponentVersion(COMPONENT, VERSION))
-		Expect(len(comp.GetDescriptor().Resources)).To(Equal(2))
-		data := Must(json.Marshal(comp.GetDescriptor().Resources[1].Access))
+			MustBeSuccessful(transfer.TransferVersion(nil, nil, cv, tgt, handler))
+			Expect(env.DirExists(OUT)).To(BeTrue())
 
-		fmt.Printf("%s\n", string(data))
-		Expect(string(data)).To(StringEqualWithContext(`{"globalAccess":{"imageReference":"baseurl.io/ocm/value:v2.0","type":"ociArtifact"},"localReference":"sha256:b0692bcec00e0a875b6b280f3209d6776f3eca128adcb7e81e82fd32127c0c62","mediaType":"application/vnd.oci.image.manifest.v1+tar+gzip","referenceName":"ocm/value:v2.0","type":"localBlob"}`))
-		ocirepo := genericocireg.GetOCIRepository(tgt)
-		Expect(ocirepo).NotTo(BeNil())
+			list := Must(tgt.ComponentLister().GetComponents("", true))
+			Expect(list).To(Equal([]string{COMPONENT}))
+			comp := Must(tgt.LookupComponentVersion(COMPONENT, VERSION))
+			Expect(len(comp.GetDescriptor().Resources)).To(Equal(2))
+			data := Must(json.Marshal(comp.GetDescriptor().Resources[1].Access))
 
-		art := Must(ocirepo.LookupArtifact(OCINAMESPACE, OCIVERSION))
-		defer Close(art, "artifact")
+			fmt.Printf("%s\n", string(data))
+			Expect(string(data)).To(StringEqualWithContext(`{"globalAccess":{"imageReference":"baseurl.io/ocm/value:v2.0@sha256:` + D_OCIMANIFEST1 + `","type":"ociArtifact"},"localReference":"sha256:b0692bcec00e0a875b6b280f3209d6776f3eca128adcb7e81e82fd32127c0c62","mediaType":"application/vnd.oci.image.manifest.v1+tar+gzip","referenceName":"ocm/value:v2.0","type":"localBlob"}`))
+			ocirepo := genericocireg.GetOCIRepository(tgt)
+			Expect(ocirepo).NotTo(BeNil())
 
-		man := MustBeNonNil(art.ManifestAccess())
-		Expect(len(man.GetDescriptor().Layers)).To(Equal(1))
-		Expect(man.GetDescriptor().Layers[0].Digest).To(Equal(ldesc.Digest))
+			art := Must(ocirepo.LookupArtifact(OCINAMESPACE, OCIVERSION))
+			defer Close(art, "artifact")
 
-		blob := Must(man.GetBlob(ldesc.Digest))
-		data = Must(blob.Get())
-		Expect(string(data)).To(Equal(OCILAYER))
+			man := MustBeNonNil(art.ManifestAccess())
+			Expect(len(man.GetDescriptor().Layers)).To(Equal(1))
+			Expect(man.GetDescriptor().Layers[0].Digest).To(Equal(ldesc.Digest))
+
+			blob := Must(man.GetBlob(ldesc.Digest))
+			data = Must(blob.Get())
+			Expect(string(data)).To(Equal(OCILAYER))
+		})
+
+		It("it should copy a resource by value and export the OCI image", func() {
+			env.OCMContext().BlobHandlers().Register(ocirepo.NewArtifactHandler(FakeOCIRegBaseFunction),
+				cpi.ForRepo(oci.CONTEXT_TYPE, ocictf.Type), cpi.ForMimeType(artdesc.ToContentMediaType(artdesc.MediaTypeImageManifest)))
+
+			src := Must(ctf.Open(env.OCMContext(), accessobj.ACC_READONLY, ARCH, 0, env))
+			cv := Must(src.LookupComponentVersion(COMPONENT, VERSION))
+			tgt := Must(ctf.Create(env.OCMContext(), accessobj.ACC_WRITABLE|accessobj.ACC_CREATE, OUT, 0o700, accessio.FormatDirectory, env))
+			defer tgt.Close()
+
+			opts := &standard.Options{}
+			opts.SetResourcesByValue(true)
+			handler := standard.NewDefaultHandler(opts)
+
+			MustBeSuccessful(transfer.TransferVersion(nil, nil, cv, tgt, handler))
+			Expect(env.DirExists(OUT)).To(BeTrue())
+
+			list := Must(tgt.ComponentLister().GetComponents("", true))
+			Expect(list).To(Equal([]string{COMPONENT}))
+			comp := Must(tgt.LookupComponentVersion(COMPONENT, VERSION))
+			Expect(len(comp.GetDescriptor().Resources)).To(Equal(2))
+			data := Must(json.Marshal(comp.GetDescriptor().Resources[1].Access))
+
+			fmt.Printf("%s\n", string(data))
+			Expect(string(data)).To(StringEqualWithContext(`{"imageReference":"baseurl.io/ocm/value:v2.0@sha256:` + D_OCIMANIFEST1 + `","type":"ociArtifact"}`))
+
+			ocirepo := genericocireg.GetOCIRepository(tgt)
+			art := Must(ocirepo.LookupArtifact(OCINAMESPACE, OCIVERSION))
+			defer Close(art, "artifact")
+
+			man := MustBeNonNil(art.ManifestAccess())
+			Expect(len(man.GetDescriptor().Layers)).To(Equal(1))
+			Expect(man.GetDescriptor().Layers[0].Digest).To(Equal(ldesc.Digest))
+
+			blob := Must(man.GetBlob(ldesc.Digest))
+			data = Must(blob.Get())
+			Expect(string(data)).To(Equal(OCILAYER))
+		})
+
+		It("it should copy a resource by value and export the OCI image with hashed repo name", func() {
+			env.OCMContext().BlobHandlers().Register(ocirepo.NewArtifactHandler(FakeOCIRegBaseFunction),
+				cpi.ForRepo(oci.CONTEXT_TYPE, ocictf.Type), cpi.ForMimeType(artdesc.ToContentMediaType(artdesc.MediaTypeImageManifest)))
+
+			src := Must(ctf.Open(env.OCMContext(), accessobj.ACC_READONLY, ARCH, 0, env))
+			cv := Must(src.LookupComponentVersion(COMPONENT, VERSION))
+			tgt := Must(ctf.Create(env.OCMContext(), accessobj.ACC_WRITABLE|accessobj.ACC_CREATE, OUT, 0o700, accessio.FormatDirectory, env))
+			defer tgt.Close()
+
+			opts := &standard.Options{}
+			opts.SetResourcesByValue(true)
+			handler := standard.NewDefaultHandler(opts)
+			mapocirepoattr.Set(env.OCMContext(), &mapocirepoattr.Attribute{Mode: mapocirepoattr.ShortHashMode, Always: true})
+			rdigest := "e9b6af2174cb2fb78b2882a1f487b01295b8f6bfa7e4c1ceb350440104c9ce65"
+
+			MustBeSuccessful(transfer.TransferVersion(nil, nil, cv, tgt, handler))
+			Expect(env.DirExists(OUT)).To(BeTrue())
+
+			list := Must(tgt.ComponentLister().GetComponents("", true))
+			Expect(list).To(Equal([]string{COMPONENT}))
+			comp := Must(tgt.LookupComponentVersion(COMPONENT, VERSION))
+			Expect(len(comp.GetDescriptor().Resources)).To(Equal(2))
+			data := Must(json.Marshal(comp.GetDescriptor().Resources[1].Access))
+
+			fmt.Printf("%s\n", string(data))
+			Expect(string(data)).To(StringEqualWithContext(`{"imageReference":"baseurl.io/` + rdigest[:8] + `/value:v2.0@sha256:` + D_OCIMANIFEST1 + `","type":"ociArtifact"}`))
+
+			namespace := rdigest[:8] + "/value"
+			ocirepo := genericocireg.GetOCIRepository(tgt)
+			art := Must(ocirepo.LookupArtifact(namespace, OCIVERSION))
+			defer Close(art, "artifact")
+
+			man := MustBeNonNil(art.ManifestAccess())
+			Expect(len(man.GetDescriptor().Layers)).To(Equal(1))
+			Expect(man.GetDescriptor().Layers[0].Digest).To(Equal(ldesc.Digest))
+
+			blob := Must(man.GetBlob(ldesc.Digest))
+			data = Must(blob.Get())
+			Expect(string(data)).To(Equal(OCILAYER))
+		})
+
+		It("it should copy a resource by value and export the OCI image with hashed repo name and prefix", func() {
+			env.OCMContext().BlobHandlers().Register(ocirepo.NewArtifactHandler(FakeOCIRegBaseFunction),
+				cpi.ForRepo(oci.CONTEXT_TYPE, ocictf.Type), cpi.ForMimeType(artdesc.ToContentMediaType(artdesc.MediaTypeImageManifest)))
+
+			src := Must(ctf.Open(env.OCMContext(), accessobj.ACC_READONLY, ARCH, 0, env))
+			cv := Must(src.LookupComponentVersion(COMPONENT, VERSION))
+			tgt := Must(ctf.Create(env.OCMContext(), accessobj.ACC_WRITABLE|accessobj.ACC_CREATE, OUT, 0o700, accessio.FormatDirectory, env))
+			defer tgt.Close()
+
+			opts := &standard.Options{}
+			opts.SetResourcesByValue(true)
+			handler := standard.NewDefaultHandler(opts)
+			prefix := "ocm"
+			mapocirepoattr.Set(env.OCMContext(), &mapocirepoattr.Attribute{Mode: mapocirepoattr.ShortHashMode, Always: true, Prefix: &prefix})
+			rdigest := "e9b6af2174cb2fb78b2882a1f487b01295b8f6bfa7e4c1ceb350440104c9ce65"
+
+			MustBeSuccessful(transfer.TransferVersion(nil, nil, cv, tgt, handler))
+			Expect(env.DirExists(OUT)).To(BeTrue())
+
+			list := Must(tgt.ComponentLister().GetComponents("", true))
+			Expect(list).To(Equal([]string{COMPONENT}))
+			comp := Must(tgt.LookupComponentVersion(COMPONENT, VERSION))
+			Expect(len(comp.GetDescriptor().Resources)).To(Equal(2))
+			data := Must(json.Marshal(comp.GetDescriptor().Resources[1].Access))
+
+			fmt.Printf("%s\n", string(data))
+			Expect(string(data)).To(StringEqualWithContext(`{"imageReference":"baseurl.io/ocm/` + rdigest[:8] + `/value:v2.0@sha256:` + D_OCIMANIFEST1 + `","type":"ociArtifact"}`))
+
+			namespace := "ocm/" + rdigest[:8] + "/value"
+			ocirepo := genericocireg.GetOCIRepository(tgt)
+			art := Must(ocirepo.LookupArtifact(namespace, OCIVERSION))
+			defer Close(art, "artifact")
+
+			man := MustBeNonNil(art.ManifestAccess())
+			Expect(len(man.GetDescriptor().Layers)).To(Equal(1))
+			Expect(man.GetDescriptor().Layers[0].Digest).To(Equal(ldesc.Digest))
+
+			blob := Must(man.GetBlob(ldesc.Digest))
+			data = Must(blob.Get())
+			Expect(string(data)).To(Equal(OCILAYER))
+		})
 	})
 
-	It("it should copy a resource by value and export the OCI image", func() {
-		env.OCMContext().BlobHandlers().Register(ocirepo.NewArtifactHandler(FakeOCIRegBaseFunction),
-			cpi.ForRepo(oci.CONTEXT_TYPE, ocictf.Type), cpi.ForMimeType(artdesc.ToContentMediaType(artdesc.MediaTypeImageManifest)))
+	Context("with digest", func() {
+		BeforeEach(func() {
+			env.OCMCommonTransport(ARCH, accessio.FormatDirectory, func() {
+				env.Component(COMPONENT, func() {
+					env.Version(VERSION, func() {
+						env.Provider(PROVIDER)
+						env.Resource("testdata", "", "PlainText", metav1.LocalRelation, func() {
+							env.BlobStringData(mime.MIME_TEXT, "testdata")
+						})
+						env.Resource("artifact", "", resourcetypes.OCI_IMAGE, metav1.LocalRelation, func() {
+							env.Access(
+								ociartifact.New(oci.StandardOCIRef(OCIHOST+".alias", OCINAMESPACE, "@sha256:"+D_OCIMANIFEST1)),
+							)
+						})
+					})
+				})
+			})
+		})
 
-		src := Must(ctf.Open(env.OCMContext(), accessobj.ACC_READONLY, ARCH, 0, env))
-		cv := Must(src.LookupComponentVersion(COMPONENT, VERSION))
-		tgt := Must(ctf.Create(env.OCMContext(), accessobj.ACC_WRITABLE|accessobj.ACC_CREATE, OUT, 0o700, accessio.FormatDirectory, env))
-		defer tgt.Close()
+		It("it should copy a resource by value and export the OCI image", func() {
+			env.OCMContext().BlobHandlers().Register(ocirepo.NewArtifactHandler(FakeOCIRegBaseFunction),
+				cpi.ForRepo(oci.CONTEXT_TYPE, ocictf.Type), cpi.ForMimeType(artdesc.ToContentMediaType(artdesc.MediaTypeImageManifest)))
 
-		opts := &standard.Options{}
-		opts.SetResourcesByValue(true)
-		handler := standard.NewDefaultHandler(opts)
+			src := Must(ctf.Open(env.OCMContext(), accessobj.ACC_READONLY, ARCH, 0, env))
+			cv := Must(src.LookupComponentVersion(COMPONENT, VERSION))
+			tgt := Must(ctf.Create(env.OCMContext(), accessobj.ACC_WRITABLE|accessobj.ACC_CREATE, OUT, 0o700, accessio.FormatDirectory, env))
+			defer tgt.Close()
 
-		MustBeSuccessful(transfer.TransferVersion(nil, nil, cv, tgt, handler))
-		Expect(env.DirExists(OUT)).To(BeTrue())
+			opts := &standard.Options{}
+			opts.SetResourcesByValue(true)
+			handler := standard.NewDefaultHandler(opts)
 
-		list := Must(tgt.ComponentLister().GetComponents("", true))
-		Expect(list).To(Equal([]string{COMPONENT}))
-		comp := Must(tgt.LookupComponentVersion(COMPONENT, VERSION))
-		Expect(len(comp.GetDescriptor().Resources)).To(Equal(2))
-		data := Must(json.Marshal(comp.GetDescriptor().Resources[1].Access))
+			MustBeSuccessful(transfer.TransferVersion(nil, nil, cv, tgt, handler))
+			Expect(env.DirExists(OUT)).To(BeTrue())
 
-		fmt.Printf("%s\n", string(data))
-		Expect(string(data)).To(StringEqualWithContext("{\"imageReference\":\"baseurl.io/ocm/value:v2.0\",\"type\":\"ociArtifact\"}"))
+			list := Must(tgt.ComponentLister().GetComponents("", true))
+			Expect(list).To(Equal([]string{COMPONENT}))
+			comp := Must(tgt.LookupComponentVersion(COMPONENT, VERSION))
+			Expect(len(comp.GetDescriptor().Resources)).To(Equal(2))
+			data := Must(json.Marshal(comp.GetDescriptor().Resources[1].Access))
 
-		ocirepo := genericocireg.GetOCIRepository(tgt)
-		art := Must(ocirepo.LookupArtifact(OCINAMESPACE, OCIVERSION))
-		defer Close(art, "artifact")
+			fmt.Printf("%s\n", string(data))
+			Expect(string(data)).To(StringEqualWithContext(`{"imageReference":"baseurl.io/ocm/value@sha256:` + D_OCIMANIFEST1 + `","type":"ociArtifact"}`))
 
-		man := MustBeNonNil(art.ManifestAccess())
-		Expect(len(man.GetDescriptor().Layers)).To(Equal(1))
-		Expect(man.GetDescriptor().Layers[0].Digest).To(Equal(ldesc.Digest))
+			ocirepo := genericocireg.GetOCIRepository(tgt)
+			art := Must(ocirepo.LookupArtifact(OCINAMESPACE, "@sha256:"+D_OCIMANIFEST1))
+			defer Close(art, "artifact")
 
-		blob := Must(man.GetBlob(ldesc.Digest))
-		data = Must(blob.Get())
-		Expect(string(data)).To(Equal(OCILAYER))
+			man := MustBeNonNil(art.ManifestAccess())
+			Expect(len(man.GetDescriptor().Layers)).To(Equal(1))
+			Expect(man.GetDescriptor().Layers[0].Digest).To(Equal(ldesc.Digest))
+
+			blob := Must(man.GetBlob(ldesc.Digest))
+			data = Must(blob.Get())
+			Expect(string(data)).To(Equal(OCILAYER))
+		})
 	})
 
-	It("it should copy a resource by value and export the OCI image with hashed repo name", func() {
-		env.OCMContext().BlobHandlers().Register(ocirepo.NewArtifactHandler(FakeOCIRegBaseFunction),
-			cpi.ForRepo(oci.CONTEXT_TYPE, ocictf.Type), cpi.ForMimeType(artdesc.ToContentMediaType(artdesc.MediaTypeImageManifest)))
+	Context("with tag + digest", func() {
+		BeforeEach(func() {
+			env.OCMCommonTransport(ARCH, accessio.FormatDirectory, func() {
+				env.Component(COMPONENT, func() {
+					env.Version(VERSION, func() {
+						env.Provider(PROVIDER)
+						env.Resource("testdata", "", "PlainText", metav1.LocalRelation, func() {
+							env.BlobStringData(mime.MIME_TEXT, "testdata")
+						})
+						env.Resource("artifact", "", resourcetypes.OCI_IMAGE, metav1.LocalRelation, func() {
+							env.Access(
+								ociartifact.New(oci.StandardOCIRef(OCIHOST+".alias", OCINAMESPACE, OCIVERSION+"@sha256:"+D_OCIMANIFEST1)),
+							)
+						})
+					})
+				})
+			})
+		})
 
-		src := Must(ctf.Open(env.OCMContext(), accessobj.ACC_READONLY, ARCH, 0, env))
-		cv := Must(src.LookupComponentVersion(COMPONENT, VERSION))
-		tgt := Must(ctf.Create(env.OCMContext(), accessobj.ACC_WRITABLE|accessobj.ACC_CREATE, OUT, 0o700, accessio.FormatDirectory, env))
-		defer tgt.Close()
+		It("it should copy a resource by value and export the OCI image", func() {
+			env.OCMContext().BlobHandlers().Register(ocirepo.NewArtifactHandler(FakeOCIRegBaseFunction),
+				cpi.ForRepo(oci.CONTEXT_TYPE, ocictf.Type), cpi.ForMimeType(artdesc.ToContentMediaType(artdesc.MediaTypeImageManifest)))
 
-		opts := &standard.Options{}
-		opts.SetResourcesByValue(true)
-		handler := standard.NewDefaultHandler(opts)
-		mapocirepoattr.Set(env.OCMContext(), &mapocirepoattr.Attribute{Mode: mapocirepoattr.ShortHashMode, Always: true})
-		rdigest := "e9b6af2174cb2fb78b2882a1f487b01295b8f6bfa7e4c1ceb350440104c9ce65"
+			src := Must(ctf.Open(env.OCMContext(), accessobj.ACC_READONLY, ARCH, 0, env))
+			cv := Must(src.LookupComponentVersion(COMPONENT, VERSION))
+			tgt := Must(ctf.Create(env.OCMContext(), accessobj.ACC_WRITABLE|accessobj.ACC_CREATE, OUT, 0o700, accessio.FormatDirectory, env))
+			defer tgt.Close()
 
-		MustBeSuccessful(transfer.TransferVersion(nil, nil, cv, tgt, handler))
-		Expect(env.DirExists(OUT)).To(BeTrue())
+			opts := &standard.Options{}
+			opts.SetResourcesByValue(true)
+			handler := standard.NewDefaultHandler(opts)
 
-		list := Must(tgt.ComponentLister().GetComponents("", true))
-		Expect(list).To(Equal([]string{COMPONENT}))
-		comp := Must(tgt.LookupComponentVersion(COMPONENT, VERSION))
-		Expect(len(comp.GetDescriptor().Resources)).To(Equal(2))
-		data := Must(json.Marshal(comp.GetDescriptor().Resources[1].Access))
+			MustBeSuccessful(transfer.TransferVersion(nil, nil, cv, tgt, handler))
+			Expect(env.DirExists(OUT)).To(BeTrue())
 
-		fmt.Printf("%s\n", string(data))
-		Expect(string(data)).To(StringEqualWithContext("{\"imageReference\":\"baseurl.io/" + rdigest[:8] + "/value:v2.0\",\"type\":\"ociArtifact\"}"))
+			list := Must(tgt.ComponentLister().GetComponents("", true))
+			Expect(list).To(Equal([]string{COMPONENT}))
+			comp := Must(tgt.LookupComponentVersion(COMPONENT, VERSION))
+			Expect(len(comp.GetDescriptor().Resources)).To(Equal(2))
+			data := Must(json.Marshal(comp.GetDescriptor().Resources[1].Access))
 
-		namespace := rdigest[:8] + "/value"
-		ocirepo := genericocireg.GetOCIRepository(tgt)
-		art := Must(ocirepo.LookupArtifact(namespace, OCIVERSION))
-		defer Close(art, "artifact")
+			fmt.Printf("%s\n", string(data))
+			Expect(string(data)).To(StringEqualWithContext(`{"imageReference":"baseurl.io/ocm/value:v2.0@sha256:` + D_OCIMANIFEST1 + `","type":"ociArtifact"}`))
 
-		man := MustBeNonNil(art.ManifestAccess())
-		Expect(len(man.GetDescriptor().Layers)).To(Equal(1))
-		Expect(man.GetDescriptor().Layers[0].Digest).To(Equal(ldesc.Digest))
+			ocirepo := genericocireg.GetOCIRepository(tgt)
 
-		blob := Must(man.GetBlob(ldesc.Digest))
-		data = Must(blob.Get())
-		Expect(string(data)).To(Equal(OCILAYER))
-	})
+			Expect(Must(ocirepo.ExistsArtifact(OCINAMESPACE, OCIVERSION))).To(BeTrue())
+			Expect(Must(ocirepo.ExistsArtifact(OCINAMESPACE, "@sha256:"+D_OCIMANIFEST1))).To(BeTrue())
 
-	It("it should copy a resource by value and export the OCI image with hashed repo name and prefix", func() {
-		env.OCMContext().BlobHandlers().Register(ocirepo.NewArtifactHandler(FakeOCIRegBaseFunction),
-			cpi.ForRepo(oci.CONTEXT_TYPE, ocictf.Type), cpi.ForMimeType(artdesc.ToContentMediaType(artdesc.MediaTypeImageManifest)))
+			art := Must(ocirepo.LookupArtifact(OCINAMESPACE, OCIVERSION))
+			defer Close(art, "artifact")
 
-		src := Must(ctf.Open(env.OCMContext(), accessobj.ACC_READONLY, ARCH, 0, env))
-		cv := Must(src.LookupComponentVersion(COMPONENT, VERSION))
-		tgt := Must(ctf.Create(env.OCMContext(), accessobj.ACC_WRITABLE|accessobj.ACC_CREATE, OUT, 0o700, accessio.FormatDirectory, env))
-		defer tgt.Close()
+			man := MustBeNonNil(art.ManifestAccess())
+			Expect(len(man.GetDescriptor().Layers)).To(Equal(1))
+			Expect(man.GetDescriptor().Layers[0].Digest).To(Equal(ldesc.Digest))
 
-		opts := &standard.Options{}
-		opts.SetResourcesByValue(true)
-		handler := standard.NewDefaultHandler(opts)
-		prefix := "ocm"
-		mapocirepoattr.Set(env.OCMContext(), &mapocirepoattr.Attribute{Mode: mapocirepoattr.ShortHashMode, Always: true, Prefix: &prefix})
-		rdigest := "e9b6af2174cb2fb78b2882a1f487b01295b8f6bfa7e4c1ceb350440104c9ce65"
-
-		MustBeSuccessful(transfer.TransferVersion(nil, nil, cv, tgt, handler))
-		Expect(env.DirExists(OUT)).To(BeTrue())
-
-		list := Must(tgt.ComponentLister().GetComponents("", true))
-		Expect(list).To(Equal([]string{COMPONENT}))
-		comp := Must(tgt.LookupComponentVersion(COMPONENT, VERSION))
-		Expect(len(comp.GetDescriptor().Resources)).To(Equal(2))
-		data := Must(json.Marshal(comp.GetDescriptor().Resources[1].Access))
-
-		fmt.Printf("%s\n", string(data))
-		Expect(string(data)).To(StringEqualWithContext("{\"imageReference\":\"baseurl.io/ocm/" + rdigest[:8] + "/value:v2.0\",\"type\":\"ociArtifact\"}"))
-
-		namespace := "ocm/" + rdigest[:8] + "/value"
-		ocirepo := genericocireg.GetOCIRepository(tgt)
-		art := Must(ocirepo.LookupArtifact(namespace, OCIVERSION))
-		defer Close(art, "artifact")
-
-		man := MustBeNonNil(art.ManifestAccess())
-		Expect(len(man.GetDescriptor().Layers)).To(Equal(1))
-		Expect(man.GetDescriptor().Layers[0].Digest).To(Equal(ldesc.Digest))
-
-		blob := Must(man.GetBlob(ldesc.Digest))
-		data = Must(blob.Get())
-		Expect(string(data)).To(Equal(OCILAYER))
+			blob := Must(man.GetBlob(ldesc.Digest))
+			data = Must(blob.Get())
+			Expect(string(data)).To(Equal(OCILAYER))
+		})
 	})
 })

--- a/api/ocm/extensions/download/handlers/ocirepo/handler.go
+++ b/api/ocm/extensions/download/handlers/ocirepo/handler.go
@@ -55,7 +55,7 @@ func (h *handler) Download(p common.Printer, racc cpi.ResourceAccess, path strin
 
 	var repo oci.Repository
 
-	var version string = "latest"
+	var tag string
 
 	aspec := m.AccessSpec()
 	namespace := racc.ReferenceHint()
@@ -63,10 +63,21 @@ func (h *handler) Download(p common.Printer, racc cpi.ResourceAccess, path strin
 		namespace = l.ReferenceName
 	}
 
+	// get rid of digest
 	i := strings.LastIndex(namespace, ":")
 	if i > 0 {
-		version = namespace[i:]
-		version = version[1:] // remove colon
+		tag = namespace[i:]
+		tag = tag[1:] // remove colon
+		namespace = namespace[:i]
+
+		i = strings.LastIndex(tag, "@")
+		if i > 0 {
+			tag = tag[:i]
+		}
+	}
+
+	i = strings.LastIndex(namespace, "@")
+	if i > 0 {
 		namespace = namespace[:i]
 	}
 
@@ -113,23 +124,23 @@ func (h *handler) Download(p common.Printer, racc cpi.ResourceAccess, path strin
 	}
 	log.Debug("using artifact spec", "spec", artspec.String())
 	if artspec.Digest != nil {
-		return true, "", fmt.Errorf("digest no possible for target")
+		return true, "", fmt.Errorf("digest not possible for target")
 	}
 
 	if artspec.Repository != "" {
 		namespace = artspec.Repository
 	}
-	if artspec.Reference() != "" {
-		version = artspec.Reference()
+	if artspec.IsTagged() {
+		tag = *artspec.Tag
 	}
 
 	if prefix != "" && namespace != "" {
 		namespace = prefix + grammar.RepositorySeparator + namespace
 	}
-	if version == "" || version == "latest" {
-		version = racc.Meta().GetVersion()
+	if tag == "" || tag == "latest" {
+		tag = racc.Meta().GetVersion()
 	}
-	log.Debug("using final target", "namespace", namespace, "version", version)
+	log.Debug("using final target", "namespace", namespace, "tag", tag)
 	if namespace == "" {
 		return true, "", fmt.Errorf("no OCI namespace")
 	}
@@ -178,13 +189,13 @@ func (h *handler) Download(p common.Printer, racc cpi.ResourceAccess, path strin
 		log.Debug("using direct transfer mode")
 	}
 
-	p.Printf("uploading resource %s to %s[%s:%s]...\n", racc.Meta().GetName(), repo.GetSpecification().UniformRepositorySpec(), namespace, version)
-	err = transfer.TransferArtifact(art, ns, oci.AsTags(version)...)
+	p.Printf("uploading resource %s to %s[%s:%s]...\n", racc.Meta().GetName(), repo.GetSpecification().UniformRepositorySpec(), namespace, tag)
+	err = transfer.TransferArtifact(art, ns, oci.AsTags(tag)...)
 	if err != nil {
 		return true, "", errors.Wrapf(err, "transfer artifact")
 	}
 
 	result.Repository = namespace
-	result.Tag = &version
+	result.Tag = &tag
 	return true, result.String(), nil
 }

--- a/api/ocm/extensions/download/handlers/ocirepo/handler.go
+++ b/api/ocm/extensions/download/handlers/ocirepo/handler.go
@@ -64,20 +64,15 @@ func (h *handler) Download(p common.Printer, racc cpi.ResourceAccess, path strin
 	}
 
 	// get rid of digest
-	i := strings.LastIndex(namespace, ":")
+	i := strings.LastIndex(namespace, "@")
+	if i >= 0 {
+		namespace = namespace[:i] // remove digest
+	}
+
+	i = strings.LastIndex(namespace, ":")
 	if i > 0 {
 		tag = namespace[i:]
 		tag = tag[1:] // remove colon
-		namespace = namespace[:i]
-
-		i = strings.LastIndex(tag, "@")
-		if i > 0 {
-			tag = tag[:i]
-		}
-	}
-
-	i = strings.LastIndex(namespace, "@")
-	if i > 0 {
 		namespace = namespace[:i]
 	}
 

--- a/api/ocm/extensions/repositories/genericocireg/repo_test.go
+++ b/api/ocm/extensions/repositories/genericocireg/repo_test.go
@@ -39,7 +39,7 @@ import (
 	"ocm.software/ocm/api/ocm/extensions/repositories/genericocireg"
 	"ocm.software/ocm/api/ocm/extensions/repositories/genericocireg/componentmapping"
 	ocmreg "ocm.software/ocm/api/ocm/extensions/repositories/ocireg"
-	ocmutils "ocm.software/ocm/api/ocm/ocmutils"
+	"ocm.software/ocm/api/ocm/ocmutils"
 	ocmtesthelper "ocm.software/ocm/api/ocm/testhelper"
 	"ocm.software/ocm/api/tech/signing/hasher/sha256"
 	"ocm.software/ocm/api/utils/accessio"
@@ -270,7 +270,7 @@ var _ = Describe("component repository mapping", func() {
 		Expect(acc).NotTo(BeNil())
 		Expect(acc.GetKind()).To(Equal(ociartifact.Type))
 		o = acc.(*ociartifact.AccessSpec)
-		Expect(o.ImageReference).To(Equal(TESTBASE + "/artifact2:v1"))
+		Expect(o.ImageReference).To(Equal(TESTBASE + "/artifact2:v1@sha256:" + testhelper.DIGEST_MANIFEST))
 
 		MustBeSuccessful(nested.Finalize())
 

--- a/cmds/ocm/commands/ocicmds/tags/show/cmd.go
+++ b/cmds/ocm/commands/ocicmds/tags/show/cmd.go
@@ -107,7 +107,7 @@ func (o *Command) Run() error {
 			return err
 		}
 		if cr.IsVersion() {
-			art, err = session.GetArtifact(ns, cr.Reference())
+			art, err = session.GetArtifact(ns, cr.Version())
 			if err != nil {
 				return err
 			}

--- a/cmds/ocm/commands/ocmcmds/components/transfer/disableupload_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/transfer/disableupload_test.go
@@ -85,7 +85,7 @@ transferring version "github.com/mandelsoft/test:v1"...
 
 		acc := Must(res.Access())
 		Expect(acc.GetKind()).To(Equal(ociartifact.Type))
-		Expect(acc.Describe(env.OCMContext())).To(Equal("OCI artifact " + BASEURL + "/" + OCINAMESPACE + ":" + OCIVERSION))
+		Expect(acc.Describe(env.OCMContext())).To(Equal("OCI artifact " + BASEURL + "/" + OCINAMESPACE + ":" + OCIVERSION + "@sha256:" + D_OCIMANIFEST1))
 	})
 
 	It("transfers ctf without upload", func() {

--- a/cmds/ocm/commands/ocmcmds/components/transfer/upload_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/transfer/upload_test.go
@@ -120,7 +120,7 @@ transferring version "github.com/compa:1.0.0"...
 		Expect(acc.GetKind()).To(Equal(ociartifact.Type))
 		val := Must(ctx.AccessSpecForSpec(acc))
 		// TODO: the result is invalid for ctf: better handling for ctf refs
-		Expect(val.(*ociartifact.AccessSpec).ImageReference).To(Equal("/tmp/target//copy/ocm/value:v2.0"))
+		Expect(val.(*ociartifact.AccessSpec).ImageReference).To(Equal("/tmp/target//copy/ocm/value:v2.0@sha256:" + D_OCIMANIFEST1))
 
 		target, err := ctfoci.Open(ctx.OCIContext(), accessobj.ACC_READONLY, TARGET, 0, env)
 		Expect(err).To(Succeed())


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

If in a OCI ref both, the tag and the digest is given, the tag is preferred, so far. BUt the digest should always have precedence.

#### Which issue(s) this PR fixes
Fixes #911

