### PR TITLE
chore(deps): bump distroless/static-debian12 from `a9f88e0` to `e8a4044`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV BUILD_FLAGS="-trimpath"
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN make bin/ocm GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH}
 
-FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9f88e0d99c1ceedbce565fad7d3f96744d15e6919c19c7dafe84a6dd9a80c61
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:e8a4044e0b4ae4257efa45fc026c0bc30ad320d43bd4c1a7d5271bd241e386d0
 
 COPY --from=build /src/bin/ocm /usr/local/bin/ocm
 


### PR DESCRIPTION
Bumps distroless/static-debian12 from `a9f88e0` to `e8a4044`.

On-behalf-of: Gerald Morrison (SAP) <gerald.morrison@sap.com>


---
updated-dependencies:
- dependency-name: distroless/static-debian12 dependency-version: nonroot dependency-type: direct:production ...

<!-- markdownlint-disable MD041 -->
Supersedes #1619 as it contained non-signed commits.

#### Which issue(s) this PR is related to
<!--
Usage: `Related to #<issue number>`, or `Related to (paste link of issue)`.
-->