### PR TITLE
fix: add back scheme option after it was accidentally removed

### DIFF
--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/base.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/base.go
@@ -11,7 +11,10 @@ type ResourceSpecHandlerBase struct {
 	options options.OptionSet
 }
 
-var _ options.Options = (*ResourceSpecHandlerBase)(nil)
+var (
+	_ options.Options           = (*ResourceSpecHandlerBase)(nil)
+	_ options.OptionSetProvider = (*ResourceSpecHandlerBase)(nil)
+)
 
 func NewBase(opts ...options.Options) ResourceSpecHandlerBase {
 	return ResourceSpecHandlerBase{options: opts}
@@ -26,7 +29,7 @@ func (h *ResourceSpecHandlerBase) WithCLIOptions(opts ...options.Options) Resour
 	return *h
 }
 
-func (h *ResourceSpecHandlerBase) GetOptions() options.OptionSet {
+func (h *ResourceSpecHandlerBase) AsOptionSet() options.OptionSet {
 	return h.options
 }
 

--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/comp/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/comp/elements.go
@@ -52,11 +52,16 @@ func New(opts ...ocm.ModificationOption) *ResourceSpecHandler {
 	}
 }
 
+func (h *ResourceSpecHandler) AsOptionSet() options.OptionSet {
+	return options.OptionSet{h.rschandler.AsOptionSet(), h.srchandler.AsOptionSet(), h.refhandler.AsOptionSet(), h.schema}
+}
+
 func (h *ResourceSpecHandler) AddFlags(fs *pflag.FlagSet) {
 	h.rschandler.AddFlags(fs)
 	h.srchandler.AddFlags(fs)
 	h.refhandler.AddFlags(fs)
 	fs.StringVarP(&h.version, "version", "v", "", "default version for components")
+	h.schema.AddFlags(fs)
 }
 
 func (h *ResourceSpecHandler) WithCLIOptions(opts ...options.Options) *ResourceSpecHandler {
@@ -112,7 +117,7 @@ func (h *ResourceSpecHandler) Add(ctx clictx.Context, ictx inputs.Context, elem 
 
 	cd := cv.GetDescriptor()
 
-	opts := h.srchandler.GetOptions()[0].(*addhdlrs.Options)
+	opts := h.srchandler.AsOptionSet()[0].(*addhdlrs.Options)
 	if !opts.Replace {
 		cd.Resources = nil
 		cd.Sources = nil

--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/rscs/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/rscs/elements.go
@@ -48,7 +48,7 @@ func (h *ResourceSpecHandler) WithCLIOptions(opts ...options.Options) *ResourceS
 }
 
 func (h *ResourceSpecHandler) getModOpts() []ocm.ModificationOption {
-	opts := options.FindOptions[ocm.ModificationOption](h.GetOptions())
+	opts := options.FindOptions[ocm.ModificationOption](h.AsOptionSet())
 	if h.opts != nil {
 		opts = append(opts, h.opts)
 	}
@@ -103,7 +103,7 @@ func (h ResourceSpecHandler) Set(v ocm.ComponentVersionAccess, r addhdlrs.Elemen
 	}
 	opts := h.getModOpts()
 	if spec.SkipDigestGeneration {
-		opts = append(opts, ocm.SkipDigest()) //nolint:staticcheck // skip digest still used for tests)
+		opts = append(opts, ocm.SkipDigest()) //nolint:staticcheck // skip digest still used for tests
 	}
 	if ocm.IsIntermediate(v.Repository().GetSpecification()) {
 		opts = append(opts, ocm.ModifyResource())

--- a/cmds/ocm/commands/ocmcmds/components/add/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/components/add/cmd.go
@@ -56,9 +56,11 @@ type Command struct {
 }
 
 func NewCommand(ctx clictx.Context, names ...string) *cobra.Command {
+	hdlr := comp.New().WithCLIOptions(&addhdlrs.Options{})
 	return utils.SetupCommand(&Command{
-		Handler: comp.New().WithCLIOptions(&addhdlrs.Options{}),
+		Handler: hdlr,
 		BaseCommand: utils.NewBaseCommand(ctx,
+			hdlr,
 			formatoption.New(ctf.GetFormats()...),
 			fileoption.New("transport-archive"),
 			templateroption.New(""),
@@ -151,7 +153,6 @@ Various elements support to add arbitrary information by using labels
 
 func (o *Command) AddFlags(fs *pflag.FlagSet) {
 	o.BaseCommand.AddFlags(fs)
-	o.Handler.AddFlags(fs)
 	fs.BoolVarP(&o.Force, "force", "f", false, "remove existing content")
 	fs.BoolVarP(&o.Create, "create", "c", false, "(re)create archive")
 	fs.BoolVarP(&o.Closure, "complete", "C", false, "include all referenced component version")

--- a/docs/reference/ocm_add_componentversions.md
+++ b/docs/reference/ocm_add_componentversions.md
@@ -27,6 +27,7 @@ componentversions, componentversion, cv, components, component, comps, comp, c
       --lookup stringArray        repository name or spec for closure lookup fallback
   -O, --output string             output file for dry-run
   -R, --replace                   replace existing elements
+  -S, --scheme string             schema version (default "v2")
   -s, --settings stringArray      settings file with variable settings (yaml)
       --skip-digest-generation    skip digest creation
       --templater string          templater to use (go, none, spiff, subst) (default "subst")


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
complete #1070

Move handler-local options correctly to the comp handler and adapt the
using code to reflect this change.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
