### PR TITLE
chore: fixup release action versioning and notes process

### DIFF
--- a/.github/workflows/components.yaml
+++ b/.github/workflows/components.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
   workflow_call:
     inputs:
-      effective-version:
+      version:
         type: string
         required: false
         description: "The version to use for the build"
@@ -92,7 +92,7 @@ jobs:
           
           PATH=$PATH:$(go env GOPATH)/bin \
           CTF_TYPE=${{ env.CTF_TYPE }} \
-          EFFECTIVE_VERSION=${{ inputs.effective-version }} \
+          VERSION=${{ inputs.version }} \
           PLATFORMS="${{ env.PLATFORMS }}" \
           IMAGE_PLATFORMS="${{ env.IMAGE_PLATFORMS }}" \
           make \

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,52 +38,52 @@ jobs:
     outputs:
       draft-release-notes: ${{ steps.release-notes.outputs.json }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Check Tag
-        run: |
-          set -e
-          if git ls-remote --exit-code origin refs/tags/${{ env.RELEASE_VERSION }} ; then
-            >&2 echo "tag ${{ env.RELEASE_VERSION }} already exists"
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Check Tag
+      run: |
+        set -e
+        if git ls-remote --exit-code origin refs/tags/${{ env.RELEASE_VERSION }} ; then
+          >&2 echo "tag ${{ env.RELEASE_VERSION }} already exists"
+          exit 1
+        fi
+    - name: Check if release is running on release branch
+      run: |
+        if [[ ${{ env.REF }} != *"releases/"* ]]; then
+            echo "The branch ${{ env.REF }} is not a valid release branch and cannot be used for a release"
             exit 1
-          fi
-      - name: Check if release is running on release branch
-        run: |
-          if [[ ${{ env.REF }} != *"releases/"* ]]; then
-              echo "The branch ${{ env.REF }} is not a valid release branch and cannot be used for a release"
-              exit 1
-          fi
-          echo "Branch ${{ env.REF }} is a valid release branch"
-      - name: Generate token
-        id: generate_token
-        uses: tibdex/github-app-token@v2
-        with:
-          app_id: ${{ secrets.OCMBOT_APP_ID }}
-          private_key: ${{ secrets.OCMBOT_PRIV_KEY }}
-      - name: Ensure existing Draft Release Notes exist
-        id: release-notes
-        shell: bash
-        env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-        run: |
-          RELEASE_JSON=$( \
-            gh api /repos/${{ github.repository }}/releases \
-            -q '.[] | select(.name == "${{ env.RELEASE_VERSION_NO_SUFFIX }}" and .draft == true)' \
-          )
-          echo "json=${RELEASE_JSON}" >> $GITHUB_OUTPUT
-          # if no draft release notes are found, we cannot continue
-          if [ -z "${RELEASE_JSON}" ]; then
-            echo "No draft release notes found for ${{ env.RELEASE_VERSION_NO_SUFFIX }}"
-            exit 1
-          fi
+        fi
+        echo "Branch ${{ env.REF }} is a valid release branch"
+    - name: Generate token
+      id: generate_token
+      uses: tibdex/github-app-token@v2
+      with:
+        app_id: ${{ secrets.OCMBOT_APP_ID }}
+        private_key: ${{ secrets.OCMBOT_PRIV_KEY }}
+    - name: Ensure existing Draft Release Notes exist
+      id: release-notes
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+      run: |
+        RELEASE_JSON=$( \
+          gh api /repos/${{ github.repository }}/releases \
+          -q '.[] | select(.name == "${{ env.RELEASE_VERSION_NO_SUFFIX }}" and .draft == true)' \
+        )
+        echo "json=${RELEASE_JSON}" >> $GITHUB_OUTPUT
+        # if no draft release notes are found, we cannot continue
+        if [ -z "${RELEASE_JSON}" ]; then
+          echo "No draft release notes found for ${{ env.RELEASE_VERSION_NO_SUFFIX }}"
+          exit 1
+        fi
   components:
     name: Component CTF Builds
     uses: ./.github/workflows/components.yaml
     needs: [ check,release-version ]
     with:
-      effective-version: ${{ needs.release-version.outputs.version_no_prefix }}
+      version: ${{ needs.release-version.outputs.version_no_prefix }}
       upload-ctf: true
       ref: ${{ github.ref }}
     permissions:
@@ -92,11 +92,11 @@ jobs:
 
   release:
     needs:
-      # run check before actual release to make sure we succeed
-      # they will be skipped from the needs check
-      - check
-      - release-version
-      - components
+    # run check before actual release to make sure we succeed
+    # they will be skipped from the needs check
+    - check
+    - release-version
+    - components
     name: Release Build
     runs-on: large_runner
     permissions:
@@ -105,185 +105,136 @@ jobs:
       packages: write
     env:
       RELEASE_VERSION: ${{ needs.release-version.outputs.version }}
-      RELEASE_NOTES: ${{ fromJSON(needs.check.outputs.draft-release-notes).body }}
     steps:
-      - name: Self Hosted Runner Post Job Cleanup Action
-        uses: TooMuch4U/actions-clean@v2.2
-      - name: Generate token
-        id: generate_token
-        uses: tibdex/github-app-token@v2
-        with:
-          app_id: ${{ secrets.OCMBOT_APP_ID }}
-          private_key: ${{ secrets.OCMBOT_PRIV_KEY }}
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          # fetch all history so we can calculate the version and tagging
-          fetch-depth: 0
-          token: ${{ steps.generate_token.outputs.token }}
+    - name: Self Hosted Runner Post Job Cleanup Action
+      uses: TooMuch4U/actions-clean@v2.2
+    - name: Generate token
+      id: generate_token
+      uses: tibdex/github-app-token@v2
+      with:
+        app_id: ${{ secrets.OCMBOT_APP_ID }}
+        private_key: ${{ secrets.OCMBOT_PRIV_KEY }}
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        # fetch all history so we can calculate the version and tagging
+        fetch-depth: 0
+        token: ${{ steps.generate_token.outputs.token }}
 
-      - name: Setup Syft
-        uses: anchore/sbom-action/download-syft@fc46e51fd3cb168ffb36c6d1915723c47db58abb # v0.17.7
+    - name: Setup Syft
+      uses: anchore/sbom-action/download-syft@fc46e51fd3cb168ffb36c6d1915723c47db58abb # v0.17.7
 
-      - name: Setup Cosign
-        uses: sigstore/cosign-installer@v3.7.0
+    - name: Setup Cosign
+      uses: sigstore/cosign-installer@v3.7.0
 
-      - name: Download CTF
-        uses: actions/download-artifact@v4
-        with:
-          pattern: 'ctf-aggregated'
-          path: gen/downloaded-ctfs
-      - name: Move CTF into correct directory to be recognized by the release process
-        run: |
-          mv \
-              ${{ github.workspace }}/gen/downloaded-ctfs/ctf-aggregated \
-              ${{ github.workspace }}/gen/ctf
+    - name: Download CTF
+      uses: actions/download-artifact@v4
+      with:
+        pattern: 'ctf-aggregated'
+        path: gen/downloaded-ctfs
+    - name: Move CTF into correct directory to be recognized by the release process
+      run: |
+        mv \
+            ${{ github.workspace }}/gen/downloaded-ctfs/ctf-aggregated \
+            ${{ github.workspace }}/gen/ctf
 
-      # TODO: Remove Go setup once binaries no longer need to be built by goreleaser.
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: '${{ github.workspace }}/go.mod'
-          check-latest: false
-          cache: false
-      - name: Get go environment for use with cache
-        run: |
-          echo "go_cache=$(go env GOCACHE)" >> $GITHUB_ENV
-          echo "go_modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
-        # This step will only reuse the go mod and build cache from main made during the Build,
-        # see push_ocm.yaml => "ocm-cli-latest" Job
-        # This means it never caches by itself and PRs cannot cause cache pollution / thrashing
-        # This is because we have huge storage requirements for our cache because of the mass of dependencies
-      - name: Restore / Reuse Cache from central build
-        id: cache-golang-restore
-        uses: actions/cache/restore@v4 # Only Restore, not build another cache (too big)
-        with:
-          path: |
-            ${{ env.go_cache }}
-            ${{ env.go_modcache }}
-          key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
-          restore-keys: |
-            ${{ env.cache_name }}-${{ runner.os }}-go-
-        env:
-          cache_name: ocm-cli-latest-go-cache # needs to be the same key in the end as in the build step
+    # TODO: Remove Go setup once binaries no longer need to be built by goreleaser.
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: '${{ github.workspace }}/go.mod'
+        check-latest: false
+        cache: false
+    - name: Get go environment for use with cache
+      run: |
+        echo "go_cache=$(go env GOCACHE)" >> $GITHUB_ENV
+        echo "go_modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
+      # This step will only reuse the go mod and build cache from main made during the Build,
+      # see push_ocm.yaml => "ocm-cli-latest" Job
+      # This means it never caches by itself and PRs cannot cause cache pollution / thrashing
+      # This is because we have huge storage requirements for our cache because of the mass of dependencies
+    - name: Restore / Reuse Cache from central build
+      id: cache-golang-restore
+      uses: actions/cache/restore@v4 # Only Restore, not build another cache (too big)
+      with:
+        path: |
+          ${{ env.go_cache }}
+          ${{ env.go_modcache }}
+        key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
+        restore-keys: |
+          ${{ env.cache_name }}-${{ runner.os }}-go-
+      env:
+        cache_name: ocm-cli-latest-go-cache # needs to be the same key in the end as in the build step
 
-      - name: Setup git config
-        run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<41898282+github-actions[bot]@users.noreply.github.com>"
+    - name: Setup git config
+      run: |
+        git config user.name "GitHub Actions Bot"
+        git config user.email "<41898282+github-actions[bot]@users.noreply.github.com>"
 
-      - name: Update Release Notes File
-        env:
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-        run: |
-          if git ls-remote --exit-code origin refs/tags/${{ env.RELEASE_VERSION }}; then
-            >&2 echo "tag ${{ env.RELEASE_VERSION }} already exists"
-            exit 2
-          fi
-          v="${{env.RELEASE_VERSION}}"
-          f="docs/releasenotes/$v.md"
-          if [ ! -f "$f" ]; then
-            echo "# Release ${{ env.RELEASE_VERSION }}" > "$f"
-            echo "$RELEASE_NOTES" | tail -n +2 >> "$f"
-            git add "$f"
-            git commit -m "ReleaseNotes for $RELEASE_VERSION"
-            git push origin ${GITHUB_REF#refs/heads/}
-          else
-            echo "Using release notes file $f from code base"
-          fi
-          echo "RELEASE_NOTES_FILE=$f" >> $GITHUB_ENV
+    - name: Create and Push Release
+      env:
+        GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+      run: |
+        # git checkout --detach HEAD
+        echo -n "${RELEASE_VERSION#v}" > VERSION
+        git add VERSION
+        git commit -m "Release $RELEASE_VERSION"
+        msg="Release ${{ env.RELEASE_VERSION }}"
+        git tag --annotate --message "${msg}" ${{ env.RELEASE_VERSION }}
+        # push both the tag as well as a release branch with that tag.
+        git push origin ${{ env.RELEASE_VERSION }}
 
-      - name: Create and Push Release
-        env:
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-        run: |
-          # git checkout --detach HEAD
-          echo -n "${RELEASE_VERSION#v}" > VERSION
-          git add VERSION
-          git commit -m "Release $RELEASE_VERSION"
-          msg="Release ${{ env.RELEASE_VERSION }}"
-          git tag --annotate --message "${msg}" ${{ env.RELEASE_VERSION }}
-          # push both the tag as well as a release branch with that tag.
-          git push origin ${{ env.RELEASE_VERSION }}
+    - name: Create GPG Token file from Secret
+      run: |
+        echo "${{ secrets.GPG_PRIVATE_KEY_FOR_SIGNING }}" > ocm-releases-key.gpg
+        echo "GPG_KEY_PATH=ocm-releases-key.gpg" >> $GITHUB_ENV
 
-      - name: Create GPG Token file from Secret
-        run: |
-          echo "${{ secrets.GPG_PRIVATE_KEY_FOR_SIGNING }}" > ocm-releases-key.gpg
-          echo "GPG_KEY_PATH=ocm-releases-key.gpg" >> $GITHUB_ENV
+    - name: Setup Release Notes as File to make it readable by GoReleaser
+      run: |
+        echo "${{ fromJSON(needs.check.outputs.draft-release-notes).body }}" > $RUNNER_TEMP/RELEASE_NOTES.md
+        echo "RELEASE_NOTES=$RUNNER_TEMP/RELEASE_NOTES.md" >> $GITHUB_ENV
+        cat $RUNNER_TEMP/RELEASE_NOTES.md
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v6
+      with:
+        distribution: goreleaser
+        version: 2.1.0
+        args: release --clean --timeout 60m --skip=validate --config=.github/config/goreleaser.yaml --release-notes=${{ env.RELEASE_NOTES }}
+      env:
+        GITHUBORG: ${{ github.repository_owner }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GORELEASER_CURRENT_TAG: ${{ env.RELEASE_VERSION }}
+        NFPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          distribution: goreleaser
-          version: 2.1.0
-          args: release --clean --timeout 60m --skip=validate --config=.github/config/goreleaser.yaml --release-notes=${{ env.RELEASE_NOTES_FILE }}
-        env:
-          GITHUBORG: ${{ github.repository_owner }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GORELEASER_CURRENT_TAG: ${{ env.RELEASE_VERSION }}
-          NFPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+    - name: Remove GPG Token file
+      run: |
+        rm ocm-releases-key.gpg
 
-      - name: Remove GPG Token file
-        run: |
-          rm ocm-releases-key.gpg
+    - name: Push OCM Components
+      env:
+        GITHUBORG: ${{ github.repository_owner }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: make plain-push
 
-      - name: Push OCM Components
-        env:
-          GITHUBORG: ${{ github.repository_owner }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: make plain-push
+    - name: Publish Release Event
+      if: inputs.release_candidate == false
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        token: ${{ steps.generate_token.outputs.token }}
+        repository: open-component-model/ocm-website
+        event-type: ocm-cli-release
+        client-payload: '{"tag": "${{ env.RELEASE_VERSION }}"}'
 
-      - name: Publish Release Event
-        if: inputs.release_candidate == false
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ steps.generate_token.outputs.token }}
-          repository: open-component-model/ocm-website
-          event-type: ocm-cli-release
-          client-payload: '{"tag": "${{ env.RELEASE_VERSION }}"}'
-
-      # now distribute the release event so that other jobs can listen for this
-      # and use the event to publish our release to other package registries
-      - name: Publish Release Event for other package registries
-        if: inputs.release_candidate == false
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ steps.generate_token.outputs.token }}
-          repository: ${{ github.repository_owner }}/ocm
-          event-type: publish-ocm-cli
-          client-payload: '{"version":"${{ env.RELEASE_VERSION }}","push-to-aur":true,"push-to-chocolatey":true,"push-to-winget":true}'
-
-  merge-back-release-into-release-branch-history:
-    needs: release
-    runs-on: ubuntu-latest
-    name: Write an empty Commit into the release branch with the tag
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-          # fetch the tags so we can use it in our merge command
-          fetch-tags: true
-          token: ${{ steps.generate_token.outputs.token }}
-      - name: Setup git config
-        run: |
-          git config user.name "GitHub Actions Bot"
-          git config user.email "<41898282+github-actions[bot]@users.noreply.github.com>"
-      # merge the tag back into the release branch
-      # this is necessary to make sure that the release branch contains the tag
-      # and the tag is not "dangling" in the history
-      - name: Merge back Release Tag into history
-        env:
-          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-        run: |
-          git checkout ${{ github.ref }}
-          git merge \
-            --no-ff \
-            --no-edit \
-            --message "Release ${{ env.RELEASE_VERSION }}" \
-            --strategy ours \
-            refs/tags/${{ env.RELEASE_VERSION }}
-          git push origin ${{ github.ref }}
+    # now distribute the release event so that other jobs can listen for this
+    # and use the event to publish our release to other package registries
+    - name: Publish Release Event for other package registries
+      if: inputs.release_candidate == false
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        token: ${{ steps.generate_token.outputs.token }}
+        repository: ${{ github.repository_owner }}/ocm
+        event-type: publish-ocm-cli
+        client-payload: '{"version":"${{ env.RELEASE_VERSION }}","push-to-aur":true,"push-to-chocolatey":true,"push-to-winget":true}'
 
   # make sure that the branch contains the next valid patch
   bump-release-branch-pr:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,50 +38,50 @@ jobs:
     outputs:
       draft-release-notes: ${{ steps.release-notes.outputs.json }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-    - name: Check Tag
-      run: |
-        set -e
-        if git ls-remote --exit-code origin refs/tags/${{ env.RELEASE_VERSION }} ; then
-          >&2 echo "tag ${{ env.RELEASE_VERSION }} already exists"
-          exit 1
-        fi
-    - name: Check if release is running on release branch
-      run: |
-        if [[ ${{ env.REF }} != *"releases/"* ]]; then
-            echo "The branch ${{ env.REF }} is not a valid release branch and cannot be used for a release"
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check Tag
+        run: |
+          set -e
+          if git ls-remote --exit-code origin refs/tags/${{ env.RELEASE_VERSION }} ; then
+            >&2 echo "tag ${{ env.RELEASE_VERSION }} already exists"
             exit 1
-        fi
-        echo "Branch ${{ env.REF }} is a valid release branch"
-    - name: Generate token
-      id: generate_token
-      uses: tibdex/github-app-token@v2
-      with:
-        app_id: ${{ secrets.OCMBOT_APP_ID }}
-        private_key: ${{ secrets.OCMBOT_PRIV_KEY }}
-    - name: Ensure existing Draft Release Notes exist
-      id: release-notes
-      shell: bash
-      env:
-        GH_TOKEN: ${{ steps.generate_token.outputs.token }}
-      run: |
-        RELEASE_JSON=$( \
-          gh api /repos/${{ github.repository }}/releases \
-          -q '.[] | select(.name == "${{ env.RELEASE_VERSION_NO_SUFFIX }}" and .draft == true)' \
-        )
-        echo "json=${RELEASE_JSON}" >> $GITHUB_OUTPUT
-        # if no draft release notes are found, we cannot continue
-        if [ -z "${RELEASE_JSON}" ]; then
-          echo "No draft release notes found for ${{ env.RELEASE_VERSION_NO_SUFFIX }}"
-          exit 1
-        fi
+          fi
+      - name: Check if release is running on release branch
+        run: |
+          if [[ ${{ env.REF }} != *"releases/"* ]]; then
+              echo "The branch ${{ env.REF }} is not a valid release branch and cannot be used for a release"
+              exit 1
+          fi
+          echo "Branch ${{ env.REF }} is a valid release branch"
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.OCMBOT_APP_ID }}
+          private_key: ${{ secrets.OCMBOT_PRIV_KEY }}
+      - name: Ensure existing Draft Release Notes exist
+        id: release-notes
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          RELEASE_JSON=$( \
+            gh api /repos/${{ github.repository }}/releases \
+            -q '.[] | select(.name == "${{ env.RELEASE_VERSION_NO_SUFFIX }}" and .draft == true)' \
+          )
+          echo "json=${RELEASE_JSON}" >> $GITHUB_OUTPUT
+          # if no draft release notes are found, we cannot continue
+          if [ -z "${RELEASE_JSON}" ]; then
+            echo "No draft release notes found for ${{ env.RELEASE_VERSION_NO_SUFFIX }}"
+            exit 1
+          fi
   components:
     name: Component CTF Builds
     uses: ./.github/workflows/components.yaml
-    needs: [check,release-version]
+    needs: [ check,release-version ]
     with:
       effective-version: ${{ needs.release-version.outputs.version_no_prefix }}
       upload-ctf: true
@@ -92,11 +92,11 @@ jobs:
 
   release:
     needs:
-    # run check before actual release to make sure we succeed
-    # they will be skipped from the needs check
-    - check
-    - release-version
-    - components
+      # run check before actual release to make sure we succeed
+      # they will be skipped from the needs check
+      - check
+      - release-version
+      - components
     name: Release Build
     runs-on: large_runner
     permissions:
@@ -107,130 +107,183 @@ jobs:
       RELEASE_VERSION: ${{ needs.release-version.outputs.version }}
       RELEASE_NOTES: ${{ fromJSON(needs.check.outputs.draft-release-notes).body }}
     steps:
-    - name: Self Hosted Runner Post Job Cleanup Action
-      uses: TooMuch4U/actions-clean@v2.2
-    - name: Generate token
-      id: generate_token
-      uses: tibdex/github-app-token@v2
-      with:
-        app_id: ${{ secrets.OCMBOT_APP_ID }}
-        private_key: ${{ secrets.OCMBOT_PRIV_KEY }}
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        # fetch all history so we can calculate the version and tagging
-        fetch-depth: 0
-        token: ${{ steps.generate_token.outputs.token }}
+      - name: Self Hosted Runner Post Job Cleanup Action
+        uses: TooMuch4U/actions-clean@v2.2
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.OCMBOT_APP_ID }}
+          private_key: ${{ secrets.OCMBOT_PRIV_KEY }}
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # fetch all history so we can calculate the version and tagging
+          fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
 
-    - name: Setup Syft
-      uses: anchore/sbom-action/download-syft@fc46e51fd3cb168ffb36c6d1915723c47db58abb # v0.17.7
+      - name: Setup Syft
+        uses: anchore/sbom-action/download-syft@fc46e51fd3cb168ffb36c6d1915723c47db58abb # v0.17.7
 
-    - name: Setup Cosign
-      uses: sigstore/cosign-installer@v3.7.0
+      - name: Setup Cosign
+        uses: sigstore/cosign-installer@v3.7.0
 
-    - name: Download CTF
-      uses: actions/download-artifact@v4
-      with:
-        pattern: 'ctf-aggregated'
-        path: gen/downloaded-ctfs
-    - name: Move CTF into correct directory to be recognized by the release process
-      run: |
-        mv \
-            ${{ github.workspace }}/gen/downloaded-ctfs/ctf-aggregated \
-            ${{ github.workspace }}/gen/ctf
+      - name: Download CTF
+        uses: actions/download-artifact@v4
+        with:
+          pattern: 'ctf-aggregated'
+          path: gen/downloaded-ctfs
+      - name: Move CTF into correct directory to be recognized by the release process
+        run: |
+          mv \
+              ${{ github.workspace }}/gen/downloaded-ctfs/ctf-aggregated \
+              ${{ github.workspace }}/gen/ctf
 
-    # TODO: Remove Go setup once binaries no longer need to be built by goreleaser.
-    - name: Setup Go
-      uses: actions/setup-go@v5
-      with:
-        go-version-file: '${{ github.workspace }}/go.mod'
-        check-latest: false
-        cache: false
-    - name: Get go environment for use with cache
-      run: |
-        echo "go_cache=$(go env GOCACHE)" >> $GITHUB_ENV
-        echo "go_modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
-      # This step will only reuse the go mod and build cache from main made during the Build,
-      # see push_ocm.yaml => "ocm-cli-latest" Job
-      # This means it never caches by itself and PRs cannot cause cache pollution / thrashing
-      # This is because we have huge storage requirements for our cache because of the mass of dependencies
-    - name: Restore / Reuse Cache from central build
-      id: cache-golang-restore
-      uses: actions/cache/restore@v4 # Only Restore, not build another cache (too big)
-      with:
-        path: |
-          ${{ env.go_cache }}
-          ${{ env.go_modcache }}
-        key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
-        restore-keys: |
-          ${{ env.cache_name }}-${{ runner.os }}-go-
-      env:
-        cache_name: ocm-cli-latest-go-cache # needs to be the same key in the end as in the build step
+      # TODO: Remove Go setup once binaries no longer need to be built by goreleaser.
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: '${{ github.workspace }}/go.mod'
+          check-latest: false
+          cache: false
+      - name: Get go environment for use with cache
+        run: |
+          echo "go_cache=$(go env GOCACHE)" >> $GITHUB_ENV
+          echo "go_modcache=$(go env GOMODCACHE)" >> $GITHUB_ENV
+        # This step will only reuse the go mod and build cache from main made during the Build,
+        # see push_ocm.yaml => "ocm-cli-latest" Job
+        # This means it never caches by itself and PRs cannot cause cache pollution / thrashing
+        # This is because we have huge storage requirements for our cache because of the mass of dependencies
+      - name: Restore / Reuse Cache from central build
+        id: cache-golang-restore
+        uses: actions/cache/restore@v4 # Only Restore, not build another cache (too big)
+        with:
+          path: |
+            ${{ env.go_cache }}
+            ${{ env.go_modcache }}
+          key: ${{ env.cache_name }}-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-${{ hashFiles('**/go.mod') }}
+          restore-keys: |
+            ${{ env.cache_name }}-${{ runner.os }}-go-
+        env:
+          cache_name: ocm-cli-latest-go-cache # needs to be the same key in the end as in the build step
 
-    - name: Setup git config
-      run: |
-        git config user.name "GitHub Actions Bot"
-        git config user.email "<41898282+github-actions[bot]@users.noreply.github.com>"
+      - name: Setup git config
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<41898282+github-actions[bot]@users.noreply.github.com>"
 
-    - name: Create and Push Release
-      env:
-        GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-      run: |
-        # git checkout --detach HEAD
-        echo -n "${RELEASE_VERSION#v}" > VERSION
-        git add VERSION
-        git commit -m "Release $RELEASE_VERSION"
-        msg="Release ${{ env.RELEASE_VERSION }}"
-        git tag --annotate --message "${msg}" ${{ env.RELEASE_VERSION }}
-        # push both the tag as well as a release branch with that tag.
-        git push origin releases/${{ env.RELEASE_VERSION }} ${{ env.RELEASE_VERSION }}
+      - name: Update Release Notes File
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          if git ls-remote --exit-code origin refs/tags/${{ env.RELEASE_VERSION }}; then
+            >&2 echo "tag ${{ env.RELEASE_VERSION }} already exists"
+            exit 2
+          fi
+          v="${{env.RELEASE_VERSION}}"
+          f="docs/releasenotes/$v.md"
+          if [ ! -f "$f" ]; then
+            echo "# Release ${{ env.RELEASE_VERSION }}" > "$f"
+            echo "$RELEASE_NOTES" | tail -n +2 >> "$f"
+            git add "$f"
+            git commit -m "ReleaseNotes for $RELEASE_VERSION"
+            git push origin ${GITHUB_REF#refs/heads/}
+          else
+            echo "Using release notes file $f from code base"
+          fi
+          echo "RELEASE_NOTES_FILE=$f" >> $GITHUB_ENV
 
-    - name: Create GPG Token file from Secret
-      run: |
-        echo "${{ secrets.GPG_PRIVATE_KEY_FOR_SIGNING }}" > ocm-releases-key.gpg
-        echo "GPG_KEY_PATH=ocm-releases-key.gpg" >> $GITHUB_ENV
+      - name: Create and Push Release
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          # git checkout --detach HEAD
+          echo -n "${RELEASE_VERSION#v}" > VERSION
+          git add VERSION
+          git commit -m "Release $RELEASE_VERSION"
+          msg="Release ${{ env.RELEASE_VERSION }}"
+          git tag --annotate --message "${msg}" ${{ env.RELEASE_VERSION }}
+          # push both the tag as well as a release branch with that tag.
+          git push origin ${{ env.RELEASE_VERSION }}
 
-    - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v6
-      with:
-        distribution: goreleaser
-        version: 2.1.0
-        args: release --clean --timeout 60m --skip=validate --config=.github/config/goreleaser.yaml --release-notes=${{ env.RELEASE_NOTES_FILE }}
-      env:
-        GITHUBORG: ${{ github.repository_owner }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GORELEASER_CURRENT_TAG: ${{ env.RELEASE_VERSION }}
-        NFPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      - name: Create GPG Token file from Secret
+        run: |
+          echo "${{ secrets.GPG_PRIVATE_KEY_FOR_SIGNING }}" > ocm-releases-key.gpg
+          echo "GPG_KEY_PATH=ocm-releases-key.gpg" >> $GITHUB_ENV
 
-    - name: Remove GPG Token file
-      run: |
-        rm ocm-releases-key.gpg
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: 2.1.0
+          args: release --clean --timeout 60m --skip=validate --config=.github/config/goreleaser.yaml --release-notes=${{ env.RELEASE_NOTES_FILE }}
+        env:
+          GITHUBORG: ${{ github.repository_owner }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_CURRENT_TAG: ${{ env.RELEASE_VERSION }}
+          NFPM_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
-    - name: Push OCM Components
-      env:
-        GITHUBORG: ${{ github.repository_owner }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: make plain-push
+      - name: Remove GPG Token file
+        run: |
+          rm ocm-releases-key.gpg
 
-    - name: Publish Release Event
-      if: inputs.release_candidate == false
-      uses: peter-evans/repository-dispatch@v3
-      with:
-        token: ${{ steps.generate_token.outputs.token }}
-        repository: open-component-model/ocm-website
-        event-type: ocm-cli-release
-        client-payload: '{"tag": "${{ env.RELEASE_VERSION }}"}'
+      - name: Push OCM Components
+        env:
+          GITHUBORG: ${{ github.repository_owner }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make plain-push
 
-    # now distribute the release event so that other jobs can listen for this
-    # and use the event to publish our release to other package registries
-    - name: Publish Release Event for other package registries
-      if: inputs.release_candidate == false
-      uses: peter-evans/repository-dispatch@v3
-      with:
-        token: ${{ steps.generate_token.outputs.token }}
-        repository: ${{ github.repository_owner }}/ocm
-        event-type: publish-ocm-cli
-        client-payload: '{"version":"${{ env.RELEASE_VERSION }}","push-to-aur":true,"push-to-chocolatey":true,"push-to-winget":true}'
+      - name: Publish Release Event
+        if: inputs.release_candidate == false
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          repository: open-component-model/ocm-website
+          event-type: ocm-cli-release
+          client-payload: '{"tag": "${{ env.RELEASE_VERSION }}"}'
+
+      # now distribute the release event so that other jobs can listen for this
+      # and use the event to publish our release to other package registries
+      - name: Publish Release Event for other package registries
+        if: inputs.release_candidate == false
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          repository: ${{ github.repository_owner }}/ocm
+          event-type: publish-ocm-cli
+          client-payload: '{"version":"${{ env.RELEASE_VERSION }}","push-to-aur":true,"push-to-chocolatey":true,"push-to-winget":true}'
+
+  merge-back-release-into-release-branch-history:
+    needs: release
+    runs-on: ubuntu-latest
+    name: Write an empty Commit into the release branch with the tag
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          # fetch the tags so we can use it in our merge command
+          fetch-tags: true
+          token: ${{ steps.generate_token.outputs.token }}
+      - name: Setup git config
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "<41898282+github-actions[bot]@users.noreply.github.com>"
+      # merge the tag back into the release branch
+      # this is necessary to make sure that the release branch contains the tag
+      # and the tag is not "dangling" in the history
+      - name: Merge back Release Tag into history
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          git checkout ${{ github.ref }}
+          git merge \
+            --no-ff \
+            --no-edit \
+            --message "Release ${{ env.RELEASE_VERSION }}" \
+            --strategy ours \
+            refs/tags/${{ env.RELEASE_VERSION }}
+          git push origin ${{ github.ref }}
 
   # make sure that the branch contains the next valid patch
   bump-release-branch-pr:

--- a/components/demoplugin/Makefile
+++ b/components/demoplugin/Makefile
@@ -7,7 +7,9 @@ PLATFORMS ?= linux/amd64 linux/arm64
 CTF_TYPE ?= directory
 
 REPO_ROOT                                      := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/../..
-VERSION                                        = $(shell go run ../../api/version/generate/release_generate.go print-rc-version $(CANDIDATE))
+ifeq ($(VERSION),)
+VERSION                                        := $(shell go run ../../api/version/generate/release_generate.go print-rc-version $(CANDIDATE))
+endif
 COMMIT                                         = $(shell git rev-parse --verify HEAD)
 # if EFFECTIVE_VERSION is not set, set it to VERSION+COMMIT
 # this is not the same as '?=' because it will also set the value if EFFECTIVE_VERSION is set to an empty string

--- a/components/ecrplugin/Makefile
+++ b/components/ecrplugin/Makefile
@@ -8,7 +8,9 @@ CTF_TYPE ?= directory
 
 
 REPO_ROOT                                      := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/../..
-VERSION                                        = $(shell go run ../../api/version/generate/release_generate.go print-rc-version $(CANDIDATE))
+ifeq ($(VERSION),)
+VERSION                                        := $(shell go run ../../api/version/generate/release_generate.go print-rc-version $(CANDIDATE))
+endif
 COMMIT                                         = $(shell git rev-parse --verify HEAD)
 # if EFFECTIVE_VERSION is not set, set it to VERSION+COMMIT
 # this is not the same as '?=' because it will also set the value if EFFECTIVE_VERSION is set to an empty string

--- a/components/helmdemo/Makefile
+++ b/components/helmdemo/Makefile
@@ -8,9 +8,11 @@ CTF_TYPE ?= directory
 HELMINSTCOMP = $(PROVIDER)/toi/installers/helminstaller
 
 REPO_ROOT                                     := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/../..
-VERSION                                        = $(shell go run ../../api/version/generate/release_generate.go print-rc-version $(CANDIDATE))
+ifeq ($(VERSION),)
+VERSION                                        := $(shell go run ../../api/version/generate/release_generate.go print-rc-version $(CANDIDATE))
+endif
 COMMIT                                         = $(shell git rev-parse --verify HEAD)
-# if EFFECTIVE_VERSION is not set, set it to VERSION-COMMIT
+# if EFFECTIVE_VERSION is not set, set it to VERSION+COMMIT
 # this is not the same as '?=' because it will also set the value if EFFECTIVE_VERSION is set to an empty string
 ifeq ($(EFFECTIVE_VERSION),)
 EFFECTIVE_VERSION                              := $(VERSION)+$(COMMIT)

--- a/components/helminstaller/Makefile
+++ b/components/helminstaller/Makefile
@@ -9,9 +9,11 @@ IMAGE_PLATFORMS ?= linux/amd64 linux/arm64
 CTF_TYPE ?= directory
 
 REPO_ROOT                                      := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/../..
+ifeq ($(VERSION),)
 VERSION                                        := $(shell go run ../../api/version/generate/release_generate.go print-rc-version $(CANDIDATE))
+endif
 COMMIT                                         := $(shell git rev-parse --verify HEAD)
-# if EFFECTIVE_VERSION is not set, set it to VERSION-COMMIT
+# if EFFECTIVE_VERSION is not set, set it to VERSION+COMMIT
 # this is not the same as '?=' because it will also set the value if EFFECTIVE_VERSION is set to an empty string
 ifeq ($(EFFECTIVE_VERSION),)
 EFFECTIVE_VERSION                              := $(VERSION)+$(COMMIT)

--- a/components/ocmcli/Makefile
+++ b/components/ocmcli/Makefile
@@ -12,7 +12,9 @@ CTF_TYPE ?= directory
 
 REPO_ROOT                                      := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))../..
 GIT_TREE_STATE                                 = $(shell [ -z "$$(git status --porcelain 2>/dev/null)" ] && echo clean || echo dirty)
-VERSION                                        = $(shell go run ../../api/version/generate/release_generate.go print-rc-version $(CANDIDATE))
+ifeq ($(VERSION),)
+VERSION                                        := $(shell go run ../../api/version/generate/release_generate.go print-rc-version $(CANDIDATE))
+endif
 COMMIT                                         = $(shell git rev-parse --verify HEAD)
 # if EFFECTIVE_VERSION is not set, set it to VERSION+COMMIT
 # this is not the same as '?=' because it will also set the value if EFFECTIVE_VERSION is set to an empty string

--- a/components/subchartsdemo/Makefile
+++ b/components/subchartsdemo/Makefile
@@ -13,9 +13,11 @@ PODINFO_CHART_VERSION = 6.3.5
 
 REPO_ROOT                                     := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/../..
 GIT_TREE_STATE                                 = $(shell [ -z "$$(git status --porcelain 2>/dev/null)" ] && echo clean || echo dirty)
-VERSION                                        = $(shell go run $(REPO_ROOT)/api/version/generate/release_generate.go print-rc-version $(CANDIDATE))
+ifeq ($(VERSION),)
+VERSION                                        := $(shell go run ../../api/version/generate/release_generate.go print-rc-version $(CANDIDATE))
+endif
 COMMIT                                         = $(shell git rev-parse --verify HEAD)
-# if EFFECTIVE_VERSION is not set, set it to VERSION-COMMIT
+# if EFFECTIVE_VERSION is not set, set it to VERSION+COMMIT
 # this is not the same as '?=' because it will also set the value if EFFECTIVE_VERSION is set to an empty string
 ifeq ($(EFFECTIVE_VERSION),)
 EFFECTIVE_VERSION                              := $(VERSION)+$(COMMIT)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Makes sure that release notes are correctly drawn in and that we always have the version set correctly in our CTFs.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

This fixes up the release action in 2 important ways:

1. As part of the removal of the release notes we now no longer have a file to use for release notes to give to goreleaser. This means we have to temporarily create one
2. While discovering this I noticed that the Component Versions that are built, are actually using the `VERSION` variable while `EFFECTIVE_VERSION` is a combination of VERSION+COMMIT by default. I didnt want to change this behavior originally, so now I started to use VERSION for the Makefiles (which also means I had to export them as settable). This now leads to correct CTF versions `v0.19.0-rc.1` instead of `v0.19.0-dev` for example.

As such its a follow up from https://github.com/open-component-model/ocm/pull/1120 and https://github.com/open-component-model/ocm/pull/1077