### PR TITLE
[release-v0.18.0] fix: version info for OCI refs

### DIFF
--- a/api/oci/ociutils/ref.go
+++ b/api/oci/ociutils/ref.go
@@ -31,6 +31,9 @@ func ParseVersion(vers string) (*ArtVersion, error) {
 			Digest: &dig,
 		}, nil
 	}
+	if vers == "" {
+		return &ArtVersion{}, nil
+	}
 	return &ArtVersion{
 		Tag: &vers,
 	}, nil
@@ -50,7 +53,7 @@ type ArtVersion struct {
 }
 
 func (v *ArtVersion) VersionSpec() string {
-	if v != nil {
+	if v == nil {
 		return ""
 	}
 
@@ -94,4 +97,21 @@ func (v *ArtVersion) GetTag() string {
 		return *v.Tag
 	}
 	return ""
+}
+
+func (v *ArtVersion) GetDigest() digest.Digest {
+	if v != nil && v.Digest != nil {
+		return *v.Digest
+	}
+	return ""
+}
+
+func (r *ArtVersion) Version() string {
+	if r.Digest != nil {
+		return "@" + string(*r.Digest)
+	}
+	if r.Tag != nil {
+		return *r.Tag
+	}
+	return "latest"
 }

--- a/api/oci/ociutils/ref_test.go
+++ b/api/oci/ociutils/ref_test.go
@@ -1,0 +1,70 @@
+package ociutils_test
+
+import (
+	. "github.com/mandelsoft/goutils/testutils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/opencontainers/go-digest"
+	"ocm.software/ocm/api/oci/ociutils"
+	"ocm.software/ocm/api/oci/testhelper"
+)
+
+var _ = Describe("Ref Test Environment", func() {
+	dig := "sha256:" + testhelper.H_OCIARCHMANIFEST1
+
+	type expect struct {
+		yaml        string
+		versionSpec string
+		isVersion   bool
+		version     string
+		isTag       bool
+		tag         string
+		isDigested  bool
+		digest      string
+	}
+
+	DescribeTable("parsing", func(src string, e expect) {
+		v := Must(ociutils.ParseVersion(src))
+		Expect(v).NotTo(BeNil())
+		Expect(v).To(YAMLEqual(e.yaml))
+		Expect(v.VersionSpec()).To(Equal(e.versionSpec))
+		Expect(v.IsVersion()).To(Equal(e.isVersion))
+		Expect(v.Version()).To(Equal(e.version))
+		Expect(v.IsTagged()).To(Equal(e.isTag))
+		Expect(v.GetTag()).To(Equal(e.tag))
+		Expect(v.IsDigested()).To(Equal(e.isDigested))
+		Expect(v.GetDigest()).To(Equal(digest.Digest(e.digest)))
+	},
+		Entry("empty", "", expect{
+			yaml:        "{}",
+			versionSpec: "latest",
+			version:     "latest",
+		}),
+		Entry("tag", "tag", expect{
+			yaml:        "{\"tag\":\"tag\"}",
+			versionSpec: "tag",
+			isVersion:   true,
+			version:     "tag",
+			isTag:       true,
+			tag:         "tag",
+		}),
+		Entry("digest", "@"+dig, expect{
+			yaml:        "{\"digest\":\"" + dig + "\"}",
+			versionSpec: "@" + dig,
+			isVersion:   true,
+			version:     "@" + dig,
+			isDigested:  true,
+			digest:      dig,
+		}),
+		Entry("tag@digest", "tag@"+dig, expect{
+			yaml:        "{\"tag\":\"tag\",\"digest\":\"" + dig + "\"}",
+			versionSpec: "tag@" + dig,
+			isVersion:   true,
+			version:     "@" + dig,
+			isTag:       true,
+			tag:         "tag",
+			isDigested:  true,
+			digest:      dig,
+		}),
+	)
+})

--- a/api/oci/ociutils/suite_test.go
+++ b/api/oci/ociutils/suite_test.go
@@ -1,0 +1,13 @@
+package ociutils_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "OCI Utils Test Suite")
+}

--- a/api/oci/ref.go
+++ b/api/oci/ref.go
@@ -272,16 +272,6 @@ type ArtSpec struct {
 	ArtVersion `json:",inline"`
 }
 
-func (r *ArtSpec) Version() string {
-	if r.Digest != nil {
-		return "@" + string(*r.Digest)
-	}
-	if r.Tag != nil {
-		return *r.Tag
-	}
-	return "latest"
-}
-
 func (r *ArtSpec) IsRegistry() bool {
 	return r.Repository == ""
 }

--- a/api/oci/testhelper/manifests.go
+++ b/api/oci/testhelper/manifests.go
@@ -64,8 +64,8 @@ func OCIArtifactResource1(env *builder.Builder, name string, host string, funcs 
 
 const (
 	D_OCIMANIFEST1     = "0c4abdb72cf59cb4b77f4aacb4775f9f546ebc3face189b2224a966c8826ca9f"
-	H_OCIARCHMANIFEST1 = "818fb6a69a5f55e8b3dbc921a61fdd000b9445a745b587ba753a811b02426326"
-	// H_OCIARCHMANIFEST1 = "b0692bcec00e0a875b6b280f3209d6776f3eca128adcb7e81e82fd32127c0c62".
+	H_OCIARCHMANIFEST1 = "b0692bcec00e0a875b6b280f3209d6776f3eca128adcb7e81e82fd32127c0c62"
+	// H_OCIARCHMANIFEST1 = "818fb6a69a5f55e8b3dbc921a61fdd000b9445a745b587ba753a811b02426326".
 )
 
 var DS_OCIMANIFEST1 = &metav1.DigestSpec{
@@ -124,8 +124,8 @@ func OCIManifest2For(env *builder.Builder, ns, tag string, nested ...func()) (*a
 
 const (
 	D_OCIMANIFEST2     = "c2d2dca275c33c1270dea6168a002d67c0e98780d7a54960758139ae19984bd7"
-	H_OCIARCHMANIFEST2 = "2aaf6f8857dcbfa04a72fb98dd53f649b46e5d81aa4fb17330df74b0ffc30839"
-	// H_OCIARCHMANIFEST2 = "cb85cd58b10e36343971691abbfe40200cb645c6e95f0bdabd111a30cf794708".
+	H_OCIARCHMANIFEST2 = "cb85cd58b10e36343971691abbfe40200cb645c6e95f0bdabd111a30cf794708"
+	// H_OCIARCHMANIFEST2 = "2aaf6f8857dcbfa04a72fb98dd53f649b46e5d81aa4fb17330df74b0ffc30839".
 )
 
 func HashManifest2(fmt string) string {

--- a/api/ocm/extensions/accessmethods/relativeociref/method_test.go
+++ b/api/ocm/extensions/accessmethods/relativeociref/method_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Method", func() {
 			return m.Close()
 		})
 		data := Must(m.Get())
-		Expect(len(data)).To(Equal(630))
+		Expect(len(data)).To(Equal(628))
 		Expect(accspeccpi.GetAccessMethodImplementation(m).(blobaccess.DigestSource).Digest().String()).To(Equal("sha256:0c4abdb72cf59cb4b77f4aacb4775f9f546ebc3face189b2224a966c8826ca9f"))
 		Expect(utils.GetOCIArtifactRef(env, res)).To(Equal("ocm/value:v2.0"))
 	})

--- a/docs/releasenotes/v0.18.0-rc.2.md
+++ b/docs/releasenotes/v0.18.0-rc.2.md
@@ -1,0 +1,48 @@
+# Release v0.18.0-rc.2
+
+- change short text for help topic (#1058)
+- bug: allow http protocol for oci access (#1060)
+- bug: fix unmarshal consumer identity with empty value (#1057)
+- fix artifact set tagging (#1033)
+- component constructor with references field (#1054)
+- priority for CLI registration options (#1045)
+- chore: update 'flake.nix' (#1049)
+- add action doc (#1032)
+- chore: update 'flake.nix' (#1040)
+- chore: update 'flake.nix' (#1039)
+- fix downloader handling (#1031)
+- Adjust README with rotated GPG key (#1025)
+
+## 🐛 Bug Fixes
+
+- fix: set tlskyber=0 (#1047)
+- fix: remove ocm release key if present (#1024)
+- chore: release fallout corrections (#1023)
+- fix version info for OCI refs (#1078) [cherry-picked](https://github.com/open-component-model/ocm/pull/1080)
+
+## 🧰 Maintenance
+
+<details>
+<summary>8 changes</summary>
+
+- chore: force bump to 0.18.0-dev (#1061)
+- chore: reuse aggregation from ctf during component build (#1044)
+- chore: disable runner cache for release note drafter (#1051)
+- chore: enhance the publishing to other repositories then github (#1028)
+- chore: migrate all component builds: ca => ctf (#1043)
+- chore(ci): various optimizations for build processing, caching and concurrency (#996)
+- fix: remove ocm release key if present (#1024)
+- chore: release fallout corrections (#1023)
+</details>
+
+## ⬆️ Dependencies
+
+<details>
+<summary>4 changes</summary>
+
+- chore(deps): bump github.com/golang-jwt/jwt/v4 from 4.5.0 to 4.5.1 in the go\_modules group (#1048)
+- chore(deps): bump github.com/containerd/errdefs from 0.3.0 to 1.0.0 (#1037)
+- chore(deps): bump the ci group with 2 updates (#1038)
+- chore(deps): bump the go group with 8 updates (#1036)
+</details>
+

--- a/examples/lib/tour/01-getting-started/README.md
+++ b/examples/lib/tour/01-getting-started/README.md
@@ -168,32 +168,32 @@ differ, because the code always describes the latest version):
 
 ```text
 resources of the latest version:
-  version:  0.17.0
+  version:  0.18.0-rc.1
   provider: ocm.software
    1: name:           ocmcli
       extra identity: "architecture"="amd64","os"="linux"
       resource type:  executable
-      access:         Local blob sha256:03a45dcde67ba565fe806cb5db67da3387f772f7c50af711a0edd6f802570c04[]
+      access:         Local blob sha256:74fdf71c5467cacd1cb09d15d6ad4944d60cc8efa1d704a91c337e54dcd03fbc[]
    2: name:           ocmcli
       extra identity: "architecture"="arm64","os"="linux"
       resource type:  executable
-      access:         Local blob sha256:5a622634ae43cf03eac91079389d83266891d1f9b2d8a3884cef6fe639180324[]
+      access:         Local blob sha256:d0022850cce685d48ca589b3b59913ecbc3572f7f5082bca5c086a4bf2b47c5a[]
    3: name:           ocmcli
       extra identity: "architecture"="arm64","os"="darwin"
       resource type:  executable
-      access:         Local blob sha256:1482fe5b764e3a86cf96704d7a839ad7e53dcbfd4f5fce5405abffb1962153dd[]
+      access:         Local blob sha256:1161fc38d0fe78ba3be97783f8676a46afa2baf57c199f937798f791cc4961d3[]
    4: name:           ocmcli
       extra identity: "architecture"="amd64","os"="darwin"
       resource type:  executable
-      access:         Local blob sha256:805f181aff48511eea12c699ed1bbcee8bdc4c5168924e81058aff8715946875[]
+      access:         Local blob sha256:33074ce5cc079ea4fc1dbcc7bd54c27cc93f0e188d9ad8c56ba642c4ba6744af[]
    5: name:           ocmcli
       extra identity: "architecture"="amd64","os"="windows"
       resource type:  executable
-      access:         Local blob sha256:20839c68bf0c4cf99444d78ebb93f53358fa9e95fe806f186220bd21d520efa7[]
+      access:         Local blob sha256:2fbac39d7772ae1cf209aca5bb5efdbb6b91e83aede9464c52304c3ccebb4f67[]
    6: name:           ocmcli-image
       extra identity: 
       resource type:  ociImage
-      access:         OCI artifact ghcr.io/open-component-model/ocm/ocm.software/ocmcli/ocmcli-image:0.17.0@sha256:16fb52a1cb11c867bd058f4124dea53fbab94229842cc14b52653c2e80b1cede
+      access:         OCI artifact ghcr.io/open-component-model/ocm/ocm.software/ocmcli/ocmcli-image:0.18.0-rc.1@sha256:3ba3e8c075f7f91e851ec3ce53da2347fe464b3ac33c6d65cf89a459193bb5cb
 ```
 
 Resources have some metadata, like their identity and a resource type.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Cherry Pick from https://github.com/open-component-model/ocm/commit/a1890c261fc2a5ffb58ee1590662b04a752fa9a0

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
