### PR TITLE
fix: use oci.ParseRef for ociArtifact input validation

### DIFF
--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/ociartifact/input_test.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/ociartifact/input_test.go
@@ -11,6 +11,7 @@ import (
 	. "ocm.software/ocm/cmds/ocm/testhelper"
 
 	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"ocm.software/ocm/api/oci"
 	"ocm.software/ocm/api/oci/extensions/repositories/artifactset"
@@ -139,6 +140,31 @@ var _ = Describe("Test Environment", func() {
 			spec := Must(inputs.DefaultInputTypeScheme.GetInputSpecFor(opts))
 			Expect(spec).To(Equal(me.New("ghcr.io/open-component-model/image:v1.0", "linux/amd64", "/arm64")))
 		})
+	})
+
+	Context("validation", func() {
+		DescribeTable("accepts valid OCI references",
+			func(ref string) {
+				spec := me.New(ref)
+				errs := spec.Validate(field.NewPath("input"), nil, "")
+				Expect(errs).To(BeEmpty())
+			},
+			Entry("domain/repo:tag", "ghcr.io/open-component-model/image:v1.0"),
+			Entry("domain/repo:tag@digest", "ghcr.io/stefanprodan/podinfo:6.11.2@sha256:187803cdf611a19d4fffbdf6a4260a01be4c09ffe9924b28902424fc0639ceb8"),
+			Entry("domain/repo@digest", "ghcr.io/stefanprodan/podinfo@sha256:187803cdf611a19d4fffbdf6a4260a01be4c09ffe9924b28902424fc0639ceb8"),
+			Entry("docker library shorthand", "alpine:3.19"),
+			Entry("docker org shorthand", "library/alpine:3.19"),
+		)
+
+		DescribeTable("rejects invalid OCI references",
+			func(ref string) {
+				spec := me.New(ref)
+				errs := spec.Validate(field.NewPath("input"), nil, "")
+				Expect(errs).NotTo(BeEmpty())
+			},
+			Entry("empty string", ""),
+			Entry("just a tag", ":latest"),
+		)
 	})
 
 	Context("scenario", func() {

--- a/cmds/ocm/commands/ocmcmds/common/inputs/types/ociartifact/spec.go
+++ b/cmds/ocm/commands/ocmcmds/common/inputs/types/ociartifact/spec.go
@@ -5,7 +5,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
-	"ocm.software/ocm/api/oci/extensions/repositories/docker"
+	"ocm.software/ocm/api/oci"
 	"ocm.software/ocm/api/oci/grammar"
 	"ocm.software/ocm/api/oci/tools/transfer/filters"
 	"ocm.software/ocm/api/ocm/extensions/accessmethods/ociartifact"
@@ -16,7 +16,7 @@ import (
 )
 
 type Spec struct {
-	// PathSpec holds the repository path and tag of the image in the docker daemon
+	// PathSpec holds the OCI image reference.
 	cpi.PathSpec
 	// Repository is the repository hint for the index artifact
 	Repository string `json:"repository,omitempty"`
@@ -39,8 +39,7 @@ func (s *Spec) Validate(fldPath *field.Path, ctx inputs.Context, inputFilePath s
 	allErrs = ValidateRepository(fldPath.Child("repository"), allErrs, s.Repository)
 	if s.Path != "" {
 		pathField := fldPath.Child("path")
-		_, _, err := docker.ParseGenericRef(s.Path)
-		if err != nil {
+		if _, err := oci.ParseRef(s.Path); err != nil {
 			allErrs = append(allErrs, field.Invalid(pathField, s.Path, err.Error()))
 		}
 	}


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it
The ociArtifact input type validated its path using docker.ParseGenericRef, which splits on ":" and rejects references with more than two colon-separated parts. This broke OCI references containing digests (e.g. repo:tag@sha256:...) because the digest introduces a third colon.

Replace with oci.ParseRef, which is the same parser used at runtime by the ociArtifact access method.

#### Which issue(s) this PR is related to
<!--
Usage: `Related to #<issue number>`, or `Related to (paste link of issue)`.
-->