### PR TITLE
chore(ci): use reusable stale bot configuration

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -6,18 +6,10 @@ on:
     inputs:
 
 permissions:
-  contents: write # only for delete-branch option
+  contents: read
   issues: write
   pull-requests: write
 jobs:
-  stale:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/stale@v9
-        with:
-          stale-issue-message: 'This issue was marked as stale because it has not had recent activity.'
-          stale-issue-label: 'lifecycle/stale'
-          stale-pr-message: 'This pull request was marked as stale because it has not had recent activity.'
-          stale-pr-label: 'lifecycle/stale'
-          days-before-close: '-1' # never close issues
-          days-before-stale: '90'
+  stale:  # call reusable workflow from central '.github' repo
+    uses: open-component-model/.github/.github/workflows/stale.yml@main
+    secrets: inherit


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Changes the stale configuration to https://github.com/open-component-model/.github/blob/main/.github/workflows/stale.yml

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
