### PR TITLE
fix: remove usage of deprecated `DockerCli.Apply()`

### DIFF
--- a/api/ocm/tools/toi/drivers/docker/driver.go
+++ b/api/ocm/tools/toi/drivers/docker/driver.go
@@ -206,7 +206,8 @@ func (d *Driver) initializeDockerCli() (command.Cli, error) {
 	}
 
 	if d.config[OptionQuiet] == "1" {
-		err = cli.Apply(command.WithCombinedStreams(io.Discard))
+		op := command.WithCombinedStreams(io.Discard)
+		err = op(cli)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

The PR removes the usage of the deprecated `DockerCli.Apply`.

#### Which issue(s) this PR is related to

This PR is a prerequisite for #1634.