### PR TITLE
chore: set RELEASE_VERSION correct

### DIFF
--- a/.github/workflows/publish-to-other-than-github.yaml
+++ b/.github/workflows/publish-to-other-than-github.yaml
@@ -69,7 +69,7 @@ jobs:
         }
         if (-not ([string]::IsNullOrEmpty($repository_version))) {
           $repository_version = "$repository_version" -replace 'v'
-          echo "RELEASE_VERSION=($repository_version -replace 'v')" | Out-File $env:GITHUB_ENV
+          echo "RELEASE_VERSION=$repository_version" | Out-File $env:GITHUB_ENV
           exit 0
         }
         Write-Host "Version not provided"


### PR DESCRIPTION
#### What this PR does / why we need it

push to Chocolatey fails as long as we don't set `RELEASE_VERSION` environment correctly