### PR TITLE
chore: fixup release notes

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -82,13 +82,13 @@ jobs:
                -q .body \
              )
           
-          if [[ -z $notes ]]; then
+          if [[ -z "${notes}" ]]; then
             echo "No release notes generated from API, failed"
             exit 1
           fi
           
           echo "Auto-Collapsing release notes to reduce size"
-          echo $notes > $RUNNER_TEMP/release_notes.md
+          echo "${notes}" > $RUNNER_TEMP/release_notes.md
           bash hack/collapse/auto_collapse.sh $RUNNER_TEMP/release_notes.md $RUNNER_TEMP/release_notes_processed.md ${{ env.COLLAPSE_THRESHOLD }}
           notes=$(cat $RUNNER_TEMP/release_notes_processed.md)
           


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

the release notes that were fixed up require a small adjustment to be able to deal with properly multilined files.

This is because the notes are stored in bash variables which removes newlines by default. Now they are properly formatted in again and we also fixup the script so that the line count is correct

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Makes sure that multilined release notes are interpreted correctly and dont break out. This happened with release/v0.19 so that commit was patched up by force push to test out the notes
