### PR TITLE
chore: raise alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.23-alpine3.20 AS build
+FROM --platform=$BUILDPLATFORM golang:1.23-alpine3.21 AS build
 
 RUN apk add --no-cache make git
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
raise Alpine version für OCM CLI Image