### PR TITLE
chore: remove wrong source path from blackduck-rapid-scan

### DIFF
--- a/test-blackduck-rapid-scan.md
+++ b/test-blackduck-rapid-scan.md
@@ -1,3 +1,0 @@
-# Test Blackduck SCA Rapid Scan action
-
-Just some test content to create PRs


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Blackduck SCA seems to have a correct default for the detect agent that is already the GH repo roots folder. Setting it to ./ looks like this targets the detect working directory != Go project source path. So the parameter needs to be removed. 