### PR TITLE
chore: Copilot Secret Scanning, let's use always the same sample

### DIFF
--- a/api/credentials/extensions/repositories/memory/config/type.go
+++ b/api/credentials/extensions/repositories/memory/config/type.go
@@ -121,11 +121,11 @@ of arbitrary credentials stored in a memory based credentials repository:
         reference:  # refer to a credential set stored in some other credential repository
           type: Credentials # this is a repo providing just one explicit credential set
           properties:
-            username: mandelsoft
-            password: specialsecret
+            username: <my-user>
+            password: <my-secret-password>
       - credentialsName: direct
         credentials: # direct credential specification
-            username: mandelsoft2
-            password: specialsecret2
+            username: <my-user>
+            password: <my-secret-password>
 </pre>
 `

--- a/docs/reference/ocm_configfile.md
+++ b/docs/reference/ocm_configfile.md
@@ -198,12 +198,12 @@ The following configuration types are supported:
           reference:  # refer to a credential set stored in some other credential repository
             type: Credentials # this is a repo providing just one explicit credential set
             properties:
-              username: mandelsoft
-              password: specialsecret
+              username: <my-user>
+              password: <my-secret-password>
         - credentialsName: direct
           credentials: # direct credential specification
-              username: mandelsoft2
-              password: specialsecret2
+              username: <my-user>
+              password: <my-secret-password>
   </pre>
 - <code>merge.config.ocm.software</code>
   The config type <code>merge.config.ocm.software</code> can be used to set some


### PR DESCRIPTION
#### What this PR does / why we need it

Although the text: `specialsecret2` might not be used as real password, let's try to use always a more obvious placeholder: `<my-secret-password>`

#### Which issue(s) this PR fixes

fixes: https://github.com/open-component-model/ocm/security/secret-scanning/6