### PR TITLE
chore: Potential fix for code scanning alert no. 11: Clear-text logging of sensitive information

### DIFF
--- a/api/credentials/internal/consumers.go
+++ b/api/credentials/internal/consumers.go
@@ -244,8 +244,8 @@ func (p *consumerProviderRegistry) catchedMatch(ectx EvaluationContext, sub Cons
 		cs = nil
 		ci = cur
 	}, exception.ByPrototypes(&UnwindStack{}))
-	log.Trace("pattern: {{pattern}}\ncontext: {{context}}\nprovider: {{provider}}",
-		"pattern", pattern, "context", ectx, "provider", sub)
+	log.Trace("pattern: {{pattern}}\ncontext: {{context}}",
+		"pattern", pattern, "context", ectx)
 	ectx, useprov, _ := p.checkHandleProvider(ectx, sub, pattern)
 	if !useprov {
 		return nil, cur


### PR DESCRIPTION
Potential fix for [https://github.com/open-component-model/ocm/security/code-scanning/11](https://github.com/open-component-model/ocm/security/code-scanning/11)

To fix the problem, we should avoid logging sensitive information directly. Instead, we can log non-sensitive metadata or obfuscate the sensitive parts. In this case, we can remove the logging of the `sub` variable or replace it with a less sensitive representation.

- Remove or obfuscate the logging of the `sub` variable in the `catchedMatch` function.
- Ensure that no sensitive information is logged in clear text.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
