### PR TITLE
chore: Potential fix for code scanning alert no. 13: Clear-text logging of sensitive information

### DIFF
--- a/api/utils/logging/roundtripper.go
+++ b/api/utils/logging/roundtripper.go
@@ -20,11 +20,13 @@ type RoundTripper struct {
 }
 
 func (t *RoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Redact the Authorization header to make sure it doesn't get logged at any point.
-	header := req.Header
-	if key := "Authorization"; req.Header.Get(key) != "" {
-		header = header.Clone()
-		header.Set(key, "***")
+	// Redact sensitive headers to make sure they don't get logged at any point.
+	header := req.Header.Clone()
+	sensitiveHeaders := []string{"Authorization", "Cookie", "Set-Cookie", "Proxy-Authorization", "WWW-Authenticate"}
+	for _, key := range sensitiveHeaders {
+		if header.Get(key) != "" {
+			header.Set(key, "***")
+		}
 	}
 
 	t.logger.Trace("roundtrip",


### PR DESCRIPTION
Potential fix for [https://github.com/open-component-model/ocm/security/code-scanning/13](https://github.com/open-component-model/ocm/security/code-scanning/13)

To fix the problem, we need to ensure that all potentially sensitive headers are redacted before logging. This can be done by creating a list of sensitive headers and redacting their values in the `header` variable before logging it. This approach ensures that no sensitive information is logged in clear text.

1. Identify and create a list of sensitive headers.
2. Iterate over the headers and redact the values of any headers that are in the sensitive list.
3. Log the sanitized headers.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
