### PR TITLE
chore: automatically set github actions label

### DIFF
--- a/.github/config/labeler.yml
+++ b/.github/config/labeler.yml
@@ -8,3 +8,7 @@ dependencies:
 - any:
   - head-branch: 'dependencies/*'
   - head-branch: 'dependabot/*'
+github-actions:
+- any:
+  - changed-files:
+    - '.github/**'

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   branch-name-labeler:
-    name: Label PR based on branch name
+    name: Label PR based on Config
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

currently the github actions label is not set automatically and I tend to forget it. Thats why this PR is changing this so that the labeller config also sets the github actions label if anything in `.github` changes

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
