### PR TITLE
chore: use ternary operator to avoid "skipped" integration test job

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -2,10 +2,10 @@ name: Integration Tests
 
 on:
   push:
-      branches:
+    branches:
       - main
   pull_request_target:
-      branches:
+    branches:
       - main
   workflow_dispatch:
 
@@ -16,8 +16,7 @@ permissions:
 
 jobs:
   test:
-    if: github.event_name == 'push'
-    name: Run tests
+    name: Run
     uses: open-component-model/ocm-integrationtest/.github/workflows/integrationtest.yaml@main
     permissions:
       contents: write
@@ -25,17 +24,5 @@ jobs:
       packages: write
     secrets: inherit
     with:
-      ref: ${{ github.ref }}
-      repo: ${{ github.repository }}
-  test-pr:
-    if: github.event_name == 'pull_request_target'
-    name: Run tests
-    uses: open-component-model/ocm-integrationtest/.github/workflows/integrationtest.yaml@main
-    permissions:
-      contents: write
-      id-token: write
-      packages: write
-    secrets: inherit
-    with:
-      ref: ${{ github.event.pull_request.head.ref }}
-      repo: ${{ github.event.pull_request.head.repo.full_name }}
+      ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.ref || github.ref }}
+      repo: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.repository }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Adds a ternary expression as per
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example

so that we dont have a "skipped" integration test job in our job list that might cause confusion

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->