### PR TITLE
fix(oci): normalize library/ prefix for explicit docker.io single-component refs

### DIFF
--- a/api/oci/ref.go
+++ b/api/oci/ref.go
@@ -130,6 +130,9 @@ func ParseRef(ref string) (RefSpec, error) {
 		spec.Repository = string(match[3])
 		spec.Tag = pointer(match[4])
 		spec.Digest = dig(match[5])
+		if (spec.Host == dockerHubDomain || spec.Host == dockerHubLegacyDomain) && !strings.Contains(spec.Repository, "/") {
+			spec.Repository = "library" + grammar.RepositorySeparator + spec.Repository
+		}
 		return spec, nil
 	}
 	match = grammar.TypedReferenceRegexp.FindSubmatch([]byte(ref))

--- a/api/oci/ref_test.go
+++ b/api/oci/ref_test.go
@@ -575,6 +575,12 @@ var _ = Describe("ref parsing", func() {
 	It("succeeds for repository", func() {
 		CheckRef("::ghcr.io/", &oci.RefSpec{UniformRepositorySpec: ghcr})
 	})
+	It("normalizes docker.io single-component repos with library/ prefix", func() {
+		bashTag := "5.3.9"
+		CheckRef("docker.io/bash:5.3.9", &oci.RefSpec{UniformRepositorySpec: docker, ArtSpec: oci.ArtSpec{Repository: "library/bash", ArtVersion: oci.ArtVersion{Tag: &bashTag}}})
+		CheckRef("docker.io/ubuntu", &oci.RefSpec{UniformRepositorySpec: docker, ArtSpec: oci.ArtSpec{Repository: "library/ubuntu"}})
+		CheckRef("docker.io/library/bash:5.3.9", &oci.RefSpec{UniformRepositorySpec: docker, ArtSpec: oci.ArtSpec{Repository: "library/bash", ArtVersion: oci.ArtVersion{Tag: &bashTag}}})
+	})
 	It("succeeds", func() {
 		CheckRef("ubuntu", &oci.RefSpec{UniformRepositorySpec: docker, ArtSpec: oci.ArtSpec{Repository: "library/ubuntu"}})
 		CheckRef("ubuntu:v1", &oci.RefSpec{UniformRepositorySpec: docker, ArtSpec: oci.ArtSpec{Repository: "library/ubuntu", ArtVersion: oci.ArtVersion{Tag: &tag}}})


### PR DESCRIPTION
## Summary

- `ParseRef("docker.io/bash:5.3.9")` now correctly returns `Repository: "library/bash"` instead of `"bash"`
- Bare names like `bash:5.3.9` already worked via `DockerLibraryReferenceRegexp`; explicit `docker.io/` prefix bypassed that branch and fell through to `ReferenceRegexp` without normalization
- Fix: after `ReferenceRegexp` match, check if host is `docker.io`/`index.docker.io` and repository has no `/` — if so, prepend `library/`

Fixes #1947

## Changes

- `api/oci/ref.go`: 3-line normalization check in `ReferenceRegexp` match block
- `api/oci/ref_test.go`: new `It` block with 3 test cases covering `docker.io/bash:5.3.9`, `docker.io/ubuntu`, and `docker.io/library/bash:5.3.9` (idempotent)

## Test plan

- [ ] `go test ./api/oci/...` passes (all 17 packages green)
- [ ] New test cases cover the reported regression
- [ ] Existing docker.io and multi-component ref tests unaffected
- [ ] `docker.io/library/bash:5.3.9` (already-normalized form) is not double-prefixed