### PR TITLE
fix(ci): correct artifact download path in release workflow to ensure proper recognition

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,7 +139,7 @@ jobs:
     - name: Move CTF into correct directory to be recognized by the release process
       run: |
         mv \
-            ${{ github.workspace }}/gen/downloaded-ctfs/ctf-aggregated \
+            ${{ github.workspace }}/gen/downloaded-ctfs \
             ${{ github.workspace }}/gen/ctf
 
     # TODO: Remove Go setup once binaries no longer need to be built by goreleaser.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

https://github.com/actions/download-artifact/releases/tag/v5.0.0 has a breaking change that causes the path to now be without a subpath named after the artifact. that means we need to patch the artifact source path

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

After cherry pick this will fix our currently failing RC release