### PR TITLE
fix: ocm transfer ignored --enforce when --overwrite is set

### DIFF
--- a/cmds/ocm/commands/ocmcmds/common/options/overwriteoption/option.go
+++ b/cmds/ocm/commands/ocmcmds/common/options/overwriteoption/option.go
@@ -50,10 +50,14 @@ versions are re-transported).
 
 func (o *Option) ApplyTransferOption(opts transferhandler.TransferOptions) error {
 	if (o.overwrite != nil && o.overwrite.Changed) || o.Overwrite {
-		return standard.Overwrite(o.Overwrite).ApplyTransferOption(opts)
+		if err := standard.Overwrite(o.Overwrite).ApplyTransferOption(opts); err != nil {
+			return err
+		}
 	}
 	if (o.enforce != nil && o.enforce.Changed) || o.EnforceTransport {
-		return standard.EnforceTransport(o.EnforceTransport).ApplyTransferOption(opts)
+		if err := standard.EnforceTransport(o.EnforceTransport).ApplyTransferOption(opts); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Fixes a bug in the `ocm transfer` command, that caused the `--enforce` option to be ignored if `--overwrite` was set. 

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
#1186