### PR TITLE
chore(ci): remove i386, optimize latest build and add various comments

### DIFF
--- a/.github/config/goreleaser.yaml
+++ b/.github/config/goreleaser.yaml
@@ -1,3 +1,5 @@
+# goreleaser.yaml (this config) is responsible for our official releases.
+# However, latest builds (equivalent to nightlies based on the main branch), uses latest.yml
 version: 2
 
 before:
@@ -33,6 +35,9 @@ builds:
     id: windows
     goos:
       - windows
+    goarch:
+      - amd64
+      - arm64
 
 archives:
   - name_template: "{{ .Binary }}-{{ .Version }}-{{ .Os }}-{{ .Arch }}"

--- a/.github/config/latest.yml
+++ b/.github/config/latest.yml
@@ -1,10 +1,6 @@
-# .goreleaser.yml
-
+# this file only takes care of the latest builds (equivalent to nightlies based on the main branch),
+# for the official (real) release, check goreleaser.yaml
 version: 2
-
-before:
-  hooks:
-    - go mod tidy
 
 builds:
   - <<: &build_defaults
@@ -34,6 +30,9 @@ builds:
     id: windows
     goos:
       - windows
+    goarch:
+      - amd64
+      - arm64
 
 archives:
   - name_template: "{{ .Binary }}-latest-{{ .Os }}-{{ .Arch }}"

--- a/.github/workflows/publish-latest.yaml
+++ b/.github/workflows/publish-latest.yaml
@@ -10,6 +10,7 @@ on:
       - '**/*.mod'
       - '**/*.sum'
       - 'resources/**'
+      - '.github/config/latest.yml'
 
 jobs:
 

--- a/.github/workflows/publish-to-other-than-github.yaml
+++ b/.github/workflows/publish-to-other-than-github.yaml
@@ -1,4 +1,11 @@
-name: Publish Release
+# This publish step takes care of some (but not all ;) ) of the package registries
+# that we think might be useful for people to consume.
+#
+# Other package registries might also be pushed in the goreleaser step (see publish-latest.yaml) and are configured
+# within .github/config/goreleaser.yaml.
+#
+# TODO: Unify
+name: Publish Release to other package registries than Github
 
 on:
   workflow_dispatch:
@@ -118,7 +125,6 @@ jobs:
       run: |
         cd hack\winget
         wingetcreate update --submit --token ${{ steps.generate_token.outputs.token }} --urls `
-          https://github.com/open-component-model/ocm/releases/download/v${{ env.RELEASE_VERSION }}/ocm-${{ env.RELEASE_VERSION }}-windows-386.zip `
           https://github.com/open-component-model/ocm/releases/download/v${{ env.RELEASE_VERSION }}/ocm-${{ env.RELEASE_VERSION }}-windows-amd64.zip `
           https://github.com/open-component-model/ocm/releases/download/v${{ env.RELEASE_VERSION }}/ocm-${{ env.RELEASE_VERSION }}-windows-arm64.zip `
           --version ${{ env.RELEASE_VERSION }} `

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -296,6 +296,8 @@ jobs:
         event-type: ocm-cli-release
         client-payload: '{"tag": "${{ env.RELEASE_VERSION }}"}'
 
+    # now distribute the release event so that other jobs can listen for this
+    # and use the event to publish our release to other package registries
     - name: Publish Release Event for other package registries
       if: inputs.release_candidate == false
       uses: peter-evans/repository-dispatch@v3

--- a/hack/chocolatey/tools/chocolateyinstall.ps1
+++ b/hack/chocolatey/tools/chocolateyinstall.ps1
@@ -1,17 +1,13 @@
 $ErrorActionPreference = 'Stop'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url = "run: update.ps1"
 $url64 = "run: update.ps1"
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   unzipLocation = $toolsDir
-  url           = $url
   url64bit      = $url64
   softwareName  = 'ocm-cli*'
 
-  checksum = 'run: update.ps1'
-  checksumType  = 'sha256'
   checksum64 = 'run: update.ps1'
   checksumType64= 'sha256'
 }

--- a/hack/chocolatey/update.ps1
+++ b/hack/chocolatey/update.ps1
@@ -18,11 +18,8 @@ $response = Invoke-RestMethod -Uri $url -Headers @{ "User-Agent" = "PowerShell" 
 $latestVersion = $response.tag_name -replace '^v', ''
 Write-Output "The latest released ocm-cli version is $latestVersion"
 $assets = $response.assets
-$url = $assets | Where-Object { $_.name -match 'windows-386.zip$' } | Select-Object -ExpandProperty browser_download_url
 $url64 = $assets | Where-Object { $_.name -match 'windows-amd64.zip$' } | Select-Object -ExpandProperty browser_download_url
-$sha256url = $assets | Where-Object { $_.name -match 'windows-386.zip.sha256$' } | Select-Object -ExpandProperty browser_download_url
 $sha256url64 = $assets | Where-Object { $_.name -match 'windows-amd64.zip.sha256$' } | Select-Object -ExpandProperty browser_download_url
-$sha256 = [System.Text.Encoding]::UTF8.GetString((Invoke-WebRequest -Uri $sha256url).Content)
 $sha256_64 = [System.Text.Encoding]::UTF8.GetString((Invoke-WebRequest -Uri $sha256url64).Content)
 
 # Update the description and release notes in the nuspec file
@@ -58,13 +55,10 @@ Write-Output "Updated the <authors> tag in the nuspec file with the sorted list 
 # Update the install script with the new URLs
 $scriptPath = Join-Path -Path $PSScriptRoot -ChildPath "tools\chocolateyinstall.ps1"
 $scriptContent = Get-Content -Path $scriptPath -Raw
-$updatedContent = $scriptContent -replace '\$url\s*=\s*".*"', (-join('$url = "', $url, '"'))
-$updatedContent = $updatedContent -replace '\$url64\s*=\s*".*"', (-join('$url64 = "', $url64, '"'))
-$updatedContent = $updatedContent -replace "checksum\s*=\s*'.*'", "checksum = '$sha256'"
+$updatedContent = $scriptContent -replace '\$url64\s*=\s*".*"', (-join('$url64 = "', $url64, '"'))
 $updatedContent = $updatedContent -replace "checksum64\s*=\s*'.*'", "checksum64 = '$sha256_64'"
 Set-Content -Path $scriptPath -Value $updatedContent
-Write-Output "Using $url ($sha256)"
-Write-Output "and $url64 ($sha256_64) as package sources."
+Write-Output "Using $url64 ($sha256_64) as package sources."
 
 # Copy the LICENSE file to the tools directory
 $licenseDest = Join-Path -Path $PSScriptRoot -ChildPath "tools\LICENSE.txt"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Explicitly marks win builds to only build for amd64 / arm64 so that we exclude i386 which is rarely used.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
fix https://github.com/open-component-model/ocm-project/issues/261