### PR TITLE
chore: add breaking change release label

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,6 +13,9 @@ exclude-labels:
   - 'triage/wont-fix'
   - 'triage/invalid'
 categories:
+  - title: '‼️ Breaking Changes'
+    labels:
+      - 'breaking-change'
   - title: '🚀 Features'
     labels:
       - 'kind/enhancement'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

makes sure that we can use the `breaking-change` label to correctly mark changes that can lead to regressions if not taken care of.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
