### PR TITLE
fix(revert): make sure that ref is an option in the gitHub AccessMethod (#1406)

### DIFF
--- a/api/ocm/elements/artifactaccess/githubaccess/resource.go
+++ b/api/ocm/elements/artifactaccess/githubaccess/resource.go
@@ -19,7 +19,7 @@ func Access[M any, P compdesc.ArtifactMetaPointer[M]](ctx ocm.Context, meta P, r
 		meta.SetType(TYPE)
 	}
 
-	spec := access.New(repo, eff.APIHostName, access.WithCommit(commit))
+	spec := access.New(repo, eff.APIHostName, commit)
 	// is global access, must work, otherwise there is an error in the lib.
 	return genericaccess.MustAccess(ctx, meta, spec)
 }

--- a/api/ocm/extensions/accessmethods/github/README.md
+++ b/api/ocm/extensions/accessmethods/github/README.md
@@ -30,11 +30,11 @@ The type specific specification fields are:
 
 - **`ref`** (optional) *string*
 
-  Original ref used to get the commit from. mutually exclusive with `commit`.
+  Original ref used to get the commit from
 
-- **`commit`** (optional) *string*
+- **`commit`** *string*
 
-  The sha/id of the git commit. mutually exclusive with `ref`.
+  The sha/id of the git commit
 
 ### Go Bindings
 

--- a/api/ocm/extensions/accessmethods/github/cli.go
+++ b/api/ocm/extensions/accessmethods/github/cli.go
@@ -11,14 +11,12 @@ func ConfigHandler() flagsets.ConfigOptionTypeSetHandler {
 		options.RepositoryOption,
 		options.HostnameOption,
 		options.CommitOption,
-		options.ReferenceOption,
 	)
 }
 
 func AddConfig(opts flagsets.ConfigOptions, config flagsets.Config) error {
 	flagsets.AddFieldByOptionP(opts, options.RepositoryOption, config, "repoUrl")
 	flagsets.AddFieldByOptionP(opts, options.CommitOption, config, "commit")
-	flagsets.AddFieldByOptionP(opts, options.ReferenceOption, config, "ref")
 	flagsets.AddFieldByOptionP(opts, options.HostnameOption, config, "apiHostname")
 	return nil
 }
@@ -37,9 +35,9 @@ The type specific specification fields are:
 
 - **<code>ref</code>** (optional) *string*
 
-  Original ref used to get the commit from. Mutually exclusive with <code>ref</code>.
+  Original ref used to get the commit from
 
 - **<code>commit</code>** *string*
 
-  The sha/id of the git commit. Mutually exclusive with <code>commit</code>.
+  The sha/id of the git commit
 `

--- a/docs/reference/ocm_add_resource-configuration.md
+++ b/docs/reference/ocm_add_resource-configuration.md
@@ -670,13 +670,13 @@ shown below.
 
     - **<code>ref</code>** (optional) *string*
 
-      Original ref used to get the commit from. Mutually exclusive with <code>ref</code>.
+      Original ref used to get the commit from
 
     - **<code>commit</code>** *string*
 
-      The sha/id of the git commit. Mutually exclusive with <code>commit</code>.
+      The sha/id of the git commit
 
-  Options used to configure fields: <code>--accessHostname</code>, <code>--accessRepository</code>, <code>--commit</code>, <code>--reference</code>
+  Options used to configure fields: <code>--accessHostname</code>, <code>--accessRepository</code>, <code>--commit</code>
 
 - Access type <code>helm</code>
 

--- a/docs/reference/ocm_add_resources.md
+++ b/docs/reference/ocm_add_resources.md
@@ -682,13 +682,13 @@ shown below.
 
     - **<code>ref</code>** (optional) *string*
 
-      Original ref used to get the commit from. Mutually exclusive with <code>ref</code>.
+      Original ref used to get the commit from
 
     - **<code>commit</code>** *string*
 
-      The sha/id of the git commit. Mutually exclusive with <code>commit</code>.
+      The sha/id of the git commit
 
-  Options used to configure fields: <code>--accessHostname</code>, <code>--accessRepository</code>, <code>--commit</code>, <code>--reference</code>
+  Options used to configure fields: <code>--accessHostname</code>, <code>--accessRepository</code>, <code>--commit</code>
 
 - Access type <code>helm</code>
 

--- a/docs/reference/ocm_add_source-configuration.md
+++ b/docs/reference/ocm_add_source-configuration.md
@@ -670,13 +670,13 @@ shown below.
 
     - **<code>ref</code>** (optional) *string*
 
-      Original ref used to get the commit from. Mutually exclusive with <code>ref</code>.
+      Original ref used to get the commit from
 
     - **<code>commit</code>** *string*
 
-      The sha/id of the git commit. Mutually exclusive with <code>commit</code>.
+      The sha/id of the git commit
 
-  Options used to configure fields: <code>--accessHostname</code>, <code>--accessRepository</code>, <code>--commit</code>, <code>--reference</code>
+  Options used to configure fields: <code>--accessHostname</code>, <code>--accessRepository</code>, <code>--commit</code>
 
 - Access type <code>helm</code>
 

--- a/docs/reference/ocm_add_sources.md
+++ b/docs/reference/ocm_add_sources.md
@@ -680,13 +680,13 @@ shown below.
 
     - **<code>ref</code>** (optional) *string*
 
-      Original ref used to get the commit from. Mutually exclusive with <code>ref</code>.
+      Original ref used to get the commit from
 
     - **<code>commit</code>** *string*
 
-      The sha/id of the git commit. Mutually exclusive with <code>commit</code>.
+      The sha/id of the git commit
 
-  Options used to configure fields: <code>--accessHostname</code>, <code>--accessRepository</code>, <code>--commit</code>, <code>--reference</code>
+  Options used to configure fields: <code>--accessHostname</code>, <code>--accessRepository</code>, <code>--commit</code>
 
 - Access type <code>helm</code>
 

--- a/docs/reference/ocm_ocm-accessmethods.md
+++ b/docs/reference/ocm_ocm-accessmethods.md
@@ -55,13 +55,13 @@ shown below.
 
     - **<code>ref</code>** (optional) *string*
 
-      Original ref used to get the commit from. Mutually exclusive with <code>ref</code>.
+      Original ref used to get the commit from
 
     - **<code>commit</code>** *string*
 
-      The sha/id of the git commit. Mutually exclusive with <code>commit</code>.
+      The sha/id of the git commit
 
-  Options used to configure fields: <code>--accessHostname</code>, <code>--accessRepository</code>, <code>--commit</code>, <code>--reference</code>
+  Options used to configure fields: <code>--accessHostname</code>, <code>--accessRepository</code>, <code>--commit</code>
 
 - Access type <code>helm</code>
 


### PR DESCRIPTION
This reverts commit 43632aa3.


<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

#### Which issue(s) this PR fixes

We have too many users reporting issues with the ref+commit combination as this was not spec compliant. We need to revert this change asap to stop breaking existing component version flows

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->