### PR TITLE
chore: remove paths-ignore from lint_and_test workflow for pull requests and pushes

### DIFF
--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -2,14 +2,10 @@ name: lint-and-test
 
 on:
   pull_request:
-    paths-ignore:
-      - ".github/workflows/**"
   workflow_call:
   push:
     branches:
       - main
-    paths-ignore:
-      - ".github/workflows/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>
Signed-off-by: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
remove ignore-paths due to conflict with required check