### PR TITLE
fix!: unwrap standard transfer handler and fix spiff handler (#1501)

### DIFF
--- a/api/ocm/tools/transfer/transferhandler/spiff/handler.go
+++ b/api/ocm/tools/transfer/transferhandler/spiff/handler.go
@@ -112,6 +112,9 @@ func (h *Handler) TransferResource(src ocm.ComponentVersionAccess, a ocm.AccessS
 	if !h.opts.IsResourcesByValue() {
 		return false, nil
 	}
+	if h.opts.IsAccessTypeOmitted(a.GetType()) {
+		return false, nil
+	}
 	if h.opts.GetScript() == nil {
 		return true, nil
 	}
@@ -121,6 +124,9 @@ func (h *Handler) TransferResource(src ocm.ComponentVersionAccess, a ocm.AccessS
 
 func (h *Handler) TransferSource(src ocm.ComponentVersionAccess, a ocm.AccessSpec, r ocm.SourceAccess) (bool, error) {
 	if !h.opts.IsSourcesByValue() {
+		return false, nil
+	}
+	if h.opts.IsAccessTypeOmitted(a.GetType()) {
 		return false, nil
 	}
 	if h.opts.GetScript() == nil {

--- a/cmds/ocm/commands/ocmcmds/components/transfer/cmd.go
+++ b/cmds/ocm/commands/ocmcmds/components/transfer/cmd.go
@@ -12,6 +12,7 @@ import (
 
 	clictx "ocm.software/ocm/api/cli"
 	"ocm.software/ocm/api/ocm"
+	"ocm.software/ocm/api/ocm/compdesc"
 	"ocm.software/ocm/api/ocm/tools/transfer"
 	"ocm.software/ocm/api/ocm/tools/transfer/transferhandler"
 	"ocm.software/ocm/api/ocm/tools/transfer/transferhandler/spiff"
@@ -173,7 +174,12 @@ func (a *action) Add(e interface{}) error {
 	if !ok {
 		return fmt.Errorf("object of type %T is not a valid comphdlr.Object", e)
 	}
-	err := transfer.TransferVersion(a.printer, a.closure, o.ComponentVersion, a.target, a.handler)
+	sub, h, err := a.handler.TransferVersion(o.Repository, nil, compdesc.NewComponentReference("", o.ComponentVersion.GetName(), o.ComponentVersion.GetVersion(), nil), a.target)
+	if err != nil {
+		return errors.Wrapf(err, "cannot transfer component version %s/%s", o.ComponentVersion.GetName(), o.ComponentVersion.GetVersion())
+	}
+	err = transfer.TransferVersion(a.printer, a.closure, sub, a.target, h)
+	sub.Close()
 	a.errors.Add(err)
 	if err != nil {
 		a.printer.Printf("Error: %s\n", err)


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

- Make `ocm transfer {cv|ctf}` respect `--omit-access-types` (as originally intended).
- Unwrap the standard transfer handler so omit logic is applied consistently across handlers.
- Fix spiff handler so it no longer reinstates access types when omit is requested.

#### Which issue(s) this PR fixes
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Previously, users might have used the flag `--omit-access-types` with a transfer and would have changed behavior now (flag was ignored).

After this change, `--omit-access-types` takes effect for any transfer as originally intended.

**Users expecting resources to be transferred even though they were mentioned with their access type in `--omit-access-types` must likely drop `--omit-access-types` for that access type if they used it before and expected the resources to still be present.**

Fixes #1500

---------


(cherry picked from commit 479f138e090e0c65ae014fad8ca4f2bee8585d8f)