### PR TITLE
bug: fix unmarshal consumer identity with empty value

### DIFF
--- a/api/credentials/internal/identity_test.go
+++ b/api/credentials/internal/identity_test.go
@@ -70,4 +70,19 @@ port:
 		cid := internal.ConsumerIdentity{}
 		Expect(yaml.Unmarshal([]byte(data), &cid)).NotTo(Succeed())
 	})
+	It("with nil", func() {
+		data := `
+scheme: http
+hostname: 127.0.0.1
+port:
+`
+		id := internal.ConsumerIdentity{
+			"scheme":   "http",
+			"hostname": "127.0.0.1",
+			"port":     "",
+		}
+		cid := internal.ConsumerIdentity{}
+		Expect(yaml.Unmarshal([]byte(data), &cid)).To(Succeed())
+		Expect(cid).To(Equal(id))
+	})
 })


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Fix empty identity value regression.

The regression was introduced after this [PR](https://github.com/open-component-model/ocm/pull/927) adding a custom unmarshaler for consumer identities which allows to specify values other than string (e.g. port: 5000), even though consumer identity is a map[string]string.


#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
