### PR TITLE
bug: allow http protocol for oci access

### DIFF
--- a/api/ocm/extensions/accessmethods/ociartifact/method.go
+++ b/api/ocm/extensions/accessmethods/ociartifact/method.go
@@ -227,7 +227,7 @@ func (m *accessMethod) eval(relto oci.Repository) error {
 		ocictx := m.ctx.OCIContext()
 		spec := ocictx.GetAlias(ref.Host)
 		if spec == nil {
-			spec = ocireg.NewRepositorySpec(ref.Host)
+			spec = ocireg.NewRepositorySpec(ref.RepositoryRef())
 		}
 		repo, err := ocictx.RepositoryForSpec(spec)
 		if err != nil {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Although we allow to fetch components from an `http` registry by specifying the scheme, we unintentionally didn't enable fetching artifacts specified in an oci access from an http registries due to this bug.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
