### PR TITLE
skip digest for component constructors

### DIFF
--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/comp/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/comp/elements.go
@@ -21,6 +21,7 @@ import (
 	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/common/addhdlrs/rscs"
 	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/common/addhdlrs/srcs"
 	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/common/inputs"
+	"ocm.software/ocm/cmds/ocm/commands/ocmcmds/common/options/schemaoption"
 	"ocm.software/ocm/cmds/ocm/common/options"
 	"ocm.software/ocm/cmds/ocm/common/utils"
 )
@@ -34,7 +35,7 @@ type ResourceSpecHandler struct {
 	srchandler *srcs.ResourceSpecHandler
 	refhandler *refs.ResourceSpecHandler
 	version    string
-	schema     string
+	schema     *schemaoption.Option
 }
 
 var (
@@ -42,13 +43,12 @@ var (
 	_ options.Options            = (*ResourceSpecHandler)(nil)
 )
 
-func New(v string, schema string, opts ...ocm.ModificationOption) *ResourceSpecHandler {
+func New(opts ...ocm.ModificationOption) *ResourceSpecHandler {
 	return &ResourceSpecHandler{
 		rschandler: rscs.New(opts...),
 		srchandler: srcs.New(),
 		refhandler: refs.New(),
-		version:    v,
-		schema:     schema,
+		schema:     schemaoption.New(compdesc.DefaultSchemeVersion),
 	}
 }
 
@@ -56,6 +56,7 @@ func (h *ResourceSpecHandler) AddFlags(fs *pflag.FlagSet) {
 	h.rschandler.AddFlags(fs)
 	h.srchandler.AddFlags(fs)
 	h.refhandler.AddFlags(fs)
+	fs.StringVarP(&h.version, "version", "v", "", "default version for components")
 }
 
 func (h *ResourceSpecHandler) WithCLIOptions(opts ...options.Options) *ResourceSpecHandler {
@@ -118,7 +119,7 @@ func (h *ResourceSpecHandler) Add(ctx clictx.Context, ictx inputs.Context, elem 
 		cd.References = nil
 	}
 
-	schema := h.schema
+	schema := h.schema.Schema
 	if r.Meta.ConfiguredVersion != "" {
 		schema = r.Meta.ConfiguredVersion
 	}

--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/options.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/options.go
@@ -1,7 +1,6 @@
 package addhdlrs
 
 import (
-	"github.com/mandelsoft/goutils/generics"
 	"github.com/spf13/pflag"
 
 	"ocm.software/ocm/api/ocm"
@@ -16,7 +15,7 @@ var _ ocm.ModificationOption = (*Options)(nil)
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	f := fs.Lookup("replace")
 	if f != nil {
-		if bp := generics.Cast[*bool](f.Value); bp != nil {
+		if f.Value.Type() == "bool" {
 			return
 		}
 	}

--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/rscs/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/rscs/elements.go
@@ -102,6 +102,9 @@ func (h ResourceSpecHandler) Set(v ocm.ComponentVersionAccess, r addhdlrs.Elemen
 		SourceRefs: compdescv2.ConvertSourcerefsTo(spec.SourceRefs),
 	}
 	opts := h.getModOpts()
+	if spec.SkipDigestGeneration {
+		opts = append(opts, ocm.SkipDigest()) //nolint:staticcheck // skip digest still used for tests)
+	}
 	if ocm.IsIntermediate(v.Repository().GetSpecification()) {
 		opts = append(opts, ocm.ModifyResource())
 	}
@@ -126,6 +129,11 @@ type ResourceSpec struct {
 	SourceRefs []compdescv2.SourceRef `json:"srcRefs"`
 
 	addhdlrs.ResourceInput `json:",inline"`
+
+	// additional process related options
+
+	// SkipDigestGeneration omits the digest generation.
+	SkipDigestGeneration bool `json:"skipDigestGeneration,omitempty"`
 }
 
 var _ addhdlrs.ElementSpec = (*ResourceSpec)(nil)

--- a/cmds/ocm/commands/ocmcmds/components/add/cmd_test.go
+++ b/cmds/ocm/commands/ocmcmds/components/add/cmd_test.go
@@ -1,6 +1,7 @@
 package add_test
 
 import (
+	"github.com/mandelsoft/goutils/general"
 	. "github.com/mandelsoft/goutils/testutils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,7 +36,7 @@ const (
 	OUT        = "/tmp/res"
 )
 
-func CheckComponent(env *TestEnv, handler func(ocm.Repository)) {
+func CheckComponent(env *TestEnv, handler func(ocm.Repository), tests ...func(cv ocm.ComponentVersionAccess)) {
 	repo := Must(ctf.Open(env.OCMContext(), accessobj.ACC_READONLY, ARCH, 0, env))
 	defer Close(repo)
 	cv := Must(repo.LookupComponentVersion("ocm.software/demo/test", "1.0.0"))
@@ -73,6 +74,10 @@ func CheckComponent(env *TestEnv, handler func(ocm.Repository)) {
 	if handler != nil {
 		handler(repo)
 	}
+
+	for _, t := range tests {
+		t(cv)
+	}
 }
 
 var _ = Describe("Test Environment", func() {
@@ -102,6 +107,17 @@ var _ = Describe("Test Environment", func() {
 		Expect(env.Execute("add", "c", "-fc", "--file", ARCH, "--version", "1.0.0", "testdata/component-constructor.yaml")).To(Succeed())
 		Expect(env.DirExists(ARCH)).To(BeTrue())
 		CheckComponent(env, nil)
+	})
+
+	It("creates ctf and adds components without digests", func() {
+		Expect(env.Execute("add", "c", "--skip-digest-generation", "-fc", "--file", ARCH, "--version", "1.0.0", "testdata/component-constructor.yaml")).To(Succeed())
+		Expect(env.DirExists(ARCH)).To(BeTrue())
+		CheckComponent(env, nil, noDigest("data"), noDigest("text"))
+	})
+	It("creates ctf and adds components without digest for one resource", func() {
+		Expect(env.Execute("add", "c", "-fc", "--file", ARCH, "--version", "1.0.0", "testdata/component-constructor-skip.yaml")).To(Succeed())
+		Expect(env.DirExists(ARCH)).To(BeTrue())
+		CheckComponent(env, nil, noDigest("data", false), noDigest("text"))
 	})
 
 	Context("failures", func() {
@@ -176,3 +192,15 @@ var _ = Describe("Test Environment", func() {
 		})
 	})
 })
+
+func noDigest(name string, skips ...bool) func(cv ocm.ComponentVersionAccess) {
+	skip := general.OptionalDefaultedBool(true, skips...)
+	return func(cv ocm.ComponentVersionAccess) {
+		r := MustWithOffset(1, Calling(cv.GetResource(metav1.Identity{"name": name})))
+		if skip {
+			ExpectWithOffset(1, r.Meta().Digest).To(BeNil())
+		} else {
+			ExpectWithOffset(1, r.Meta().Digest).NotTo(BeNil())
+		}
+	}
+}

--- a/cmds/ocm/commands/ocmcmds/components/add/testdata/component-constructor-skip.yaml
+++ b/cmds/ocm/commands/ocmcmds/components/add/testdata/component-constructor-skip.yaml
@@ -1,0 +1,35 @@
+name: ocm.software/demo/test
+version: 1.0.0
+provider:
+  name: ocm.software
+  labels:
+    - name: city
+      value: Karlsruhe
+labels:
+  - name: purpose
+    value: test
+
+resources:
+  - name: text
+    type: PlainText
+    skipDigestGeneration: true
+    labels:
+      - name: city
+        value: Karlsruhe
+        merge:
+          algorithm: default
+          config:
+            overwrite: inbound
+    input:
+      type: file
+      path: testdata
+  - name: data
+    type: PlainText
+    input:
+      type: binary
+      data: IXN0cmluZ2RhdGE=
+
+references:
+  - name: ref
+    version: v1
+    componentName: github.com/mandelsoft/test2

--- a/docs/reference/ocm_add_componentversions.md
+++ b/docs/reference/ocm_add_componentversions.md
@@ -27,8 +27,8 @@ componentversions, componentversion, cv, components, component, comps, comp, c
       --lookup stringArray        repository name or spec for closure lookup fallback
   -O, --output string             output file for dry-run
   -R, --replace                   replace existing elements
-  -S, --scheme string             schema version (default "v2")
   -s, --settings stringArray      settings file with variable settings (yaml)
+      --skip-digest-generation    skip digest creation
       --templater string          templater to use (go, none, spiff, subst) (default "subst")
   -t, --type string               archive format (directory, tar, tgz) (default "directory")
       --uploader <name>=<value>   repository uploader (<name>[:<artifact type>[:<media type>[:<priority>]]]=<JSON target config>) (default [])
@@ -83,13 +83,6 @@ archive does not exist yet. The following formats are supported:
 - tgz
 
 The default format is <code>directory</code>.
-
-
-If the option <code>--scheme</code> is given, the specified component descriptor format is used/generated.
-
-The following schema versions are supported for explicit conversions:
-  - <code>ocm.software/v3alpha1</code>
-  - <code>v2</code> (default)
 
 
 All yaml/json defined resources can be templated.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
This PR adds the option `--skip-digest-generation` to the `ocm add components` command.
It generally disables the digest generation for all added resources.
Additionally, the resource description may set `skipDigestGeneration` to `true` to disable the digest 
generation  for this particular resource.


#### Which issue(s) this PR fixes

Fixes https://github.com/open-component-model/ocm-project/issues/322

