### PR TITLE
push-to-winget: permissions: write-all

### DIFF
--- a/.github/workflows/publish-to-other-than-github.yaml
+++ b/.github/workflows/publish-to-other-than-github.yaml
@@ -125,6 +125,7 @@ jobs:
     name: Update Winget
     if: github.event.client_payload.push-to-winget && github.event.client_payload.version != ''
     runs-on: windows-latest
+    permissions: write-all
     steps:
     - name: Ensure proper version
       run: |
@@ -150,6 +151,7 @@ jobs:
           https://github.com/open-component-model/ocm/releases/download/v${{ env.RELEASE_VERSION }}/ocm-${{ env.RELEASE_VERSION }}-windows-arm64.zip `
           --version ${{ env.RELEASE_VERSION }} `
           Open-Component-Model.ocm-cli
+
   push-to-website:
     name: Update OCM Website
     runs-on: ubuntu-latest


### PR DESCRIPTION
Trying to fix the issue of: `ERROR: Resource not accessible by integration` - https://github.com/open-component-model/ocm/actions/runs/12006779990/job/33466305628

I doubt that it will work...
see: https://github.com/microsoft/winget-create/issues/470

Maybe we need classical github-token see:
https://github.com/pulumi/pulumi-winget/issues/22#issuecomment-1792809324

