### PR TITLE
chore: inherit from .github labels

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,8 @@
+# These settings are synced to GitHub by https://probot.github.io/apps/settings/
+
+# see: https://github.com/open-component-model/.github/blob/main/.github/settings.yml
+_extends: .github
+
+labels:
+- name: repo/ocm
+  color: bfd4f2


### PR DESCRIPTION
#### What this PR does / why we need it

1. merge https://github.com/open-component-model/ocm/pull/1115
2. execute [migrate-labels.sh](https://github.com/open-component-model/.github/blob/main/labels/migrate-labels.sh) on `ocm`
3. merge this PR