### PR TITLE
chore: fix permissions for called workflow

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -10,18 +10,12 @@ on:
   workflow_dispatch:
 
 permissions:
-  # Necessary to write the branch
-  # TODO: Remove once https://github.com/open-component-model/ocm-integrationtest/blob/main/.github/workflows/integrationtest.yaml#L41 is not needed anymore
-  contents: write
+  contents: read
 
 jobs:
   test:
     name: Run
     uses: open-component-model/ocm-integrationtest/.github/workflows/integrationtest.yaml@main
-    permissions:
-      contents: write
-      id-token: write
-      packages: write
     secrets: inherit
     with:
       ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.ref || github.ref }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   test:
     name: Run
-    uses: open-component-model/ocm-integrationtest/.github/workflows/integrationtest.yaml@main
+    uses: open-component-model/ocm-integrationtest/.github/workflows/integrationtest.yaml@8b914397e79353d1f0b441295d7b1d36676849c3 # main
     with:
       ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
       repo: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     branches:
       - main
   workflow_dispatch:
@@ -16,7 +16,6 @@ jobs:
   test:
     name: Run
     uses: open-component-model/ocm-integrationtest/.github/workflows/integrationtest.yaml@main
-    secrets: inherit
     with:
-      ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.ref || github.ref }}
-      repo: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.repository }}
+      ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
+      repo: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/open-component-model/ocm-integrationtest/pull/90, which hardens the called integration test workflow by removing the OCMBOT token generation and switching to unprivileged checkouts.

## Changes

- **Downgrade `contents: write` to `contents: read`**: The called workflow no longer requires write access (report upload and repo pushes were removed in the companion PR).
- **Remove `secrets: inherit`**: The called workflow no longer declares any `workflow_call` secrets — OCMBOT tokens are not needed since both repos are public and only read access is required.
- **Switch `pull_request_target` to `pull_request`**: The `pull_request_target` trigger was only needed because the called workflow required secrets to generate a token for checkout. Now that no secrets are needed, plain `pull_request` provides the same functionality without the security risk of running untrusted fork code with access to repo secrets.
- **Remove job-level `permissions` block**: The old called workflow required `contents: write`, `id-token: write`, and `packages: write`, which had to be explicitly granted at the job level since the caller's top-level permissions didn't include them. After the companion PR, the called workflow only needs `contents: read`, which is already covered by the caller's top-level `permissions` block — no additional job-level escalation is needed.
- **Pin called workflow to commit SHA**: The `@main` reference is now pinned to `8b914397e79353d1f0b441295d7b1d36676849c3` to address the `unpinned-uses` finding from zizmor.

## Dependencies

This PR must be merged **after** https://github.com/open-component-model/ocm-integrationtest/pull/90, which removes the secrets requirement and token generation from the called workflow. (Already merged.)