### PR TITLE
chore: [releases/0.35] cherry-pick: https://github.com/open-component-model/ocm/pull/1738

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -570,11 +570,14 @@ replace github.com/ThalesIgnite/crypto11 => github.com/ThalesGroup/crypto11 v1.6
 // see https://github.com/darccio/mergo?tab=readme-ov-file#100
 replace github.com/imdario/mergo => github.com/imdario/mergo v1.0.2
 
+// See https://github.com/open-component-model/ocm-project/issues/797
+replace github.com/klauspost/compress => github.com/klauspost/compress v1.18.0
+
 retract [v0.16.0, v0.16.9] // Retract all from v0.16 due to https://github.com/open-component-model/ocm-project/issues/293
 
 retract v0.22.0 // Retract because of accidentially released version, reported by https://github.com/open-component-model/ocm-project/issues/1399
 
-retract v0.34.0 // Retract because release includes majof bump of go.yaml.in/yaml/v4 which introduces breaking changes, reported by https://github.com/open-component-model/ocm-project/issues/771
+retract v0.34.0 // Retract because release includes major bump of go.yaml.in/yaml/v4 which introduces breaking changes, reported by https://github.com/open-component-model/ocm-project/issues/771
 
 // crypto/tls: Client Hello is always sent in 2 TCP frames if GODEBUG=tlskyber=1 (default) which causes
 // issues with various enterprise network gateways such as Palo Alto Networks. We have been reported issues

--- a/go.sum
+++ b/go.sum
@@ -1596,9 +1596,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/kkHAIKE/contextcheck v1.1.6 h1:7HIyRcnyzxL9Lz06NGhiKvenXq7Zw6Q0UQu/ttjfJCE=
 github.com/kkHAIKE/contextcheck v1.1.6/go.mod h1:3dDbMRNBFaq8HFXWC1JyvDSPm43CmE6IuHam8Wr0rkg=
 github.com/klauspost/asmfmt v1.3.2/go.mod h1:AG8TuvYojzulgDAMCnYn50l/5QV3Bs/tp6j0HLHbNSE=
-github.com/klauspost/compress v1.15.9/go.mod h1:PhcZ0MbTNciWF3rruxRgKxI5NkcHHrHUDtV4Yw2GlzU=
-github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
-github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
+github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
+github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=


### PR DESCRIPTION
Cherry-pick of https://github.com/open-component-model/ocm/pull/1738 from main to releases/v0.35