### PR TITLE
documentation: fix uploader documentation

### DIFF
--- a/api/ocm/extensions/blobhandler/config/type.go
+++ b/api/ocm/extensions/blobhandler/config/type.go
@@ -77,16 +77,16 @@ func (a *Config) ApplyTo(ctx cfgcpi.Context, target interface{}) error {
 
 const usage = `
 The config type <code>` + ConfigType + `</code> can be used to define a list
-of preconfigured download handler registrations (see <CMD>ocm ocm-downloadhandlers</CMD>):
+of preconfigured upload handler registrations (see <CMD>ocm ocm-uploadhandlers</CMD>):
 
 <pre>
     type: ` + ConfigType + `
-    description: "my standard download handler configuration"
+    description: "my standard upload handler configuration"
     handlers:
       - name: oci/artifact
         artifactType: ociImage
-        mimeType:
-        config: ...
+        config:
+          ociRef: ghcr.io/open-component-model/...
       ...
 </pre>
 `

--- a/docs/reference/ocm_configfile.md
+++ b/docs/reference/ocm_configfile.md
@@ -312,16 +312,16 @@ The following configuration types are supported:
   </pre>
 - <code>uploader.ocm.config.ocm.software</code>
   The config type <code>uploader.ocm.config.ocm.software</code> can be used to define a list
-  of preconfigured download handler registrations (see [ocm ocm-downloadhandlers](ocm_ocm-downloadhandlers.md)):
+  of preconfigured upload handler registrations (see [ocm ocm-uploadhandlers](ocm_ocm-uploadhandlers.md)):
 
   <pre>
       type: uploader.ocm.config.ocm.software
-      description: "my standard download handler configuration"
+      description: "my standard upload handler configuration"
       handlers:
         - name: oci/artifact
           artifactType: ociImage
-          mimeType:
-          config: ...
+          config:
+            ociRef: ghcr.io/open-component-model/...
         ...
   </pre>
 
@@ -357,4 +357,5 @@ configurations:
 ##### Additional Links
 
 * [<b>ocm ocm-downloadhandlers</b>](ocm_ocm-downloadhandlers.md)	 &mdash; List of all available download handlers
+* [<b>ocm ocm-uploadhandlers</b>](ocm_ocm-uploadhandlers.md)	 &mdash; List of all available upload handlers
 


### PR DESCRIPTION
Just doing the documentation fix, without any renaning. NOTHING more!

This is now a replacement of: https://github.com/open-component-model/ocm/pull/944

renaming might happen with implementation of:
https://github.com/open-component-model/ocm-project/issues/286
