### PR TITLE
fix version info for OCI refs

### DIFF
--- a/api/oci/ociutils/ref.go
+++ b/api/oci/ociutils/ref.go
@@ -31,6 +31,9 @@ func ParseVersion(vers string) (*ArtVersion, error) {
 			Digest: &dig,
 		}, nil
 	}
+	if vers == "" {
+		return &ArtVersion{}, nil
+	}
 	return &ArtVersion{
 		Tag: &vers,
 	}, nil
@@ -50,7 +53,7 @@ type ArtVersion struct {
 }
 
 func (v *ArtVersion) VersionSpec() string {
-	if v != nil {
+	if v == nil {
 		return ""
 	}
 
@@ -93,4 +96,21 @@ func (v *ArtVersion) GetTag() string {
 		return *v.Tag
 	}
 	return ""
+}
+
+func (v *ArtVersion) GetDigest() digest.Digest {
+	if v != nil && v.Digest != nil {
+		return *v.Digest
+	}
+	return ""
+}
+
+func (r *ArtVersion) Version() string {
+	if r.Digest != nil {
+		return "@" + string(*r.Digest)
+	}
+	if r.Tag != nil {
+		return *r.Tag
+	}
+	return "latest"
 }

--- a/api/oci/ociutils/ref_test.go
+++ b/api/oci/ociutils/ref_test.go
@@ -1,0 +1,31 @@
+package ociutils_test
+
+import (
+	. "github.com/mandelsoft/goutils/testutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/opencontainers/go-digest"
+	"ocm.software/ocm/api/oci/ociutils"
+	"ocm.software/ocm/api/oci/testhelper"
+)
+
+var _ = Describe("Ref Test Environment", func() {
+	dig := "sha256:" + testhelper.H_OCIARCHMANIFEST1
+	DescribeTable("parsing", func(src, yaml, vspec string, isvers bool, vers string, istag bool, tag string, isdig bool, dig string) {
+		v := Must(ociutils.ParseVersion(src))
+		Expect(v).NotTo(BeNil())
+		Expect(v).To(YAMLEqual(yaml))
+		Expect(v.VersionSpec()).To(Equal(vspec))
+		Expect(v.IsVersion()).To(Equal(isvers))
+		Expect(v.Version()).To(Equal(vers))
+		Expect(v.IsTagged()).To(Equal(istag))
+		Expect(v.GetTag()).To(Equal(tag))
+		Expect(v.IsDigested()).To(Equal(isdig))
+		Expect(v.GetDigest()).To(Equal(digest.Digest(dig)))
+	},
+		Entry("empty", "", "{}", "latest", false, "latest", false, "", false, ""),
+		Entry("tag", "tag", "{\"tag\":\"tag\"}", "tag", true, "tag", true, "tag", false, ""),
+		Entry("digest", "@"+dig, "{\"digest\":\""+dig+"\"}", "@"+dig, true, "@"+dig, false, "", true, dig),
+		Entry("tag@digest", "tag@"+dig, "{\"tag\":\"tag\",\"digest\":\""+dig+"\"}", "tag@"+dig, true, "@"+dig, true, "tag", true, dig),
+	)
+})

--- a/api/oci/ociutils/suite_test.go
+++ b/api/oci/ociutils/suite_test.go
@@ -1,0 +1,13 @@
+package ociutils_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OCI Utils Test Suite")
+}

--- a/api/oci/ref.go
+++ b/api/oci/ref.go
@@ -272,16 +272,6 @@ type ArtSpec struct {
 	ArtVersion `json:",inline"`
 }
 
-func (r *ArtSpec) Version() string {
-	if r.Digest != nil {
-		return "@" + string(*r.Digest)
-	}
-	if r.Tag != nil {
-		return *r.Tag
-	}
-	return "latest"
-}
-
 func (r *ArtSpec) IsRegistry() bool {
 	return r.Repository == ""
 }

--- a/api/oci/testhelper/manifests.go
+++ b/api/oci/testhelper/manifests.go
@@ -64,8 +64,8 @@ func OCIArtifactResource1(env *builder.Builder, name string, host string, funcs 
 
 const (
 	D_OCIMANIFEST1     = "0c4abdb72cf59cb4b77f4aacb4775f9f546ebc3face189b2224a966c8826ca9f"
-	H_OCIARCHMANIFEST1 = "818fb6a69a5f55e8b3dbc921a61fdd000b9445a745b587ba753a811b02426326"
-	// H_OCIARCHMANIFEST1 = "b0692bcec00e0a875b6b280f3209d6776f3eca128adcb7e81e82fd32127c0c62".
+	H_OCIARCHMANIFEST1 = "b0692bcec00e0a875b6b280f3209d6776f3eca128adcb7e81e82fd32127c0c62"
+	// H_OCIARCHMANIFEST1 = "818fb6a69a5f55e8b3dbc921a61fdd000b9445a745b587ba753a811b02426326".
 )
 
 var DS_OCIMANIFEST1 = &metav1.DigestSpec{
@@ -124,8 +124,8 @@ func OCIManifest2For(env *builder.Builder, ns, tag string, nested ...func()) (*a
 
 const (
 	D_OCIMANIFEST2     = "c2d2dca275c33c1270dea6168a002d67c0e98780d7a54960758139ae19984bd7"
-	H_OCIARCHMANIFEST2 = "2aaf6f8857dcbfa04a72fb98dd53f649b46e5d81aa4fb17330df74b0ffc30839"
-	// H_OCIARCHMANIFEST2 = "cb85cd58b10e36343971691abbfe40200cb645c6e95f0bdabd111a30cf794708".
+	H_OCIARCHMANIFEST2 = "cb85cd58b10e36343971691abbfe40200cb645c6e95f0bdabd111a30cf794708"
+	// H_OCIARCHMANIFEST2 = "2aaf6f8857dcbfa04a72fb98dd53f649b46e5d81aa4fb17330df74b0ffc30839".
 )
 
 func HashManifest2(fmt string) string {

--- a/api/ocm/extensions/accessmethods/relativeociref/method_test.go
+++ b/api/ocm/extensions/accessmethods/relativeociref/method_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Method", func() {
 			return m.Close()
 		})
 		data := Must(m.Get())
-		Expect(len(data)).To(Equal(630))
+		Expect(len(data)).To(Equal(628))
 		Expect(accspeccpi.GetAccessMethodImplementation(m).(blobaccess.DigestSource).Digest().String()).To(Equal("sha256:0c4abdb72cf59cb4b77f4aacb4775f9f546ebc3face189b2224a966c8826ca9f"))
 		Expect(utils.GetOCIArtifactRef(env, res)).To(Equal("ocm/value:v2.0"))
 	})


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
PR #1033 introduced a split of the OCI version info from the repository part.
The method `Version` checks the inverted condition for an existing version inf.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
