### PR TITLE
Correct exclude path for workflow

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -3,13 +3,13 @@ name: lint-and-test
 on:
   pull_request:
     paths-ignore:
-      - ".github/**"
+      - ".github/workflows/**"
   workflow_call:
   push:
     branches:
       - main
     paths-ignore:
-      - ".github/**"
+      - ".github/workflows/**"
 
 permissions:
   contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -275,9 +275,7 @@ jobs:
     with:
       artifact_id: ctf-aggregated
     secrets:
-      BDBA_API_TOKEN: ${{ secrets.BDBA_API_TOKEN }}
-      BDBA_URL: ${{ secrets.BDBA_URL }}
-      BDBA_GROUP_ID: ${{ secrets.BDBA_GROUP_ID }}
+      secrets: inherit
     permissions:
       contents: read 
       actions: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -274,8 +274,7 @@ jobs:
     uses: open-component-model/.github/.github/workflows/bdba.yaml@main
     with:
       artifact_id: ctf-aggregated
-    secrets:
-      secrets: inherit
+    secrets: inherit
     permissions:
       contents: read 
       actions: read

--- a/api/oci/extensions/repositories/ocireg/namespace.go
+++ b/api/oci/extensions/repositories/ocireg/namespace.go
@@ -147,7 +147,8 @@ func (n *NamespaceContainer) GetArtifact(i support.NamespaceAccessImpl, vers str
 		if errdefs.IsNotFound(err) {
 			return nil, errors.ErrNotFound(cpi.KIND_OCIARTIFACT, ref, n.impl.GetNamespace())
 		}
-		return nil, err
+
+		return nil, errors.ErrUnknown(cpi.KIND_OCIARTIFACT, err.Error())
 	}
 	blobData, err := n.blobs.Get(desc.MediaType)
 	if err != nil {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
Fixed ignore paths, so that it catches changes in the workflows.