### PR TITLE
fix: fix toi doc

### DIFF
--- a/cmds/ocm/topics/toi/bootstrapping/topic.go
+++ b/cmds/ocm/topics/toi/bootstrapping/topic.go
@@ -172,7 +172,7 @@ to executors. It uses the following fields:
   the executor will be used for all actions. The first matching executor entry
   will be used to execute an action by the bootstrap command
 
-- **<code>resourceRef</code>** *[]ResourceReference*
+- **<code>resourceRef</code>** *ResourceReference*
 
   An OCM resource reference describing a component version resource relative to
   the component version containing the package resource.

--- a/docs/reference/ocm_toi-bootstrapping.md
+++ b/docs/reference/ocm_toi-bootstrapping.md
@@ -113,7 +113,7 @@ to executors. It uses the following fields:
   the executor will be used for all actions. The first matching executor entry
   will be used to execute an action by the bootstrap command
 
-- **<code>resourceRef</code>** *[]ResourceReference*
+- **<code>resourceRef</code>** *ResourceReference*
 
   An OCM resource reference describing a component version resource relative to
   the component version containing the package resource.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

The command doc for ocm toi-bootstrapping shows the wrong type for the reference to a TOI executor.

#### Which issue(s) this PR fixes

Fixes [#339](https://github.com/open-component-model/ocm-project/issues/339)

