### PR TITLE
chore: fixup labeler job config

### DIFF
--- a/.github/config/labeler.yml
+++ b/.github/config/labeler.yml
@@ -1,3 +1,4 @@
+# see https://github.com/actions/labeler?tab=readme-ov-file#match-object to configure correctly
 feature:
 - head-branch: 'feature/*'
 fix:
@@ -11,4 +12,4 @@ dependencies:
 github-actions:
 - any:
   - changed-files:
-    - '.github/**'
+    - any-glob-to-any-file: ['.github/**']


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

this fixes up the labeler job config that I messed up in 1fb2f09fcfaaa0bfab9f54678bac414bcb0a8821

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
