### PR TITLE
chore(deps): bump go to 1.26.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.1-alpine3.22 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine3.22 AS build
 
 RUN apk add --no-cache make git
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/ocm
 
-go 1.26.1
+go 1.26.2
 
 require (
 	dario.cat/mergo v1.0.2

--- a/hack/brew/go.mod
+++ b/hack/brew/go.mod
@@ -1,3 +1,3 @@
 module ocm.software/ocm/hack/brew
 
-go 1.26.1
+go 1.26.2


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Upgrade to go `1.26.2`