### PR TITLE
chore: update paths-ignore in lint_and_test workflow to be more specific

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -3,13 +3,13 @@ name: lint-and-test
 on:
   pull_request:
     paths-ignore:
-      - ".github/**"
+      - ".github/workflows/**"
   workflow_call:
   push:
     branches:
       - main
     paths-ignore:
-      - ".github/**"
+      - ".github/workflows/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>
Signed-off-by: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
to exclude changes to workflow files the ignore-paths needed to be fixed. 