### PR TITLE
feat(log): log http requests for OCI and docker based on trace level by injecting a logger

### DIFF
--- a/api/oci/extensions/repositories/docker/logging.go
+++ b/api/oci/extensions/repositories/docker/logging.go
@@ -1,0 +1,9 @@
+package docker
+
+import (
+	ocmlog "ocm.software/ocm/api/utils/logging"
+)
+
+var (
+	REALM = ocmlog.DefineSubRealm("Docker repository handling", "docker")
+)

--- a/api/oci/extensions/repositories/docker/repository.go
+++ b/api/oci/extensions/repositories/docker/repository.go
@@ -6,8 +6,10 @@ import (
 	"github.com/containers/image/v5/types"
 	dockertypes "github.com/docker/docker/api/types/image"
 	"github.com/docker/docker/client"
+	"github.com/mandelsoft/logging"
 
 	"ocm.software/ocm/api/oci/cpi"
+	ocmlog "ocm.software/ocm/api/utils/logging"
 )
 
 type RepositoryImpl struct {
@@ -20,7 +22,9 @@ type RepositoryImpl struct {
 var _ cpi.RepositoryImpl = (*RepositoryImpl)(nil)
 
 func NewRepository(ctx cpi.Context, spec *RepositorySpec) (cpi.Repository, error) {
-	client, err := newDockerClient(spec.DockerHost)
+	urs := spec.UniformRepositorySpec()
+	logger := logging.DynamicLogger(ctx, REALM, logging.NewAttribute(ocmlog.ATTR_HOST, urs.Host))
+	client, err := newDockerClient(spec.DockerHost, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/api/oci/extensions/repositories/docker/type.go
+++ b/api/oci/extensions/repositories/docker/type.go
@@ -3,9 +3,12 @@ package docker
 import (
 	"context"
 
+	"github.com/mandelsoft/logging"
+
 	"ocm.software/ocm/api/credentials"
 	"ocm.software/ocm/api/oci/cpi"
 	"ocm.software/ocm/api/utils"
+	ocmlog "ocm.software/ocm/api/utils/logging"
 	"ocm.software/ocm/api/utils/runtime"
 )
 
@@ -50,7 +53,9 @@ func (a *RepositorySpec) Repository(ctx cpi.Context, creds credentials.Credentia
 }
 
 func (a *RepositorySpec) Validate(ctx cpi.Context, creds credentials.Credentials, usageContext ...credentials.UsageContext) error {
-	client, err := newDockerClient(a.DockerHost)
+	urs := a.UniformRepositorySpec()
+	logger := logging.DynamicLogger(ctx, REALM, logging.NewAttribute(ocmlog.ATTR_HOST, urs.Host))
+	client, err := newDockerClient(a.DockerHost, logger)
 	if err != nil {
 		return err
 	}

--- a/api/oci/extensions/repositories/ocireg/logging.go
+++ b/api/oci/extensions/repositories/ocireg/logging.go
@@ -4,4 +4,6 @@ import (
 	ocmlog "ocm.software/ocm/api/utils/logging"
 )
 
-var REALM = ocmlog.DefineSubRealm("OCI repository handling", "oci", "ocireg")
+var (
+	REALM = ocmlog.DefineSubRealm("OCI repository handling", "oci", "ocireg")
+)

--- a/api/utils/logging/roundtripper.go
+++ b/api/utils/logging/roundtripper.go
@@ -1,0 +1,36 @@
+package logging
+
+import (
+	"net/http"
+
+	"github.com/mandelsoft/logging"
+)
+
+func NewRoundTripper(rt http.RoundTripper, logger logging.Logger) *RoundTripper {
+	return &RoundTripper{
+		logger:       logger,
+		RoundTripper: rt,
+	}
+}
+
+// RoundTripper is a http.RoundTripper that logs requests.
+type RoundTripper struct {
+	logger logging.Logger
+	http.RoundTripper
+}
+
+func (t *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Redact the Authorization header to make sure it doesn't get logged at any point.
+	header := req.Header
+	if key := "Authorization"; req.Header.Get(key) != "" {
+		header = header.Clone()
+		header.Set(key, "***")
+	}
+
+	t.logger.Trace("roundtrip",
+		"url", req.URL,
+		"method", req.Method,
+		"header", header,
+	)
+	return t.RoundTripper.RoundTrip(req)
+}

--- a/api/utils/logging/roundtripper_test.go
+++ b/api/utils/logging/roundtripper_test.go
@@ -1,0 +1,65 @@
+package logging_test
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+
+	logcfg "github.com/mandelsoft/logging/config"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/tonglil/buflogr"
+
+	"github.com/mandelsoft/logging"
+
+	local "ocm.software/ocm/api/utils/logging"
+)
+
+var _ = Describe("RoundTripper", func() {
+	var buf bytes.Buffer
+	var ctx *local.StaticContext
+	var roundTripper http.RoundTripper
+	var server *httptest.Server
+
+	BeforeEach(func() {
+		buf.Reset()
+		local.SetContext(logging.NewDefault())
+		ctx = local.Context()
+		ctx.SetBaseLogger(buflogr.NewWithBuffer(&buf))
+	})
+
+	AfterEach(func() {
+		if server != nil {
+			server.Close()
+		}
+	})
+
+	It("redacts Authorization header", func() {
+		r := logcfg.ConditionalRule("trace")
+		cfg := &logcfg.Config{
+			Rules: []logcfg.Rule{r},
+		}
+		Expect(ctx.Configure(cfg)).To(Succeed())
+
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		roundTripper = local.NewRoundTripper(http.DefaultTransport, ctx.Logger())
+		client := &http.Client{Transport: roundTripper}
+
+		req, err := http.NewRequest("GET", server.URL, nil)
+		Expect(err).NotTo(HaveOccurred())
+		req.Header.Set("Authorization", "this should be redacted")
+
+		_, err = client.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(buf.String()).To(ContainSubstring("roundtrip"))
+		Expect(buf.String()).To(ContainSubstring("url"))
+		Expect(buf.String()).To(ContainSubstring("method"))
+		Expect(buf.String()).To(ContainSubstring("header"))
+		Expect(buf.String()).To(ContainSubstring("***"))
+		Expect(buf.String()).NotTo(ContainSubstring("this should be redacted"))
+	})
+})


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

it is now possible to inject a trace attribute to OCMs logging architecture to allow tracing back HTTP calls for oci registries and the docker client:

```
ocm --logkeys /+ocm/oci=trace [YOUR COMMAND INTERACTING WITH OCI HERE]
```

Note that this does not take care of all access types yet because we dont have a unified http.Client.

Note that it is now also possible to pass `/+ocm/docker=trace` to enable logging for the docker client infrastructure, or set `--loglevel=trace` to get a full tracelog with HTTP statements.

Authorization Headers are redacted

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
