### PR TITLE
chore: add catch all category for release

### DIFF
--- a/.github/config/release.yml
+++ b/.github/config/release.yml
@@ -25,3 +25,6 @@ changelog:
     labels:
     - 'kind/chore'
     - 'kind/refactor'
+  - title: 'Other Changes'
+    labels:
+      - "*"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

this adds a catch all category if none of the labels mentioned in the config didnt apply.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
