### PR TITLE
chore: also create a tag to avoid dangling commits

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -160,7 +160,8 @@ jobs:
         git commit -m "Release $RELEASE_VERSION"
         msg="Release ${{ env.RELEASE_VERSION }}"
         git tag --annotate --message "${msg}" ${{ env.RELEASE_VERSION }}
-        git push origin ${{ env.RELEASE_VERSION }}
+        # push both the tag as well as a release branch with that tag.
+        git push origin releases/${{ env.RELEASE_VERSION }} ${{ env.RELEASE_VERSION }}
 
     - name: Create GPG Token file from Secret
       run: |


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

currently our tagged releases do not have branch accomodating them, leading to dangling commits. (see https://github.com/open-component-model/ocm/tree/v0.18.0-rc.1 for an example)

This fixes this by also creating an appropriate release branch.

This might introduce issues with things like the release drafter though, so this is likely only the first line of commits for this.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
