### PR TITLE
chore(ci): make sure we use candidates and branches by default

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,18 +6,18 @@ on:
       release_candidate:
         type: boolean
         description: "Release Candidate"
-        required: false
-        default: false
+        required: true
+        default: true
       create_branch:
         type: boolean
-        description: "Create Release Branch"
-        required: false
+        description: "Create Release Branch (on failure or if already existing, set to false to ensure a successful run)"
+        required: true
         default: false
       prerelease:
         type: string
-        description: "Release Candidate Name"
-        required: false
-        default: ""
+        description: "Release Candidate Name, adjust after every succinct release candidate (e.g. to rc.2, rc.3...)"
+        required: true
+        default: "rc.1"
 
 jobs:
   check:

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -55,6 +55,12 @@ branch - by executing the GitHub action `release`. Therefore, you have to
 specify the branch to release, and you can optionally indicate to create a patch
 branch or to create a pre-release by specifying a pre-release name.
 
+By default one should always create a draft release first (as a Release Candidate),
+open it up for testing (by communicating the new release candidate as available to stakeholders),
+and after a grace period, promote the draft release to a full release. It is usually worth to always create
+a release branch, since it is a good practice to have a stable branch for each release that can be separated from main
+and tested and cherry-picked on separately.
+
 ## Preparing a Patch Release
 
 There are 2 possibilities to create and release patches.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

partially resolves #997 by being able to default to candidates, releaes branches and adding a small documentation paragraph