### PR TITLE
chore(github_action): add generate_token to push-to-website

### DIFF
--- a/.github/workflows/publish-to-other-than-github.yaml
+++ b/.github/workflows/publish-to-other-than-github.yaml
@@ -147,6 +147,12 @@ jobs:
     steps:
     - name: Ensure proper version
       run: echo "RELEASE_VERSION=$(echo ${{ github.event.client_payload.version }})" >> $GITHUB_ENV
+    - name: Generate token
+      id: generate_token
+      uses: tibdex/github-app-token@v2
+      with:
+        app_id: ${{ secrets.OCMBOT_APP_ID }}
+        private_key: ${{ secrets.OCMBOT_PRIV_KEY }}
     - name: Publish Release Event
       uses: peter-evans/repository-dispatch@v3
       with:


### PR DESCRIPTION
last publish release didn't work: https://github.com/open-component-model/ocm/actions/runs/12349057328/job/34459090022