### PR TITLE
chore: correct gosec annotations

### DIFF
--- a/.github/workflows/check_diff_action.yaml
+++ b/.github/workflows/check_diff_action.yaml
@@ -4,6 +4,9 @@ on:
   pull_request: {}
   workflow_call:
 
+permissions:
+  contents: read
+  
 jobs:
   diff-check-manifests:
     name: Check for diff

--- a/api/oci/extensions/repositories/ocireg/repository.go
+++ b/api/oci/extensions/repositories/ocireg/repository.go
@@ -142,7 +142,7 @@ func (r *RepositoryImpl) getResolver(comp string) (oras.Resolver, error) {
 	client.Transport = ocmlog.NewRoundTripper(retry.DefaultClient.Transport, logger)
 	if r.info.Scheme == "https" {
 		// set up TLS
-		//nolint:gosec // used like the default, there are OCI servers (quay.io) not working with min version.
+		// #nosec G402 -- used like the default, there are OCI servers (quay.io) not working with min version.
 		conf := &tls.Config{
 			// MinVersion: tls.VersionTLS13,
 			RootCAs: func() *x509.CertPool {

--- a/api/ocm/extensions/blobhandler/handlers/generic/npm/publish.go
+++ b/api/ocm/extensions/blobhandler/handlers/generic/npm/publish.go
@@ -6,7 +6,8 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
-	//nolint:gosec // older npm (prior to v5) uses sha1
+
+	// #nosec G505 -- older npm (prior to v5) uses sha1
 	"crypto/sha1"
 	"crypto/sha512"
 	"encoding/base64"
@@ -62,7 +63,7 @@ func createSha512(data []byte) string {
 }
 
 func createSha1(data []byte) string {
-	hash := sha1.New() //nolint:gosec // older npm (prior to v5) uses sha1
+	hash := sha1.New() // #nosec G505 -- older npm (prior to v5) uses sha1
 	hash.Write(data)
 	return hex.EncodeToString(hash.Sum(nil))
 }

--- a/api/ocm/extensions/repositories/genericocireg/state.go
+++ b/api/ocm/extensions/repositories/genericocireg/state.go
@@ -123,12 +123,13 @@ func (s *StateAccess) readComponentDescriptorFromTar(r io.Reader) ([]byte, error
 		}
 
 		var data bytes.Buffer
-		//nolint:gosec // We don't know what size limit we could set, the tar
+		// We don't know what size limit we could set, the tar
 		// archive can be an image layer and that can even reach the gigabyte range.
 		// For now, we acknowledge the risk.
 		//
 		// We checked other software and tried to figure out how they manage this,
 		// but it's handled the same way.
+		// #nosec G110
 		if _, err := io.Copy(&data, tr); err != nil {
 			return nil, fmt.Errorf("error while reading component descriptor file from tar: %w", err)
 		}

--- a/api/utils/tarutils/extract.go
+++ b/api/utils/tarutils/extract.go
@@ -118,12 +118,13 @@ func ExtractTarToFsWithInfo(fs vfs.FileSystem, in io.Reader) (fcnt int64, bcnt i
 				return fcnt, bcnt, fmt.Errorf("unable to open file %s: %w", header.Name, err)
 			}
 			bcnt += header.Size
-			//nolint:gosec // We don't know what size limit we could set, the tar
+			// We don't know what size limit we could set, the tar
 			// archive can be an image layer and that can even reach the gigabyte range.
 			// For now, we acknowledge the risk.
 			//
 			// We checked other software and tried to figure out how they manage this,
 			// but it's handled the same way.
+			// # nosec G110
 			if _, err := io.Copy(file, tr); err != nil {
 				return fcnt, bcnt, fmt.Errorf("unable to copy tar file to filesystem: %w", err)
 			}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
correct gosec annoations 