### PR TITLE
feat: add ref to github access spec

### DIFF
--- a/api/ocm/extensions/accessmethods/github/method.go
+++ b/api/ocm/extensions/accessmethods/github/method.go
@@ -64,6 +64,10 @@ type AccessSpec struct {
 	// Commit defines the hash of the commit
 	Commit string `json:"commit"`
 
+	// Reference defines the original ref used to get the commit from
+	// Mutually exclusive with Commit
+	Reference string `json:"ref,omitempty"`
+
 	client     *http.Client
 	downloader downloader.Downloader
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
The field part of this access type as per specification. Although, we won't leverage it for now in the implementation, we add it to the spec, so it can at least be read.
@zkdev 

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->