### PR TITLE
chore: sync contributing guide

### DIFF
--- a/.github/config/wordlist.txt
+++ b/.github/config/wordlist.txt
@@ -103,6 +103,7 @@ forwardspec
 fulcio
 gapped
 gav
+gci
 getinexpensivecontentversionidentity
 getresourcesbyname
 getter
@@ -114,6 +115,7 @@ globalaccess
 globals
 gocritic
 gofmt
+gofumpt
 golang
 golangci
 gomega

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,99 @@
-# Welcome to the OCM community
+# Contributing to the OCM CLI
 
-We welcome many different types of contributions.
+For the general contribution process (fork-and-pull workflow, commit requirements, code of conduct, and more), see the
+[central contributing guide](https://ocm.software/community/contributing/) on the project website.
 
-Please refer to the [Contributing Guide in the Community repository](https://github.com/open-component-model/.github/blob/main/CONTRIBUTING.md) for more information on how to get support from maintainers, find work to contribute, the Pull Request checklist, the Pull Request process, and other useful information on how to contribute to OCM.
+This document covers repository-specific development details.
+
+## Prerequisites
+
+- **Go 1.26+**
+- **Make**
+- **Docker** - required for integration tests
+
+## Project Structure
+
+```text
+.
+├── api/           # Core Go library (OCM, OCI, credentials, datacontext)
+├── cmds/          # CLI entry-points and plugins
+├── components/    # Component definitions for building OCM component versions
+├── docs/          # CLI reference, plugin reference, ADRs
+├── examples/      # Usage examples
+├── hack/          # Development scripts (generate, format, install, cross-build)
+├── Makefile       # Build automation
+└── VERSION        # Current version
+```
+
+## Common Tasks
+
+```bash
+# Build all binaries
+make build
+
+# Build ocm cli
+make bin/ocm
+
+# Run all tests (unit + integration; requires Docker)
+make test
+
+# Run unit tests only
+make unit-test
+
+# Format code (gci + gofumpt)
+make format
+
+# Lint
+make check
+
+# Lint with auto-fix
+make check-fix
+
+# Full pipeline: generate, format, generate-deepcopy, build, test, lint
+make prepare
+
+# Install dev dependencies (vault, oci-registry, ...)
+make install-requirements
+```
+
+## Testing
+
+Tests use [Ginkgo](https://onsi.github.io/ginkgo/) and [Gomega](https://onsi.github.io/gomega/).
+
+| Build tag | Purpose | Requirements |
+|-----------|---------|--------------|
+| *(none)* | Unit tests | Go only |
+| `integration` | Integration tests | Docker, vault, oci-registry |
+| `unix` | Unix-specific tests | Linux / macOS |
+
+`make test` runs with the `integration` tag. `make unit-test` runs without tags.
+
+## Linting
+
+- **Linter**: golangci-lint, configured in `.github/config/golangci.yaml`
+
+## Code Generation
+
+```bash
+make generate            # go generate
+make generate-deepcopy   # controller-gen for api/ocm/compdesc/
+```
+
+Run these before committing if you change types or CLI commands.
+
+## Pull Requests
+
+PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```text
+<type>(<optional scope>): <description>
+```
+
+Allowed types: `feat`, `fix`, `chore`, `docs`, `test`, `perf`
+
+## Questions?
+
+- [Project issues](https://github.com/open-component-model/ocm-project/issues)
+- [Repository issues](https://github.com/open-component-model/ocm/issues)
+- [Community engagement](https://ocm.software/community/engagement/)
+- [NeoNephos Code of Conduct](https://github.com/neonephos/.github/blob/main/CODE_OF_CONDUCT.md)

--- a/README.md
+++ b/README.md
@@ -170,7 +170,9 @@ You can find the old keys in the website github repository
 
 ## Contributing
 
-Code contributions, feature requests, bug reports, and help requests are very welcome. Please refer to the [Contributing Guide in the Community repository](https://github.com/open-component-model/community/blob/main/CONTRIBUTING.md) for more information on how to contribute to OCM.
+Code contributions, feature requests, bug reports, and help requests are very welcome.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and workflow details,
+or the [central contributing guide](https://ocm.software/community/contributing/) for the general process.
 
 OCM follows the [NeoNephos Code of Conduct](https://github.com/neonephos/.github/blob/main/CODE_OF_CONDUCT.md).
 


### PR DESCRIPTION
## Summary

- Rewrites `CONTRIBUTING.md` from a 4-line stub into a concise repo-specific guide covering prerequisites, project structure, common make targets, testing, linting, code generation, and PR conventions
- Points to the new [central contributing guide](https://ocm.software/community/contributing/) on the project website for the general process
- Fixes the Contributing section in `README.md` which pointed to the wrong URL (`community/CONTRIBUTING.md` instead of the central guide)

## Related issue

https://github.com/open-component-model/ocm-project/issues/981