### PR TITLE
chore: update Nix installer package to version 2.31.0 in flake_vendorhash workflow

### DIFF
--- a/.github/workflows/flake_vendorhash.yaml
+++ b/.github/workflows/flake_vendorhash.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@90bb610b90bf290cad97484ba341453bd1cbefea # v19
         with:
-          nix-package-url: https://releases.nixos.org/nix/nix-2.26.2/nix-2.26.2-x86_64-linux.tar.xz
+          nix-package-url: https://releases.nixos.org/nix/nix-2.31.0/nix-2.31.0-x86_64-linux.tar.xz
       - name: Update flake.lock
         run: nix flake update
       - name: Update ocm vendor hash


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Bumps our nix installer package in an attempt to get a later go version for our flake bumps

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->