### PR TITLE
fix: inherit secret for Trigger BDBA Scan

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -2,14 +2,11 @@ name: lint-and-test
 
 on:
   pull_request:
-    paths-ignore:
-      - ".github/workflows/**"
+    
   workflow_call:
   push:
     branches:
       - main
-    paths-ignore:
-      - ".github/workflows/**"
 
 permissions:
   contents: read

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -3,13 +3,13 @@ name: lint-and-test
 on:
   pull_request:
     paths-ignore:
-      - ".github/**"
+      - ".github/workflows/**"
   workflow_call:
   push:
     branches:
       - main
     paths-ignore:
-      - ".github/**"
+      - ".github/workflows/**"
 
 permissions:
   contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -275,9 +275,7 @@ jobs:
     with:
       artifact_id: ctf-aggregated
     secrets:
-      BDBA_API_TOKEN: ${{ secrets.BDBA_API_TOKEN }}
-      BDBA_URL: ${{ secrets.BDBA_URL }}
-      BDBA_GROUP_ID: ${{ secrets.BDBA_GROUP_ID }}
+      secrets: inherit
     permissions:
       contents: read 
       actions: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -274,8 +274,7 @@ jobs:
     uses: open-component-model/.github/.github/workflows/bdba.yaml@main
     with:
       artifact_id: ctf-aggregated
-    secrets:
-      secrets: inherit
+    secrets: inherit
     permissions:
       contents: read 
       actions: read


### PR DESCRIPTION
Fix for release workflow.

https://github.com/open-component-model/ocm/actions/runs/14058967852

```console
[Invalid workflow file: .github/workflows/release.yaml#L274](https://github.com/open-component-model/ocm/actions/runs/14058967852/workflow)
The workflow is not valid. .github/workflows/release.yaml (Line: 274, Col: 11): Secret BDBA_USERNAME is required, but not provided while calling. .github/workflows/release.yaml (Line: 274, Col: 11): Secret BDBA_PASSWORD is required, but not provided while calling.
```