### PR TITLE
chore(backport): autocollapse release notes (#1145)

### DIFF
--- a/.github/config/markdown-link-check.json
+++ b/.github/config/markdown-link-check.json
@@ -5,5 +5,6 @@
      { "pattern": "^http[s]*://localhost.*" }
     ,{ "pattern": "^https://.*\\.sigstore\\.dev.*" }
     ,{ "pattern": "^{{.*}}$" }
+    ,{ "pattern": "^https://github.com/**/compare/**" }
   ]
 }

--- a/.github/config/markdownignore
+++ b/.github/config/markdownignore
@@ -1,3 +1,4 @@
 examples/lib/tour/0*
 docs/reference
 docs/pluginreference
+hack/collapse/*

--- a/.github/config/wordlist.txt
+++ b/.github/config/wordlist.txt
@@ -27,6 +27,7 @@ bool
 boolean
 buildx
 cas
+changelog
 chocolateyinstall
 cli
 cliconfig

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -44,6 +44,7 @@ jobs:
           fetch-tags: true
       - name: Setup Release with gh
         env:
+          COLLAPSE_THRESHOLD: 5
           REF: ${{ github.ref }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}
@@ -80,6 +81,16 @@ jobs:
                -f "configuration_file_path=.github/config/release.yml" \
                -q .body \
              )
+          
+          if [[ -z $notes ]]; then
+            echo "No release notes generated from API, failed"
+            exit 1
+          fi
+          
+          echo "Auto-Collapsing release notes to reduce size"
+          echo $notes > $RUNNER_TEMP/release_notes.md
+          bash hack/collapse/auto_collapse.sh $RUNNER_TEMP/release_notes.md $RUNNER_TEMP/release_notes_processed.md ${{ env.COLLAPSE_THRESHOLD }}
+          notes=$(cat $RUNNER_TEMP/release_notes_processed.md)
           
           echo "Release Notes generated for ${{env.RELEASE_VERSION}}:"
           echo "${notes}"

--- a/hack/collapse/.gitignore
+++ b/hack/collapse/.gitignore
@@ -1,0 +1,1 @@
+test_example_collapsible.md

--- a/hack/collapse/auto_collapse.sh
+++ b/hack/collapse/auto_collapse.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+
+# allow > to overwrite files
+set +o noclobber
+
+# Auto Collapse
+#This is a script that takes in
+# - a markdown file
+# - a designated output file
+# - the number of lines as a threshold on when to collapse a section.
+#
+# Sample
+# ./auto_collapse.sh test_example.md test_example_collapsible.md 5
+
+# Input and output files
+INPUT_FILE=${1:-"README.md"}
+OUTPUT_FILE=${2:-"README_collapsible.md"}
+THRESHOLD=${3:-10}
+
+# Ensure output file is empty initially
+true > "$OUTPUT_FILE"
+
+# Variables to track sections
+inside_section=false
+section_lines=()
+section_header=""
+
+input="$(cat "$INPUT_FILE")"
+FULL_CHANGELOG=$(grep "Full Changelog" < "$INPUT_FILE")
+
+if [[ -z $FULL_CHANGELOG ]]; then
+    echo "Full Changelog not found in the input file."
+else
+    echo "Full Changelog found in the input file."
+    input=$(sed '/Full Changelog/d' <<< "${input}")
+fi
+
+# Function to count changes (lines starting with '*')
+count_changes() {
+    local lines=("$@")
+    local count=0
+    for line in "${lines[@]}"; do
+        if [[ $line =~ ^\* ]]; then
+            ((count++))
+        fi
+    done
+    echo "$count"
+}
+
+# Function to process and write a section
+write_section() {
+    local header="$1"
+    local lines=("${@:2}")
+    num_changes=$(count_changes "${lines[@]}")
+
+    # Write the section header as is
+    echo "$header" >> "$OUTPUT_FILE"
+
+    if [[ $num_changes -gt $THRESHOLD ]]; then
+        # Collapse only the content with a dynamic summary
+        {
+            echo "<details>"
+            echo "<summary>${num_changes} changes</summary>"
+            echo ""
+            printf "%s\n" "${lines[@]}"
+            echo "</details>"
+            echo ""
+        } >> "$OUTPUT_FILE"
+    else
+        # Write the content as is if it's below the threshold
+        printf "%s\n" "${lines[@]}" >> "$OUTPUT_FILE"
+    fi
+}
+
+# Read the Markdown file line by line
+echo "${input}" | while IFS= read -r line || [[ -n $line ]]; do
+    # Preserve comment blocks
+    if [[ $line =~ ^\<!-- ]] || [[ $line =~ ^--\> ]]; then
+        # Finalize the current section if inside one
+        if [[ $inside_section == true ]]; then
+            write_section "$section_header" "${section_lines[@]:1}" # Exclude the header
+            inside_section=false
+        fi
+        # Write the comment directly
+        echo "$line" >> "$OUTPUT_FILE"
+        continue
+    fi
+
+    if [[ $line =~ ^#+\  ]]; then # New section starts
+        if [[ $inside_section == true ]]; then
+            # Write the previous section
+            write_section "$section_header" "${section_lines[@]:1}" # Exclude the header
+        fi
+        # Start a new section
+        section_header="$line"
+        section_lines=("$line") # Initialize section with the header
+        inside_section=true
+    else
+        # Collect lines of the current section
+        section_lines+=("$line")
+    fi
+done
+
+# Process the last section
+if [[ $inside_section == true ]]; then
+    write_section "$section_header" "${section_lines[@]:1}" # Exclude the header
+fi
+
+if [[ ! -z $FULL_CHANGELOG ]]; then
+    echo "Appending Full Changelog to the end of the file."
+    printf "\n%s" "$FULL_CHANGELOG" >> "$OUTPUT_FILE"
+fi
+
+echo "Collapsible Markdown written to $OUTPUT_FILE"
+

--- a/hack/collapse/test_auto_collapse.sh
+++ b/hack/collapse/test_auto_collapse.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+# Paths to files
+export INPUT_FILE="$SCRIPT_DIR/test_example.md"
+export OUTPUT_FILE="$SCRIPT_DIR/test_example_collapsible.md"
+export EXPECTED_FILE="$SCRIPT_DIR/test_example_expected_collapsible.md"
+export SCRIPT="$SCRIPT_DIR/auto_collapse.sh"
+
+# Run the script
+bash "$SCRIPT" "$INPUT_FILE" "$OUTPUT_FILE" 5
+
+if [ ! -f "$OUTPUT_FILE" ]; then
+    echo "Test failed: Output file not found."
+    exit 1
+fi
+
+# Compare output with expected file
+if diff -q "$OUTPUT_FILE" "$EXPECTED_FILE" > /dev/null; then
+    echo "Test passed: Output matches expected result."
+else
+    echo "Test failed: Output does not match expected result."
+    echo "Differences:"
+    diff "$OUTPUT_FILE" "$EXPECTED_FILE"
+fi

--- a/hack/collapse/test_example.md
+++ b/hack/collapse/test_example.md
@@ -1,0 +1,19 @@
+<!-- Release notes generated using configuration in .github/config/release.yml at refs/heads/releases/v0.19 -->
+<!-- markdown-link-check-disable -->
+## What's Changed
+### 🚀 Features
+* feat(log): log http requests for OCI and docker based on trace level by injecting a logger by @author in https://github.com/open-component-model/ocm/pull/1118
+### 🧰 Maintenance
+* chore: change guide for 0.18.0 by @author in https://github.com/open-component-model/ocm/pull/1066
+* chore: allow publishing to Brew via custom script by @author in https://github.com/open-component-model/ocm/pull/1059
+* chore: remove ocm inception during build CTF aggregation by @author in https://github.com/open-component-model/ocm/pull/1065
+* chore: release branches as `releases/vX.Y` instead of `releases/vX.Y.Z` by @author in https://github.com/open-component-model/ocm/pull/1071
+* chore: cleanup release action by @author in https://github.com/open-component-model/ocm/pull/1076
+* chore: bump version to 0.19.0-dev by @author in https://github.com/open-component-model/ocm/pull/1084
+* chore: disable mandatory period comments by @author in https://github.com/open-component-model/ocm/pull/1079
+### Some other
+* chore: change guide for 0.18.0 by @author in
+* chore: allow publishing to Brew via custom script by @author in
+
+**Full Changelog**: https://github.com/open-component-model/ocm/compare/v0.18...v0.19.0
+<!-- markdown-link-check-enable -->

--- a/hack/collapse/test_example_expected_collapsible.md
+++ b/hack/collapse/test_example_expected_collapsible.md
@@ -1,0 +1,26 @@
+<!-- Release notes generated using configuration in .github/config/release.yml at refs/heads/releases/v0.19 -->
+<!-- markdown-link-check-disable -->
+## What's Changed
+
+### 🚀 Features
+* feat(log): log http requests for OCI and docker based on trace level by injecting a logger by @author in https://github.com/open-component-model/ocm/pull/1118
+### 🧰 Maintenance
+<details>
+<summary>7 changes</summary>
+
+* chore: change guide for 0.18.0 by @author in https://github.com/open-component-model/ocm/pull/1066
+* chore: allow publishing to Brew via custom script by @author in https://github.com/open-component-model/ocm/pull/1059
+* chore: remove ocm inception during build CTF aggregation by @author in https://github.com/open-component-model/ocm/pull/1065
+* chore: release branches as `releases/vX.Y` instead of `releases/vX.Y.Z` by @author in https://github.com/open-component-model/ocm/pull/1071
+* chore: cleanup release action by @author in https://github.com/open-component-model/ocm/pull/1076
+* chore: bump version to 0.19.0-dev by @author in https://github.com/open-component-model/ocm/pull/1084
+* chore: disable mandatory period comments by @author in https://github.com/open-component-model/ocm/pull/1079
+</details>
+
+### Some other
+* chore: change guide for 0.18.0 by @author in
+* chore: allow publishing to Brew via custom script by @author in
+
+<!-- markdown-link-check-enable -->
+
+**Full Changelog**: https://github.com/open-component-model/ocm/compare/v0.18...v0.19.0


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Adds a small script that autocollapses our release notes again because we no longer use release drafter

Backported to allow the release notes to be drafted correctly.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->
