### PR TITLE
docs: Add responsibles label to ocmcli component descriptor

### DIFF
--- a/components/ocmcli/component-constructor.yaml
+++ b/components/ocmcli/component-constructor.yaml
@@ -41,6 +41,9 @@ components:
           repoUrl: github.com/open-component-model/ocm
           commit: (( values.COMMIT ))
         version: (( values.VERSION ))
-
-
-
+    labels:
+      - name: cloud.gardener.cnudie/responsibles
+        value:
+          - github_hostname: github.com
+            teamname: open-component-model/ocm-cli-team
+            type: githubTeam


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
The responsibles label is used to automatically assign detected compliance issues to the responsible GitHub team. If no such responsibles are configured, GitHub repository statistics will be heuristically examined to determine the respective responsibles, however, these statistics are not properly created for this repository.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
