### PR TITLE
chore: update minimal build version to go 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/ocm
 
-go 1.24.3
+go 1.25.0
 
 require (
 	dario.cat/mergo v1.0.2

--- a/hack/brew/go.mod
+++ b/hack/brew/go.mod
@@ -1,3 +1,3 @@
 module ocm.software/ocm/hack/brew
 
-go 1.24.0
+go 1.25.0


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

this will bump our minimum required go version to go 1.25

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Will cause CI runs that default to go.mod version to go to 1.25