### PR TITLE
chore: remove .bridge folder from scans

### DIFF
--- a/.github/workflows/blackduck_scan_scheduled.yaml
+++ b/.github/workflows/blackduck_scan_scheduled.yaml
@@ -48,9 +48,11 @@ jobs:
           DETECT_PROJECT_USER_GROUPS: opencomponentmodel
           DETECT_PROJECT_VERSION_DISTRIBUTION: SAAS
           DETECT_SOURCE_PATH: ./
+          DETECT.EXCLUDED.DIRECTORIES: .bridge
           NODE_TLS_REJECT_UNAUTHORIZED: true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           blackducksca_url: ${{ secrets.BLACKDUCK_URL }}
           blackducksca_token: ${{ secrets.BLACKDUCK_API_TOKEN }}
           blackducksca_scan_full: true
+          blackduck.scan.excluded.directories: .bridge


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
remove .bridge folder from scanning to avoid false positives