### PR TITLE
chore: bump flake.lock to nixpkgs-unstable and clean up flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729665710,
-        "narHash": "sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4=",
+        "lastModified": 1742069588,
+        "narHash": "sha256-C7jVfohcGzdZRF6DO+ybyG/sqpo1h6bZi9T56sxLy+k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
+        "rev": "c80f6a7e10b39afcc1894e02ef785b1ad0b0d7e5",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,15 +16,9 @@
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
 
       # Nixpkgs instantiated for supported system types.
-      nixpkgsFor = forAllSystems (system: import (builtins.fetchGit {
-        # https://lazamar.co.uk/nix-versions/?package=go&channel=nixpkgs-unstable
-        # https://lazamar.co.uk/nix-versions/?package=go&version=1.24rc2&fullName=go-1.24rc2&keyName=go_1_24&revision=21808d22b1cda1898b71cf1a1beb524a97add2c4&channel=nixpkgs-unstable
-        name = "1.24.0";
-        url = "https://github.com/NixOS/nixpkgs.git";
-        ref = "refs/heads/nixos-unstable";
-        # take latest commit sha from https://github.com/NixOS/nixpkgs/commits/nixos-unstable/
-        rev = "73cf49b8ad837ade2de76f87eb53fc85ed5d4680";
-      }) { inherit system; });
+      nixpkgsFor = forAllSystems (system: import nixpkgs {
+        inherit system;
+      });
 
     in
     {
@@ -54,7 +48,9 @@
             # "-X ocm.software/ocm/api/version.buildDate=1970-01-01T0:00:00+0000"
             ];
 
-            CGO_ENABLED = 0;
+            env = {
+              CGO_ENABLED = "0";
+            };
 
             subPackages = [
               "cmds/ocm"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
bump flake.lock to nixpkgs-unstable

clean up flake.nix
- remove the gitfetch nixpkgs workaround
- fix the evaluation warning: "buildGoModule: specify CGO_ENABLED with env.CGO_ENABLED instead"
