### PR TITLE
chore: pin `mdref` to v0.5.1

### DIFF
--- a/hack/Makefile
+++ b/hack/Makefile
@@ -76,8 +76,7 @@ endif
 
 .PHONY: mdref
 mdref:
-	# https://github.com/mandelsoft/mdref/issues/1 as workaround set GONOSUMDB
-	GONOSUMDB='github.com/mandelsoft/mdref' go install -v github.com/mandelsoft/mdref@v0.5.0
+	go install -v github.com/mandelsoft/mdref@v0.5.1
 
 Linux_jq:
 	$(info -> jq is missing)


### PR DESCRIPTION
@mandelsoft created a new tag: https://github.com/mandelsoft/mdref/releases/tag/v0.5.1 which doesn't result in sha-sum mismatches.

#### What this PR does / why we need it

We should not use the ugly workaround with the `GONOSUMDB` setting.

#### Which issue(s) this PR fixes

fixes: https://github.com/mandelsoft/mdref/issues/1