### PR TITLE
fix: make sure that other resolve requests such as 400 are also returned as unknown errors so that OCM recognizes them

### DIFF
--- a/api/oci/extensions/repositories/ocireg/namespace.go
+++ b/api/oci/extensions/repositories/ocireg/namespace.go
@@ -147,7 +147,8 @@ func (n *NamespaceContainer) GetArtifact(i support.NamespaceAccessImpl, vers str
 		if errdefs.IsNotFound(err) {
 			return nil, errors.ErrNotFound(cpi.KIND_OCIARTIFACT, ref, n.impl.GetNamespace())
 		}
-		return nil, err
+
+		return nil, errors.ErrUnknown(cpi.KIND_OCIARTIFACT, err.Error())
 	}
 	blobData, err := n.blobs.Get(desc.MediaType)
 	if err != nil {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Makes sure resolution of artifacts resolves as Unknown Error for OCM if its something like a 400

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
fix https://github.com/open-component-model/ocm/issues/1362