### PR TITLE
Fix/publish release

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -97,7 +97,7 @@ jobs:
         }
         if (-not ([string]::IsNullOrEmpty($repository_version))) {
           $repository_version = "$repository_version" -replace 'v'
-          echo "RELEASE_VERSION=($repository_version -replace 'v')" | Out-File $env:GITHUB_ENV
+          echo "RELEASE_VERSION=$repository_version" | Out-File $env:GITHUB_ENV
           exit 0
         }
         Write-Host "Version not provided"

--- a/hack/chocolatey/update.ps1
+++ b/hack/chocolatey/update.ps1
@@ -46,7 +46,7 @@ $description = $description -replace '<', '&lt;' # used in code blocks and examp
 $description = $description -replace '>', '&gt;' # used in code blocks and examples
 $description += "`nContinue reading on [ocm.software / cli-reference](https://ocm.software/docs/cli-reference/)"
 # release notes do hopefully not contain xml tags
-$releaseNotes = Get-Content -Path "docs\releasenotes\v$latestVersion.md" -Raw
+$releaseNotes = $response.body
 $releaseNotes = $releaseNotes -replace '\(#(\d+)\)', '([$1](https://github.com/open-component-model/ocm/pull/$1))'
 $releaseNotes = $releaseNotes -replace '<summary>.*</summary>', ''
 $releaseNotes = $releaseNotes -replace '</?details>', ''


### PR DESCRIPTION
#### What this PR does / why we need it

Latest releases weren't published for all cases:

- https://github.com/open-component-model/ocm/actions/runs/11404973209/job/31735340051 relies on release notes being present in git-repo
- https://github.com/open-component-model/ocm/actions/runs/11404973209/job/31735340433 version is not set properly 
