### PR TITLE
Add options to distinguish between component and processing data

### DIFF
--- a/cmds/ocm/commands/ocmcmds/common/addhdlrs/rscs/elements.go
+++ b/cmds/ocm/commands/ocmcmds/common/addhdlrs/rscs/elements.go
@@ -102,7 +102,7 @@ func (h *ResourceSpecHandler) Set(v ocm.ComponentVersionAccess, r addhdlrs.Eleme
 		SourceRefs: compdescv2.ConvertSourcerefsTo(spec.SourceRefs),
 	}
 	opts := h.getModOpts()
-	if spec.SkipDigestGeneration {
+	if spec.Options.SkipDigestGeneration {
 		opts = append(opts, ocm.SkipDigest()) //nolint:staticcheck // skip digest still used for tests
 	}
 	/*
@@ -133,8 +133,13 @@ type ResourceSpec struct {
 	addhdlrs.ResourceInput `json:",inline"`
 
 	// additional process related options
+	Options Options `json:"options"`
 
 	// SkipDigestGeneration omits the digest generation.
+	SkipDigestGeneration bool `json:"skipDigestGeneration,omitempty"`
+}
+
+type Options struct {
 	SkipDigestGeneration bool `json:"skipDigestGeneration,omitempty"`
 }
 

--- a/cmds/ocm/commands/ocmcmds/components/add/testdata/component-constructor-skip.yaml
+++ b/cmds/ocm/commands/ocmcmds/components/add/testdata/component-constructor-skip.yaml
@@ -12,7 +12,6 @@ labels:
 resources:
   - name: text
     type: PlainText
-    skipDigestGeneration: true
     labels:
       - name: city
         value: Karlsruhe
@@ -20,6 +19,8 @@ resources:
           algorithm: default
           config:
             overwrite: inbound
+    options:
+      skipDigestGeneration: true
     input:
       type: file
       path: testdata


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
I agree that the component constructor has to support the same options as the current `add resource` command. But since that might be more than just skip digest generation, I think it's better to add a nested options object to help distinguish between component data and processing options.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
