### PR TITLE
chore: make sure that dockerfiles are setup in a standard way

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,11 @@ updates:
     labels:
       - kind/dependency
       - kind/chore
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+    labels:
+      - kind/dependency
+      - kind/chore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,4 @@
-ARG GO_VERSION="1.23"
-ARG ALPINE_VERSION="3.20"
-ARG DISTROLESS_VERSION=debian12:nonroot@sha256:d71f4b239be2d412017b798a0a401c44c3049a3ca454838473a4c32ed076bfea
-
-FROM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS build
+FROM golang:1.23-alpine3.20 AS build
 
 WORKDIR /src
 RUN go env -w GOMODCACHE=/root/.cache/go-build
@@ -21,21 +17,19 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     "-s -w -X ocm.software/ocm/api/version.gitVersion=$VERSION -X ocm.software/ocm/api/version.buildDate=$NOW" \
     -o /bin/ocm ./cmds/ocm/main.go
 
-FROM gcr.io/distroless/static-${DISTROLESS_VERSION}
-# pass arg from initial build
-ARG DISTROLESS_VERSION
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:d71f4b239be2d412017b798a0a401c44c3049a3ca454838473a4c32ed076bfea
 
 COPY --from=build /bin/ocm /usr/local/bin/ocm
 
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
-LABEL org.opencontainers.image.description="Open Component Model command line interface based on Distroless ${DISTROLESS_VERSION}"
+LABEL org.opencontainers.image.description="Open Component Model command line interface based on Distroless"
 LABEL org.opencontainers.image.vendor="SAP SE"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.url="https://ocm.software/"
 LABEL org.opencontainers.image.source="https://github.com/open-component-model/ocm"
 LABEL org.opencontainers.image.title="ocm"
 LABEL org.opencontainers.image.documentation="https://github.com/open-component-model/ocm/blob/main/docs/reference/ocm.md"
-LABEL org.opencontainers.image.base.name="gcr.io/distroless/static-${DISTROLESS_VERSION}"
+LABEL org.opencontainers.image.base.name="gcr.io/distroless/static-debian12:nonroot"
 
 ENTRYPOINT ["/usr/local/bin/ocm"]
 CMD ["version"]

--- a/components/ocmcli/Dockerfile
+++ b/components/ocmcli/Dockerfile
@@ -1,9 +1,6 @@
 # This Dockerfile is used by `make` via the Makefile
 
-ARG DISTROLESS_VERSION=debian12:nonroot@sha256:d71f4b239be2d412017b798a0a401c44c3049a3ca454838473a4c32ed076bfea
-FROM --platform=$BUILDPLATFORM gcr.io/distroless/static-${DISTROLESS_VERSION}
-# pass arg from initial build
-ARG DISTROLESS_VERSION
+FROM --platform=$BUILDPLATFORM gcr.io/distroless/static-debian12:nonroot@sha256:d71f4b239be2d412017b798a0a401c44c3049a3ca454838473a4c32ed076bfea
 
 ARG SUFFIX
 ARG OCM_VERSION
@@ -11,7 +8,7 @@ ARG OCM_VERSION
 COPY gen/ocmcli/ocmcli.$SUFFIX /usr/local/bin/ocm
 
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
-LABEL org.opencontainers.image.description="Open Component Model command line interface based on Distroless ${DISTROLESS_VERSION}"
+LABEL org.opencontainers.image.description="Open Component Model command line interface based on Distroless"
 LABEL org.opencontainers.image.vendor="SAP SE"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.url="https://ocm.software/"
@@ -20,7 +17,7 @@ LABEL org.opencontainers.image.title="ocm"
 LABEL org.opencontainers.image.version="${OCM_VERSION}"
 LABEL org.opencontainers.image.revision="${OCM_VERSION}"
 LABEL org.opencontainers.image.documentation="https://github.com/open-component-model/ocm/blob/main/docs/reference/ocm.md"
-LABEL org.opencontainers.image.base.name="gcr.io/distroless/static-${DISTROLESS_VERSION}"
+LABEL org.opencontainers.image.base.name="gcr.io/distroless/static-debian12:nonroot"
 
 ENTRYPOINT ["/usr/local/bin/ocm"]
 CMD ["version"]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

This simplifies the docker images update process because it runs through dependabot.yml

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
