### PR TITLE
feat: add function to satisfy accessMethodView interface

### DIFF
--- a/api/ocm/tools/signing/digest.go
+++ b/api/ocm/tools/signing/digest.go
@@ -107,6 +107,8 @@ type redirectedAccessMethod struct {
 	acc ocm.DataAccess
 }
 
+var _ accspeccpi.AccessMethodView = (*redirectedAccessMethod)(nil)
+
 func NewRedirectedAccessMethod(m ocm.AccessMethod, bacc ocm.DataAccess) ocm.AccessMethod {
 	return &redirectedAccessMethod{m, bacc}
 }

--- a/api/ocm/tools/signing/digest.go
+++ b/api/ocm/tools/signing/digest.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mandelsoft/goutils/general"
 
 	"ocm.software/ocm/api/ocm"
+	"ocm.software/ocm/api/ocm/cpi/accspeccpi"
 	"ocm.software/ocm/api/ocm/extensions/accessmethods/none"
 	"ocm.software/ocm/api/ocm/extensions/attrs/signingattr"
 	common "ocm.software/ocm/api/utils/misc"
@@ -108,6 +109,15 @@ type redirectedAccessMethod struct {
 
 func NewRedirectedAccessMethod(m ocm.AccessMethod, bacc ocm.DataAccess) ocm.AccessMethod {
 	return &redirectedAccessMethod{m, bacc}
+}
+
+func (m *redirectedAccessMethod) Unwrap() interface{} {
+	v, ok := m.AccessMethod.(accspeccpi.AccessMethodView)
+	if !ok {
+		return nil
+	}
+
+	return v.Unwrap()
 }
 
 func (m *redirectedAccessMethod) Close() error {


### PR DESCRIPTION
Otherwise the type-assertion for redirected access methods won't be `ok` for non-local oci-artifacts, see for example:

https://github.com/open-component-model/ocm/blob/main/api/ocm/tools/signing/digest.go#L77
v
https://github.com/open-component-model/ocm/blob/main/api/ocm/extensions/digester/digesters/artifact/digester.go#L141
v 
https://github.com/open-component-model/ocm/blob/main/api/ocm/cpi/accspeccpi/methodview.go#L142
v
not `ok` even though it should work.

