### PR TITLE
fix: fixup blackduck scan job

### DIFF
--- a/.github/workflows/blackduck_scan_scheduled.yaml
+++ b/.github/workflows/blackduck_scan_scheduled.yaml
@@ -25,6 +25,10 @@ jobs:
           go-version-file: '${{ github.workspace }}/go.mod'
           cache: false
 
+      - name: Get go environment for use with cache
+        run: |
+          echo "go_cache=$(go env GOCACHE)" >> $GITHUB_ENV
+          echo "go_modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
       # This step will only reuse the go mod and build cache from main made during the Build,
       # see push_ocm.yaml => "ocm-cli-latest" Job
       # This means it never caches by itself and PRs cannot cause cache pollution / thrashing


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Accidentally the go env didnt get set for blackduck which caused the cron job to fail before. This now sets it correctly

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
fix #1074 