### PR TITLE
chore: [releases/0.35] cherry-pick: https://github.com/open-component-model/ocm/pull/1740

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -579,6 +579,10 @@ retract v0.22.0 // Retract because of accidentially released version, reported b
 
 retract v0.34.0 // Retract because release includes major bump of go.yaml.in/yaml/v4 which introduces breaking changes, reported by https://github.com/open-component-model/ocm-project/issues/771
 
+retract v0.33.0 // Retract because of a version bump of github.com/klauspost/compress that introduces a breaking change, reported by https://github.com/open-component-model/ocm-project/issues/797
+
+retract v0.34.1 // Retract because of a version bump of github.com/klauspost/compress that introduces a breaking change, reported by https://github.com/open-component-model/ocm-project/issues/797
+
 // crypto/tls: Client Hello is always sent in 2 TCP frames if GODEBUG=tlskyber=1 (default) which causes
 // issues with various enterprise network gateways such as Palo Alto Networks. We have been reported issues
 // such as https://github.com/open-component-model/ocm/issues/1027 and do not want to pin our crypto/tls version.


### PR DESCRIPTION
Cherry-pick of https://github.com/open-component-model/ocm/pull/1740 from main to releases/v0.35

As long as we release another release candidate, it should be enough to have these retract statement on this release branch