### PR TITLE
fix(ocireg): preserve default transport settings for HTTPS registries

### DIFF
--- a/api/oci/extensions/repositories/ocireg/repository.go
+++ b/api/oci/extensions/repositories/ocireg/repository.go
@@ -53,6 +53,18 @@ type RepositoryImpl struct {
 	info   *RepositoryInfo
 }
 
+func newHTTPTransport(conf *tls.Config) *http.Transport {
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return &http.Transport{TLSClientConfig: conf}
+	}
+
+	transport := base.Clone()
+	transport.TLSClientConfig = conf
+
+	return transport
+}
+
 var (
 	_ cpi.RepositoryImpl                   = (*RepositoryImpl)(nil)
 	_ credentials.ConsumerIdentityProvider = &RepositoryImpl{}
@@ -172,9 +184,7 @@ func (r *RepositoryImpl) getResolver(comp string) (oras.Resolver, error) {
 				return rootCAs
 			}(),
 		}
-		client.Transport = ocmlog.NewRoundTripper(retry.NewTransport(&http.Transport{
-			TLSClientConfig: conf,
-		}), logger)
+		client.Transport = ocmlog.NewRoundTripper(retry.NewTransport(newHTTPTransport(conf)), logger)
 	}
 
 	authClient := &auth.Client{

--- a/api/oci/extensions/repositories/ocireg/repository_test.go
+++ b/api/oci/extensions/repositories/ocireg/repository_test.go
@@ -1,0 +1,38 @@
+package ocireg
+
+import (
+	"crypto/tls"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHTTPTransportClonesDefaultTransport(t *testing.T) {
+	t.Parallel()
+
+	base, ok := http.DefaultTransport.(*http.Transport)
+	require.True(t, ok, "default transport must be *http.Transport")
+
+	conf := &tls.Config{MinVersion: tls.VersionTLS12}
+
+	got := newHTTPTransport(conf)
+	require.NotNil(t, got)
+
+	assert.NotSame(t, base, got)
+	assert.Same(t, conf, got.TLSClientConfig)
+	assert.Equal(t, base.ForceAttemptHTTP2, got.ForceAttemptHTTP2)
+	assert.Equal(t, base.MaxIdleConns, got.MaxIdleConns)
+	assert.Equal(t, base.MaxIdleConnsPerHost, got.MaxIdleConnsPerHost)
+	assert.Equal(t, base.MaxConnsPerHost, got.MaxConnsPerHost)
+	assert.Equal(t, base.IdleConnTimeout, got.IdleConnTimeout)
+	assert.Equal(t, base.TLSHandshakeTimeout, got.TLSHandshakeTimeout)
+	assert.Equal(t, base.ExpectContinueTimeout, got.ExpectContinueTimeout)
+
+	if base.Proxy != nil {
+		require.NotNil(t, got.Proxy)
+		assert.Equal(t, reflect.ValueOf(base.Proxy).Pointer(), reflect.ValueOf(got.Proxy).Pointer())
+	}
+}


### PR DESCRIPTION
## Summary

This changes the HTTPS transport setup in `api/oci/extensions/repositories/ocireg`
to clone `http.DefaultTransport` before applying the custom TLS configuration.

The previous implementation created a bare `http.Transport` with only
`TLSClientConfig` set. That dropped default transport behavior and caused
resolver failures against some public registries.

## Root cause

The `ocireg` resolver currently replaces the HTTP transport with a new custom
transport that only sets `TLSClientConfig`.

That loses default transport settings which are preserved by
`http.DefaultTransport.(*http.Transport).Clone()`.

In practice this showed up as intermittent Docker Hub auth failures during
artifact resolution, for example:

- `GET https://auth.docker.io/token?...`
- `403 Forbidden`

A minimal resolver repro failed with the old transport and succeeded when using
a cloned default transport with the same TLS configuration.

## Changes

- add `newHTTPTransport(conf *tls.Config) *http.Transport`
- use that helper in the HTTPS resolver path
- add a unit test that verifies the transport is cloned from the default
  transport and keeps its default settings while replacing `TLSClientConfig`

## Validation

Tested with:

```bash
go test ./api/oci/extensions/repositories/ocireg -count=1
```

Additionally verified against a real resolver and fetch path on Linux where the
old behavior failed on public Docker Hub artifacts and the patched resolver
successfully resolved them.
