### PR TITLE
fix: correctly set prerelease flag

### DIFF
--- a/.github/config/goreleaser.yaml
+++ b/.github/config/goreleaser.yaml
@@ -2,6 +2,9 @@
 # However, latest builds (equivalent to nightlies based on the main branch), uses latest.yml
 version: 2
 
+release:
+  prerelease: auto
+
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Currently all releases (even if candidates) were published as the latest release even though they should be marked as prereleases. This changes this by using the correct goreleaser indicator:

```
  # If set to auto, will mark the release as not ready for production
  # in case there is an indicator for this in the tag e.g. v1.0.0-rc1
  # If set to true, will mark the release as not ready for production.
  # Default: false.
```

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
