### PR TITLE
chore: [releases/0.34] cherry-pick: https://github.com/open-component-model/ocm/pull/1709 https://github.com/open-component-model/ocm/pull/1740

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -578,6 +578,10 @@ retract v0.22.0 // Retract because of accidentially released version, reported b
 
 retract v0.34.0 // Retract because release includes majof bump of go.yaml.in/yaml/v4 which introduces breaking changes, reported by https://github.com/open-component-model/ocm-project/issues/771
 
+retract v0.33.0 // Retract because of a version bump of github.com/klauspost/compress that introduces a breaking change, reported by https://github.com/open-component-model/ocm-project/issues/797
+
+retract v0.34.1 // Retract because of a version bump of github.com/klauspost/compress that introduces a breaking change, reported by https://github.com/open-component-model/ocm-project/issues/797
+
 // crypto/tls: Client Hello is always sent in 2 TCP frames if GODEBUG=tlskyber=1 (default) which causes
 // issues with various enterprise network gateways such as Palo Alto Networks. We have been reported issues
 // such as https://github.com/open-component-model/ocm/issues/1027 and do not want to pin our crypto/tls version.

--- a/go.mod
+++ b/go.mod
@@ -576,6 +576,8 @@ retract [v0.16.0, v0.16.9] // Retract all from v0.16 due to https://github.com/o
 
 retract v0.22.0 // Retract because of accidentially released version, reported by https://github.com/open-component-model/ocm-project/issues/1399
 
+retract v0.34.0 // Retract because release includes majof bump of go.yaml.in/yaml/v4 which introduces breaking changes, reported by https://github.com/open-component-model/ocm-project/issues/771
+
 // crypto/tls: Client Hello is always sent in 2 TCP frames if GODEBUG=tlskyber=1 (default) which causes
 // issues with various enterprise network gateways such as Palo Alto Networks. We have been reported issues
 // such as https://github.com/open-component-model/ocm/issues/1027 and do not want to pin our crypto/tls version.


### PR DESCRIPTION
Cherry-pick #1709 and #1740 into release v0.34