### PR TITLE
fix: retract v0.22.0 in releases/v0.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -520,6 +520,8 @@ replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.16
 
 retract [v0.16.0, v0.16.9] // Retract all from v0.16 due to https://github.com/open-component-model/ocm-project/issues/293
 
+retract v0.22.0  // Retract because of accidentially released version, reported by https://github.com/open-component-model/ocm-project/issues/1399
+
 // crypto/tls: Client Hello is always sent in 2 TCP frames if GODEBUG=tlskyber=1 (default) which causes
 // issues with various enterprise network gateways such as Palo Alto Networks. We have been reported issues
 // such as https://github.com/open-component-model/ocm/issues/1027 and do not want to pin our crypto/tls version.


### PR DESCRIPTION
#### What this PR does / why we need it

Backport the fix of #1399

On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>

<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
retract v0.22.0 due to accidental release

