### PR TITLE
component constructor with references field

### DIFF
--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/comp/components.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/comp/components.go
@@ -1,6 +1,8 @@
 package comp
 
 import (
+	"fmt"
+
 	"github.com/mandelsoft/goutils/errors"
 	"github.com/mandelsoft/goutils/finalizer"
 	"github.com/mandelsoft/goutils/set"
@@ -21,9 +23,13 @@ func ProcessComponents(ctx clictx.Context, ictx inputs.Context, repo ocm.Reposit
 
 	for _, elem := range elems {
 		if r, ok := elem.Spec().(*ResourceSpec); ok {
+			if len(r.References) > 0 && len(r.OldReferences) > 0 {
+				return fmt.Errorf("only field references or componentReferences (deprecated) is possible")
+			}
 			list.Add(addhdlrs.ValidateElementSpecIdentities("resource", elem.Source().String(), sliceutils.Convert[addhdlrs.ElementSpec](r.Resources)))
 			list.Add(addhdlrs.ValidateElementSpecIdentities("source", elem.Source().String(), sliceutils.Convert[addhdlrs.ElementSpec](r.Sources)))
 			list.Add(addhdlrs.ValidateElementSpecIdentities("reference", elem.Source().String(), sliceutils.Convert[addhdlrs.ElementSpec](r.References)))
+			list.Add(addhdlrs.ValidateElementSpecIdentities("reference", elem.Source().String(), sliceutils.Convert[addhdlrs.ElementSpec](r.OldReferences)))
 		}
 	}
 	if err := list.Result(); err != nil {

--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/comp/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/comp/elements.go
@@ -143,7 +143,15 @@ func (h *ResourceSpecHandler) Add(ctx clictx.Context, ictx inputs.Context, elem 
 	if err != nil {
 		return err
 	}
+
+	if len(r.References) > 0 && len(r.OldReferences) > 0 {
+		return fmt.Errorf("only field references or componentReferences (deprecated) is possible")
+	}
 	err = handle(ctx, ictx, elem.Source(), cv, r.References, h.refhandler)
+	if err != nil {
+		return err
+	}
+	err = handle(ctx, ictx, elem.Source(), cv, r.OldReferences, h.refhandler)
 	if err != nil {
 		return err
 	}
@@ -169,7 +177,10 @@ type ResourceSpec struct {
 	// Sources defines sources that produced the component
 	Sources []*srcs.ResourceSpec `json:"sources"`
 	// References references component dependencies that can be resolved in the current context.
-	References []*refs.ResourceSpec `json:"componentReferences"`
+	References []*refs.ResourceSpec `json:"references"`
+	// OldReferences references component dependencies that can be resolved in the current context.
+	// Deprecated: use field References.
+	OldReferences []*refs.ResourceSpec `json:"componentReferences"`
 	// Resources defines all resources that are created by the component and by a third party.
 	Resources []*rscs.ResourceSpec `json:"resources"`
 }

--- a/cmds/ocm/commands/ocmcmds/components/add/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/add/cmd_test.go
@@ -16,7 +16,7 @@ import (
 	"ocm.software/ocm/api/ocm/extensions/accessmethods/ociartifact"
 	resourcetypes "ocm.software/ocm/api/ocm/extensions/artifacttypes"
 	"ocm.software/ocm/api/ocm/extensions/repositories/ctf"
-	ocmutils "ocm.software/ocm/api/ocm/ocmutils"
+	"ocm.software/ocm/api/ocm/ocmutils"
 	"ocm.software/ocm/api/ocm/valuemergehandler/handlers/defaultmerge"
 	"ocm.software/ocm/api/utils/accessio"
 	"ocm.software/ocm/api/utils/accessobj"
@@ -88,6 +88,12 @@ var _ = Describe("Test Environment", func() {
 
 	It("creates ctf and adds component", func() {
 		Expect(env.Execute("add", "c", "-fc", "--file", ARCH, "testdata/component-constructor.yaml")).To(Succeed())
+		Expect(env.DirExists(ARCH)).To(BeTrue())
+		CheckComponent(env, nil)
+	})
+
+	It("creates ctf and adds component (deprecated)", func() {
+		Expect(env.Execute("add", "c", "-fc", "--file", ARCH, "testdata/component-constructor-old.yaml")).To(Succeed())
 		Expect(env.DirExists(ARCH)).To(BeTrue())
 		CheckComponent(env, nil)
 	})

--- a/cmds/ocm/commands/ocmcmds/components/add/testdata/component-constructor-old.yaml
+++ b/cmds/ocm/commands/ocmcmds/components/add/testdata/component-constructor-old.yaml
@@ -9,18 +9,6 @@ labels:
   - name: purpose
     value: test
 
-sources:
-  - name: source
-    type: DirectoryTree
-    input:
-      type: binary
-      data: IXN0cmluZ2RhdGE=
-  - name: source
-    type: DirectoryTree
-    input:
-      type: binary
-      data: IXN0cmluZ2RhdGE=
-
 resources:
   - name: text
     type: PlainText
@@ -40,7 +28,7 @@ resources:
       type: binary
       data: IXN0cmluZ2RhdGE=
 
-references:
+componentReferences:
   - name: ref
     version: v1
     componentName: github.com/mandelsoft/test2

--- a/cmds/ocm/commands/ocmcmds/components/add/testdata/component-constructor.yaml
+++ b/cmds/ocm/commands/ocmcmds/components/add/testdata/component-constructor.yaml
@@ -28,7 +28,7 @@ resources:
       type: binary
       data: IXN0cmluZ2RhdGE=
 
-componentReferences:
+references:
   - name: ref
     version: v1
     componentName: github.com/mandelsoft/test2

--- a/cmds/ocm/commands/ocmcmds/components/add/testdata/component-dup-ref.yaml
+++ b/cmds/ocm/commands/ocmcmds/components/add/testdata/component-dup-ref.yaml
@@ -28,7 +28,7 @@ resources:
       type: binary
       data: IXN0cmluZ2RhdGE=
 
-componentReferences:
+references:
   - name: ref
     version: v1
     componentName: github.com/mandelsoft/test2

--- a/cmds/ocm/commands/ocmcmds/components/add/testdata/component-dup-res.yaml
+++ b/cmds/ocm/commands/ocmcmds/components/add/testdata/component-dup-res.yaml
@@ -33,7 +33,7 @@ resources:
       type: binary
       data: IXN0cmluZ2RhdGE=
 
-componentReferences:
+references:
   - name: ref
     version: v1
     componentName: github.com/mandelsoft/test2

--- a/cmds/ocm/commands/ocmcmds/components/add/testdata/components-dup.yaml
+++ b/cmds/ocm/commands/ocmcmds/components/add/testdata/components-dup.yaml
@@ -27,7 +27,7 @@ components:
       input:
         type: binary
         data: IXN0cmluZ2RhdGE=
-  componentReferences:
+  references:
     - name: ref
       version: v1
       componentName: github.com/mandelsoft/test2

--- a/cmds/ocm/commands/ocmcmds/components/add/testdata/components.yaml
+++ b/cmds/ocm/commands/ocmcmds/components/add/testdata/components.yaml
@@ -27,7 +27,7 @@ components:
       input:
         type: binary
         data: IXN0cmluZ2RhdGE=
-  componentReferences:
+  references:
     - name: ref
       version: v1
       componentName: github.com/mandelsoft/test2

--- a/components/helmdemo/component-constructor.yaml
+++ b/components/helmdemo/component-constructor.yaml
@@ -5,7 +5,7 @@ components:
       name: (( values.PROVIDER))
     # use all platforms and create a resource for each
 # ADD back once https://github.com/open-component-model/ocm/issues/1041 is fixed
-    componentReferences:
+    references:
       - name: installer
         componentName: (( values.HELMINSTCOMP ))
         version: (( values.HELMINSTVERSION ))

--- a/components/subchartsdemo/component-constructor.yaml
+++ b/components/subchartsdemo/component-constructor.yaml
@@ -7,7 +7,7 @@ components:
   version: ${VERSION}
   provider:
     name: ${PROVIDER}
-  componentReferences:
+  references:
   - name: echoserver
     componentName:  ${COMPONENT_PREFIX}/echoserver
     version: "${ECHO_VERSION}"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
The component constructor used the field `componentReferences` from the v2 version of the component descriptor.
in v3 this has been corrected to `references` (it described component version references and no component references).
This should reflected in the constructor files, also.

the old field is now deprecated (but still works). Instead, the field `references` is supported, now.
It is not possible to use both fields at the same time.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/open-component-model/ocm/issues/1041
