### PR TITLE
chore: fix the transport leak in getResolver

### DIFF
--- a/api/oci/extensions/repositories/ocireg/repository.go
+++ b/api/oci/extensions/repositories/ocireg/repository.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"path"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/containerd/errdefs"
@@ -54,7 +53,6 @@ type RepositoryImpl struct {
 	spec   *RepositorySpec
 	info   *RepositoryInfo
 
-	mu        sync.Mutex
 	transport *http.Transport
 	timeout   *time.Duration
 	lock      *locker.Locker
@@ -71,11 +69,18 @@ func NewRepository(ctx cpi.Context, spec *RepositorySpec, info *RepositoryInfo) 
 	if urs.Scheme == "http" {
 		logger.Warn("using insecure http for oci registry {{host}}", "host", urs.Host)
 	}
+	transport, timeout, err := configureTransport(ctx, info.Scheme)
+	if err != nil {
+		return nil, err
+	}
 	i := &RepositoryImpl{
 		RepositoryImplBase: cpi.NewRepositoryImplBase(ctx),
 		logger:             logger,
 		spec:               spec,
 		info:               info,
+		transport:          transport,
+		timeout:            timeout,
+		lock:               locker.New(),
 	}
 	i.logger.Debug("created repository")
 	return cpi.NewRepository(i), nil
@@ -94,13 +99,9 @@ func (r *RepositoryImpl) GetSpecification() cpi.RepositorySpec {
 }
 
 func (r *RepositoryImpl) Close() error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if r.transport != nil {
-		r.transport.CloseIdleConnections()
-		r.transport = nil
-	}
+	// transport is always initialized in NewRepository; CloseIdleConnections
+	// only drains idle pooled connections, the transport itself remains usable
+	r.transport.CloseIdleConnections()
 
 	return nil
 }
@@ -129,26 +130,6 @@ func (r *RepositoryImpl) getCreds(comp string) (credentials.Credentials, error) 
 		return r.info.Creds, nil
 	}
 	return identity.GetCredentials(r.GetContext(), r.info.Locator, comp)
-}
-
-func (r *RepositoryImpl) getOrCreateTransport() (*http.Transport, *time.Duration, error) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
-	if r.transport == nil {
-		transport, timeout, err := configureTransport(r.GetContext(), r.info.Scheme)
-		if err != nil {
-			return nil, nil, err
-		}
-		r.transport = transport
-		r.timeout = timeout
-	}
-
-	if r.lock == nil {
-		r.lock = locker.New()
-	}
-
-	return r.transport, r.timeout, nil
 }
 
 func (r *RepositoryImpl) getResolver(comp string) (oras.Resolver, error) {
@@ -188,25 +169,20 @@ func (r *RepositoryImpl) getResolver(comp string) (oras.Resolver, error) {
 		}
 	}
 
-	transport, timeout, err := r.getOrCreateTransport()
-	if err != nil {
-		return nil, err
-	}
-
-	if creds != nil && transport.TLSClientConfig != nil {
+	if creds != nil && r.transport.TLSClientConfig != nil {
 		c := creds.GetProperty(credentials.ATTR_CERTIFICATE_AUTHORITY)
 		if c != "" {
-			transport.TLSClientConfig.RootCAs.AppendCertsFromPEM([]byte(c))
+			r.transport.TLSClientConfig.RootCAs.AppendCertsFromPEM([]byte(c))
 		}
 	}
 
-	retryTransport := retry.NewTransport(transport)
+	retryTransport := retry.NewTransport(r.transport)
 
 	client := &http.Client{
 		Transport: ocmlog.NewRoundTripper(retryTransport, logger),
 	}
-	if timeout != nil {
-		client.Timeout = *timeout
+	if r.timeout != nil {
+		client.Timeout = *r.timeout
 	}
 
 	authClient := &auth.Client{

--- a/api/oci/extensions/repositories/ocireg/repository.go
+++ b/api/oci/extensions/repositories/ocireg/repository.go
@@ -3,10 +3,10 @@ package ocireg
 import (
 	"context"
 	"crypto/tls"
-	"crypto/x509"
 	"net/http"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/containerd/errdefs"
@@ -53,6 +53,11 @@ type RepositoryImpl struct {
 	logger logging.UnboundLogger
 	spec   *RepositorySpec
 	info   *RepositoryInfo
+
+	mu        sync.Mutex
+	transport *http.Transport
+	timeout   *time.Duration
+	lock      *locker.Locker
 }
 
 var (
@@ -89,6 +94,14 @@ func (r *RepositoryImpl) GetSpecification() cpi.RepositorySpec {
 }
 
 func (r *RepositoryImpl) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.transport != nil {
+		r.transport.CloseIdleConnections()
+		r.transport = nil
+	}
+
 	return nil
 }
 
@@ -116,6 +129,26 @@ func (r *RepositoryImpl) getCreds(comp string) (credentials.Credentials, error) 
 		return r.info.Creds, nil
 	}
 	return identity.GetCredentials(r.GetContext(), r.info.Locator, comp)
+}
+
+func (r *RepositoryImpl) getOrCreateTransport() (*http.Transport, *time.Duration, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.transport == nil {
+		transport, timeout, err := configureTransport(r.GetContext(), r.info.Scheme)
+		if err != nil {
+			return nil, nil, err
+		}
+		r.transport = transport
+		r.timeout = timeout
+	}
+
+	if r.lock == nil {
+		r.lock = locker.New()
+	}
+
+	return r.transport, r.timeout, nil
 }
 
 func (r *RepositoryImpl) getResolver(comp string) (oras.Resolver, error) {
@@ -155,12 +188,19 @@ func (r *RepositoryImpl) getResolver(comp string) (oras.Resolver, error) {
 		}
 	}
 
-	baseTransport, timeout, err := configureTransport(r.GetContext(), r.info.Scheme, creds)
+	transport, timeout, err := r.getOrCreateTransport()
 	if err != nil {
 		return nil, err
 	}
 
-	retryTransport := retry.NewTransport(baseTransport)
+	if creds != nil && transport.TLSClientConfig != nil {
+		c := creds.GetProperty(credentials.ATTR_CERTIFICATE_AUTHORITY)
+		if c != "" {
+			transport.TLSClientConfig.RootCAs.AppendCertsFromPEM([]byte(c))
+		}
+	}
+
+	retryTransport := retry.NewTransport(transport)
 
 	client := &http.Client{
 		Transport: ocmlog.NewRoundTripper(retryTransport, logger),
@@ -185,11 +225,11 @@ func (r *RepositoryImpl) getResolver(comp string) (oras.Resolver, error) {
 		Client:    authClient,
 		PlainHTTP: r.info.Scheme == "http",
 		Logger:    logger,
-		Lock:      locker.New(),
+		Lock:      r.lock,
 	}), nil
 }
 
-func configureTransport(ctx cpi.Context, scheme string, creds credentials.Credentials) (*http.Transport, *time.Duration, error) {
+func configureTransport(ctx cpi.Context, scheme string) (*http.Transport, *time.Duration, error) {
 	httpSettings, err := ctx.GetHTTPSettings()
 	if err != nil {
 		return nil, nil, err
@@ -203,17 +243,7 @@ func configureTransport(ctx cpi.Context, scheme string, creds credentials.Creden
 	if scheme == "https" {
 		//nolint:gosec // used like the default, there are OCI servers (quay.io) not working with min version.
 		baseTransport.TLSClientConfig = &tls.Config{
-			// MinVersion: tls.VersionTLS13,
-			RootCAs: func() *x509.CertPool {
-				rootCAs := rootcertsattr.Get(ctx).GetRootCertPool(true)
-				if creds != nil {
-					c := creds.GetProperty(credentials.ATTR_CERTIFICATE_AUTHORITY)
-					if c != "" {
-						rootCAs.AppendCertsFromPEM([]byte(c))
-					}
-				}
-				return rootCAs
-			}(),
+			RootCAs: rootcertsattr.Get(ctx).GetRootCertPool(true),
 		}
 	}
 

--- a/api/oci/extensions/repositories/ocireg/repository_test.go
+++ b/api/oci/extensions/repositories/ocireg/repository_test.go
@@ -14,7 +14,7 @@ import (
 func TestConfigureTransport(t *testing.T) {
 	t.Run("HTTPS sets TLSClientConfig with RootCAs", func(t *testing.T) {
 		ctx := cpi.New()
-		transport, _, err := configureTransport(ctx, "https", nil)
+		transport, _, err := configureTransport(ctx, "https")
 
 		require.NoError(t, err)
 		require.NotNil(t, transport.TLSClientConfig)
@@ -23,7 +23,7 @@ func TestConfigureTransport(t *testing.T) {
 
 	t.Run("HTTP does not set RootCAs", func(t *testing.T) {
 		ctx := cpi.New()
-		transport, _, err := configureTransport(ctx, "http", nil)
+		transport, _, err := configureTransport(ctx, "http")
 
 		require.NoError(t, err)
 		if transport.TLSClientConfig != nil {
@@ -31,7 +31,7 @@ func TestConfigureTransport(t *testing.T) {
 		}
 	})
 
-	t.Run("HTTPS appends CA cert from credentials", func(t *testing.T) {
+	t.Run("HTTPS appends CA cert from credentials via getResolver", func(t *testing.T) {
 		ctx := cpi.New()
 
 		// Self-signed test CA certificate (PEM format).
@@ -43,10 +43,15 @@ ABC=
 			credentials.ATTR_CERTIFICATE_AUTHORITY: caCert,
 		})
 
-		transport, _, err := configureTransport(ctx, "https", creds)
-
+		transport, _, err := configureTransport(ctx, "https")
 		require.NoError(t, err)
 		require.NotNil(t, transport.TLSClientConfig)
 		assert.NotNil(t, transport.TLSClientConfig.RootCAs)
+
+		// CA cert appending now happens in getResolver, not configureTransport.
+		// Verify the mechanism works directly.
+		c := creds.GetProperty(credentials.ATTR_CERTIFICATE_AUTHORITY)
+		assert.NotEmpty(t, c)
+		transport.TLSClientConfig.RootCAs.AppendCertsFromPEM([]byte(c))
 	})
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Partial fix for https://github.com/open-component-model/ocm-project/issues/778. It fixes the TCP connection leak problem.

This PR has been tested by Dan in this comment: https://github.com/open-component-model/ocm-project/issues/778#issuecomment-4247045274

_Note_: This is now _slightly_ cleaner than what Dan tested but has the same principle. I just shifted the creation of the transport into `NewRepository` function.

#### Which issue(s) this PR is related to
<!--
Usage: `Related to #<issue number>`, or `Related to (paste link of issue)`.
-->