### PR TITLE
fix: use copy uid gid when running toi applications

### DIFF
--- a/api/ocm/tools/toi/drivers/docker/driver.go
+++ b/api/ocm/tools/toi/drivers/docker/driver.go
@@ -264,6 +264,7 @@ func (d *Driver) Exec(op *install.Operation) (*install.OperationResult, error) {
 	}
 	options := container.CopyToContainerOptions{
 		AllowOverwriteDirWithFile: false,
+		CopyUIDGID:                true,
 	}
 	// This copies the tar to the root of the container. The tar has been assembled using the
 	// path from the given file, starting at the /.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

#### Which issue(s) this PR fixes
Fixes https://github.com/open-component-model/ocm-project/issues/359
