### PR TITLE
chore: prioritize deps over chore

### DIFF
--- a/.github/config/release.yml
+++ b/.github/config/release.yml
@@ -5,6 +5,9 @@ changelog:
     - 'kind/skip-release-notes'
     - 'dev/wont-fix'
     - 'dev/cant-reproduce'
+  # if an issue matches more than one category, the first one in the list will be used
+  # Example:
+  # Labels: kind/chore, kind/dependency => Category: Dependencies
   categories:
   - title: '‼️ Breaking Changes'
     labels:
@@ -15,10 +18,10 @@ changelog:
   - title: '🐛 Bug Fixes'
     labels:
     - 'kind/bugfix'
+  - title: '⬆️ Dependencies'
+    labels:
+      - 'kind/dependency'
   - title: '🧰 Maintenance'
     labels:
     - 'kind/chore'
     - 'kind/refactor'
-  - title: '⬆️ Dependencies'
-    labels:
-    - 'kind/dependency'


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

this makes it so that issues listing a dependency kind will be sorted into the correct category instead of maintenance even though they are listed as chore(deps)

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
