### PR TITLE
chore: update goreleaser version to 2.12.7 in publish-latest workflow (#1673)

### DIFF
--- a/.github/workflows/publish-latest.yaml
+++ b/.github/workflows/publish-latest.yaml
@@ -131,7 +131,7 @@ jobs:
       uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
       with:
         distribution: goreleaser
-        version: 2.2.0
+        version: 2.12.7
         args: release --clean --timeout 60m --snapshot --skip=validate --config=.github/config/latest.yml
       env:
         GITHUBORG: ${{ github.repository_owner }}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

fixup goreleaser to 2.12.7 in attempt to resolve release flakes

#### Which issue(s) this PR is related to
<!--
Usage: `Related to #<issue number>`, or `Related to (paste link of issue)`.
-->

(cherry picked from commit 77c45bfb8e4a92a61dd71abde96c47b97e3a2b55)