### PR TITLE
chore(backport): fixup release notes (#1148)

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -82,25 +82,25 @@ jobs:
                -q .body \
              )
           
-          if [[ -z $notes ]]; then
+          if [[ -z "${notes}" ]]; then
             echo "No release notes generated from API, failed"
             exit 1
           fi
           
           echo "Auto-Collapsing release notes to reduce size"
-          printf "%s\n" "$notes" > $RUNNER_TEMP/release_notes.md
+          echo "${notes}" > $RUNNER_TEMP/release_notes.md
           bash hack/collapse/auto_collapse.sh $RUNNER_TEMP/release_notes.md $RUNNER_TEMP/release_notes_processed.md ${{ env.COLLAPSE_THRESHOLD }}
           notes=$(cat $RUNNER_TEMP/release_notes_processed.md)
           
           echo "Release Notes generated for ${{env.RELEASE_VERSION}}:"
-          printf "%s\n" "$notes"
+          echo "${notes}"
           
           echo "Verifying if release ${{env.RELEASE_VERSION}} already exists"
           if [[ -z $(gh release list -R ${REPO} --json name -q '.[] | select(.name == "${{env.RELEASE_VERSION}}")') ]]; then
             echo "Release ${{env.RELEASE_VERSION}} does not exist yet, creating from scratch"
             gh release create ${{env.RELEASE_VERSION}} \
               --title "${{env.RELEASE_VERSION}}" \
-              --notes "$(printf "%s\n" "$notes")" \
+              --notes "${notes}" \
               --draft \
               --latest=false \
               --target ${{ github.ref }} \


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

the release notes that were fixed up require a small adjustment to be able to deal with properly multilined files.

This is because the notes are stored in bash variables which removes newlines by default. Now they are properly formatted in again and we also fixup the script so that the line count is correct

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Makes sure that multilined release notes are interpreted correctly and dont break out. This happened with release/v0.19 so that commit was patched up by force push to test out the notes

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
