### PR TITLE
fix: allow cache push through PAT

### DIFF
--- a/.github/workflows/components.yaml
+++ b/.github/workflows/components.yaml
@@ -33,7 +33,7 @@ env:
   components: '["ocmcli", "helminstaller", "helmdemo", "subchartsdemo", "ecrplugin"]'
   IMAGE_PLATFORMS: 'linux/amd64 linux/arm64'
   PLATFORMS: 'windows/amd64 darwin/arm64 darwin/amd64 linux/amd64 linux/arm64'
-  BUILDX_CACHE_PUSH: ${{ github.ref == 'refs/heads/main' }}
+  BUILDX_CACHE_PUSH: false
   BUILDX_CACHE_REF_BASE: ghcr.io/${{ github.repository }}/buildx-cache
 
 jobs:


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

temporarily disables the docker build cache because of token pass issues (while I locally didnt face any issues the docker login action doesnt seem to propagate correctly to the push)


#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
This is to unblock main builds from failing, further investigation necessary