### PR TITLE
chore: fix correct filename for provenance file

### DIFF
--- a/api/ocm/extensions/download/handlers/helm/download_test.go
+++ b/api/ocm/extensions/download/handlers/helm/download_test.go
@@ -80,7 +80,6 @@ var _ = Describe("upload", func() {
 	})
 	It("register helm download handler by name for special artifact type", func() {
 		MustBeSuccessful(download.RegisterHandlerByName(env, helm.PATH, nil, download.ForArtifactType(ArtifactType)))
-
 		repo := Must(ctf.Open(env.OCMContext(), accessobj.ACC_READONLY, CTFPath, 0o777, env))
 		cv := Must(repo.LookupComponentVersion(Component, Version))
 		path := Must(download.DownloadResource(env.OCMContext(), Must(cv.SelectResources(selectors.Identity(v1.Identity{"name": SpecialOCIResource})))[0], "/resource", download.WithFileSystem(env.FileSystem())))
@@ -94,6 +93,7 @@ var _ = Describe("upload", func() {
 		cv := Must(repo.LookupComponentVersion(Component, Version))
 		path := Must(download.DownloadResource(env.OCMContext(), Must(cv.SelectResources(selectors.Identity(v1.Identity{"name": UnusualOCIResource})))[0], "/resource", download.WithFileSystem(env.FileSystem())))
 		MustBeSuccessful(tarutils.ExtractArchiveToFs(env.FileSystem(), path, env.FileSystem()))
+		Expect(Must(vfs.FileExists(env.FileSystem(), path+".prov"))).To(BeTrue())
 		Expect(Must(vfs.FileExists(env.FileSystem(), "/postgresql/Chart.yaml"))).To(BeTrue())
 	})
 
@@ -103,6 +103,7 @@ var _ = Describe("upload", func() {
 		cv := Must(repo.LookupComponentVersion(Component, Version))
 		path := Must(download.DownloadResource(env.OCMContext(), Must(cv.SelectResources(selectors.Identity(v1.Identity{"name": UnusualOCIResource})))[0], "/path.tgz", download.WithFileSystem(env.FileSystem())))
 		MustBeSuccessful(tarutils.ExtractArchiveToFs(env.FileSystem(), path, env.FileSystem()))
+		Expect(Must(vfs.FileExists(env.FileSystem(), path+".prov"))).To(BeTrue())
 		Expect(Must(vfs.FileExists(env.FileSystem(), "/postgresql/Chart.yaml"))).To(BeTrue())
 	})
 
@@ -112,6 +113,7 @@ var _ = Describe("upload", func() {
 		cv := Must(repo.LookupComponentVersion(Component, Version))
 		path := Must(download.DownloadResource(env.OCMContext(), Must(cv.SelectResources(selectors.Identity(v1.Identity{"name": UnusualOCIResource})))[0], "/path.tar.gz", download.WithFileSystem(env.FileSystem())))
 		MustBeSuccessful(tarutils.ExtractArchiveToFs(env.FileSystem(), path, env.FileSystem()))
+		Expect(Must(vfs.FileExists(env.FileSystem(), path+".prov"))).To(BeTrue())
 		Expect(Must(vfs.FileExists(env.FileSystem(), "/postgresql/Chart.yaml"))).To(BeTrue())
 	})
 

--- a/api/ocm/extensions/download/handlers/helm/handler.go
+++ b/api/ocm/extensions/download/handlers/helm/handler.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path/filepath"
 	"strings"
 
 	"github.com/mandelsoft/goutils/finalizer"
@@ -156,7 +155,10 @@ func download(p common.Printer, art oci.ArtifactAccess, path string, fs vfs.File
 			return "", "", err
 		}
 		finalize.Close(provBlob)
-		prov = trimExtN(chart, 2) + ".prov"
+
+		// Path to provenance file is the same as chart, but with .prov suffix. See
+		// https://github.com/helm/helm-www/blob/cf3e4f875101fa3f72ff6194499b5365723f0ec1/content/en/docs/topics/provenance.md
+		prov = chart + ".prov"
 		if err := write(p, provBlob, prov, fs); err != nil {
 			return "", "", err
 		}
@@ -165,19 +167,6 @@ func download(p common.Printer, art oci.ArtifactAccess, path string, fs vfs.File
 	}
 
 	return chart, prov, nil
-}
-
-// trimExtN trims the file extension from the path, at most n times.
-// This is useful for removing the ".tgz" or ".tar.gz" suffix from a file name.
-func trimExtN(path string, n int) string {
-	for i := 0; i < n; i++ {
-		trimmed := strings.TrimSuffix(path, filepath.Ext(path))
-		if trimmed == path {
-			break
-		}
-		path = trimmed
-	}
-	return path
 }
 
 func findLayer(layers []ocispec.Descriptor, mediaType string) (*ocispec.Descriptor, error) {

--- a/api/ocm/extensions/download/handlers/helm/handler_test.go
+++ b/api/ocm/extensions/download/handlers/helm/handler_test.go
@@ -22,24 +22,3 @@ func TestAssureArchiveSuffix(t *testing.T) {
 		}
 	}
 }
-
-func TestTrimExtN(t *testing.T) {
-	tests := []struct {
-		input    string
-		n        int
-		expected string
-	}{
-		{"chart.tgz", 1, "chart"},
-		{"chart.tar.gz", 1, "chart.tar"},
-		{"chart.tar.gz", 2, "chart"},
-		{"archive.zip", 1, "archive"},
-		{"archive", 1, "archive"},
-	}
-
-	for _, tt := range tests {
-		result := trimExtN(tt.input, tt.n)
-		if result != tt.expected {
-			t.Errorf("trimExtN(%q, %d) = %q; want %q", tt.input, tt.n, result, tt.expected)
-		}
-	}
-}


### PR DESCRIPTION
According to the helm [spec](https://github.com/helm/community/blob/05eab5bba990d4f5556f90bfc001662d1a76f9a5/hips/hip-0006.md#2-support-for-provenance-files)

> assuming the presence of a file suffixed with .prov sitting next to a chart .tgz in a repository.

This is why, we initially downloaded the provenance file into a file with only the `.prov` extension. However, according to the [helm documentation](https://github.com/helm/helm-www/blob/cf3e4f875101fa3f72ff6194499b5365723f0ec1/content/en/docs/topics/provenance.md)

> For example, if the base URL for a package is https://example.com/charts/mychart-1.2.3.tgz, the provenance file, if it exists, MUST be accessible at https://example.com/charts/mychart-1.2.3.tgz.prov.

Accordingly, we changed the filename for the provenance content to include the extensions of the original helm-chart