### PR TITLE
fix: update image reference name to use the open-component-model organization repository

### DIFF
--- a/api/oci/extensions/repositories/artifactset/ctf_roundtrip_test.go
+++ b/api/oci/extensions/repositories/artifactset/ctf_roundtrip_test.go
@@ -28,7 +28,7 @@ const (
 	componentVersion = "1.0.0"
 	resourceName     = "hello-image"
 	resourceVersion  = "1.0.0"
-	imageReference   = "ghcr.io/piotrjanik/open-component-model/hello-ocm:latest"
+	imageReference   = "ghcr.io/open-component-model/open-component-model/hello-ocm:latest"
 )
 
 func gunzipToTar(tgzPath string) (string, error) {


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
This change updates image reference name to use the open-component-model organization repository.
