### PR TITLE
chore: Notify of Release in Slack

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -283,3 +283,32 @@ jobs:
         repository: ${{ github.repository_owner }}/ocm
         event-type: publish-ocm-cli
         client-payload: '{"version":"${{ env.RELEASE_VERSION }}","push-to-aur":true,"push-to-chocolatey":true,"push-to-winget":true}'
+
+    - name: Publish Release Message to Slack
+      id: slack
+      uses: slackapi/slack-github-action@v1.27.0
+      with:
+        # Slack channel id, channel name, or user id to post message.
+        # See also: https://api.slack.com/methods/chat.postMessage#channels
+        # You can pass in multiple channels to post to by providing a comma-delimited list of channel IDs.
+        # Test-channel-id: 'C057KU48M7Y'
+        # SAP Engineering Channel: 'C03B338HG3H'
+        channel-id: |
+          C057KU48M7Y
+        payload: |
+          {
+            "text" : "Open Component Model just got released with version `${{ env.RELEASE_VERSION }}`",
+            "blocks": [
+              {
+                "type": "section",
+                "text":
+                  {
+                    "type": "mrkdwn",
+                    "text": "A new version of the Open Component Model :ocm: was released: <${{ env.RELEASE_URL}}/tag/${{ env.RELEASE_VERSION }}|${{ env.RELEASE_VERSION }}>"
+                  }
+              }
+            ]
+          }
+      env:
+        RELEASE_URL: https://github.com/open-component-model/ocm/releases
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION
This notifies of the release in Slack once available.

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

We want to push the Release Message to slack once we have successfully completed the release.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


TODO:
cannot be merged until:

1. SLACK_BOT_TOKEN is maintained
2. Message was tested and approved
