### PR TITLE
chore: run `nix flake update`

### DIFF
--- a/.github/workflows/flake_vendorhash.yaml
+++ b/.github/workflows/flake_vendorhash.yaml
@@ -29,6 +29,8 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@v17
         with:
           nix-package-url: https://releases.nixos.org/nix/nix-2.26.2/nix-2.26.2-x86_64-linux.tar.xz
+      - name: Update flake.lock
+        run: nix flake update
       - name: Update ocm vendor hash
         run: nix run .#nixpkgs.nix-update -- --flake --version=skip ocm
       - name: Check diff and create action summary


### PR DESCRIPTION
From time to time, we should make sure to also update the flake we're using to create our own.

#### What this PR does / why we need it

When switching to the latest patch version of go, sometimes the action fails:
https://github.com/open-component-model/ocm/actions/runs/14731906561

So we need to ensure, the file: https://github.com/open-component-model/ocm/blob/main/flake.lock get's updated as well. Which is done by: `nix flake update`