### PR TITLE
docs: adjust flags to options in cobra help and usage template

### DIFF
--- a/api/utils/cobrautils/template.go
+++ b/api/utils/cobrautils/template.go
@@ -12,10 +12,10 @@ Aliases:
 Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if and .HasAvailableLocalFlags .IsAvailableCommand}}
 
-Flags:
+Options:
 {{ flagUsages .LocalFlags | trimTrailingWhitespaces}}{{end}}{{if and .HasAvailableInheritedFlags .IsAvailableCommand}}
 
-Global Flags:
+Global Options:
 {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}
 
 Description:
@@ -44,10 +44,10 @@ Examples:
 Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
-Flags:
+Options:
 {{ flagUsages .LocalFlags | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
 
-Global Flags:
+Global Options:
 {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
 
 Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}

--- a/cmds/cliplugin/cmds/cmd_test.go
+++ b/cmds/cliplugin/cmds/cmd_test.go
@@ -86,7 +86,7 @@ ocm check rhubarb — Determine Whether We Are In Rhubarb Season
 Synopsis:
   ocm check rhubarb <options>
 
-Flags:
+Options:
   -d, --date string   the date to ask for (MM/DD)
   -h, --help          help for check
 
@@ -106,7 +106,7 @@ ocm check rhubarb — Determine Whether We Are In Rhubarb Season
 Synopsis:
   ocm check rhubarb <options>
 
-Flags:
+Options:
   -d, --date string   the date to ask for (MM/DD)
   -h, --help          help for check
 

--- a/cmds/subcmdplugin/cmds/cmd_test.go
+++ b/cmds/subcmdplugin/cmds/cmd_test.go
@@ -64,7 +64,7 @@ Synopsis:
 Available Commands:
   demo        a demo command
 
-Flags:
+Options:
   -h, --help   help for group
 
 Description:
@@ -83,7 +83,7 @@ ocm group demo — A Demo Command
 Synopsis:
   ocm group demo <options> [flags]
 
-Flags:
+Options:
   -h, --help             help for demo
       --version string   some overloaded option
 
@@ -107,7 +107,7 @@ Synopsis:
 Available Commands:
   demo        a demo command
 
-Flags:
+Options:
   -h, --help   help for group
 
 Description:
@@ -126,7 +126,7 @@ ocm group demo — A Demo Command
 Synopsis:
   ocm group demo <options> [flags]
 
-Flags:
+Options:
   -h, --help             help for demo
       --version string   some overloaded option
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Renames the `Flags` section in `--help` to `Options`. The `Synopsis` currently shows `ocm [<options>] ...`, with <options> referring to the command line options listed under `Flags`. This might confuse users (or at least concern if something does not work). 

**Before:**
```
> ocm get component --help
ocm get componentversions — Get Component Version

Synopsis:
  ocm get componentversions [<options>] {<component-reference>}

Aliases:
  componentversions, componentversion, cv, components, component, comps, comp, c

Flags:
  -c, --constraints constraints   version constraint
  -h, --help                      help for componentversions
      --latest                    restrict component versions to latest
      --lookup stringArray        repository name or spec for closure lookup fallback
  -o, --output string             output mode (JSON, json, tree, wide, yaml)
  -r, --recursive                 follow component reference nesting
      --repo string               repository name or spec
  -S, --scheme string             schema version
  -s, --sort stringArray          sort fields
```

**Now:**
```
> ocm get component --help
ocm get componentversions — Get Component Version

Synopsis:
  ocm get componentversions [<options>] {<component-reference>}

Aliases:
  componentversions, componentversion, cv, components, component, comps, comp, c

Options:
  -c, --constraints constraints   version constraint
  -h, --help                      help for componentversions
      --latest                    restrict component versions to latest
      --lookup stringArray        repository name or spec for closure lookup fallback
  -o, --output string             output mode (JSON, json, tree, wide, yaml)
  -r, --recursive                 follow component reference nesting
      --repo string               repository name or spec
  -S, --scheme string             schema version
  -s, --sort stringArray          sort fields
```



#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
#1189