### PR TITLE
chore: move process options to struct

### DIFF
--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/rscs/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/rscs/elements.go
@@ -102,7 +102,7 @@ func (h *ResourceSpecHandler) Set(v ocm.ComponentVersionAccess, r addhdlrs.Eleme
 		SourceRefs: compdescv2.ConvertSourcerefsTo(spec.SourceRefs),
 	}
 	opts := h.getModOpts()
-	if spec.SkipDigestGeneration {
+	if spec.Options.SkipDigestGeneration {
 		opts = append(opts, ocm.SkipDigest()) //nolint:staticcheck // skip digest still used for tests
 	}
 	/*
@@ -132,8 +132,16 @@ type ResourceSpec struct {
 
 	addhdlrs.ResourceInput `json:",inline"`
 
-	// additional process related options
+	// Options describes additional process related options
+	// see ResourceOptions for more details.
+	Options ResourceOptions `json:"options,omitempty"`
+}
 
+// ResourceOptions describes additional process related options
+// which reflect the handling of the resource without describing it directly.
+// Typical examples are any options that require specific changes in handling of the resource
+// but are not reflected in the resource itself (outside of side effects)
+type ResourceOptions struct {
 	// SkipDigestGeneration omits the digest generation.
 	SkipDigestGeneration bool `json:"skipDigestGeneration,omitempty"`
 }

--- a/cmds/ocm/commands/ocmcmds/components/add/testdata/component-constructor-skip.yaml
+++ b/cmds/ocm/commands/ocmcmds/components/add/testdata/component-constructor-skip.yaml
@@ -12,7 +12,6 @@ labels:
 resources:
   - name: text
     type: PlainText
-    skipDigestGeneration: true
     labels:
       - name: city
         value: Karlsruhe
@@ -23,6 +22,8 @@ resources:
     input:
       type: file
       path: testdata
+    options:
+      skipDigestGeneration: true
   - name: data
     type: PlainText
     input:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

This is a follow up from https://github.com/open-component-model/ocm/pull/1070 as @fabianburth and I decided that it would probably be best to group process related options under a specific struct to make it more explicit that they are optional and not part of the normal resource description

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
