### PR TITLE
chore(releases-043): cherry-pick:  #1980 and #1978

### DIFF
--- a/.github/workflows/flake_vendorhash.yaml
+++ b/.github/workflows/flake_vendorhash.yaml
@@ -11,6 +11,9 @@ on:
 jobs:
   updateVendorHash:
     runs-on: ubuntu-latest
+    environment:
+      name: release
+      deployment: false
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/publish-latest.yaml
+++ b/.github/workflows/publish-latest.yaml
@@ -16,6 +16,9 @@ jobs:
 
   docker_publish:
     runs-on: ubuntu-latest
+    environment:
+      name: release
+      deployment: false
     permissions:
       contents: write
       id-token: write
@@ -72,6 +75,9 @@ jobs:
   ocm-cli-latest:
     name: Build latest ocm-cli
     runs-on: large_runner
+    environment:
+      name: release
+      deployment: false
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/publish-to-other-than-github.yaml
+++ b/.github/workflows/publish-to-other-than-github.yaml
@@ -19,6 +19,9 @@ jobs:
     name: Update Homebrew Tap
     if: github.event.client_payload.push-to-brew-tap && github.event.client_payload.version != ''
     runs-on: ubuntu-latest
+    environment:
+      name: release
+      deployment: false
     env:
       REPO: open-component-model/homebrew-tap
     steps:
@@ -80,6 +83,9 @@ jobs:
     name: Update Arch Linux User Repository
     if: github.event.client_payload.push-to-aur && github.event.client_payload.version != ''
     runs-on: ubuntu-latest
+    environment:
+      name: release
+      deployment: false
     steps:
     - name: Ensure proper version
       run: echo "RELEASE_VERSION=$(echo ${{ github.event.client_payload.version }} | tr -d ['v'])" >> $GITHUB_ENV
@@ -105,6 +111,9 @@ jobs:
     name: Update Chocolatey
     if: github.event.client_payload.push-to-chocolatey && github.event.client_payload.version != ''
     runs-on: windows-latest
+    environment:
+      name: release
+      deployment: false
     steps:
     - name: Ensure proper version
       run: |
@@ -128,6 +137,9 @@ jobs:
   push-to-website:
     name: Update OCM Website
     runs-on: ubuntu-latest
+    environment:
+      name: release
+      deployment: false
     if: github.event.client_payload.push-to-website && github.event.client_payload.version != ''
     steps:
     - name: Ensure proper version

--- a/.github/workflows/release-branch.yaml
+++ b/.github/workflows/release-branch.yaml
@@ -15,6 +15,9 @@ permissions:
 jobs:
   cutoff-preconditions:
     runs-on: ubuntu-latest
+    environment:
+      name: release
+      deployment: false
     permissions:
       contents: read
       id-token: write
@@ -63,6 +66,9 @@ jobs:
   create-branch:
     runs-on: ubuntu-latest
     needs: cutoff-preconditions
+    environment:
+      name: release
+      deployment: false
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release-bump-version.yaml
+++ b/.github/workflows/release-bump-version.yaml
@@ -18,6 +18,9 @@ jobs:
   create-bump-pr:
     name: "Pull Request"
     runs-on: ubuntu-latest
+    environment:
+      name: release
+      deployment: false
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -28,6 +28,9 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    environment:
+      name: release
+      deployment: false
     env:
       RELEASE_VERSION: ${{ needs.release-version.outputs.version }}
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,6 +27,9 @@ jobs:
   check:
     name: Check Release Preconditions
     runs-on: ubuntu-latest
+    environment:
+      name: release
+      deployment: false
     permissions:
       contents: read
       repository-projects: read
@@ -103,6 +106,9 @@ jobs:
     - components
     name: Release Build
     runs-on: large_runner
+    environment:
+      name: release
+      deployment: false
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -267,15 +267,4 @@ jobs:
     with:
       bump-type: patch
       ref: ${{ github.ref }}
-  
-  # Trigger the BDBA scan for a release
-  trigger-bdba-workflow:
-    name: Trigger BDBA Scan
-    needs: release
-    uses: open-component-model/.github/.github/workflows/bdba.yaml@main
-    with:
-      artifact_id: ctf-aggregated
-    secrets: inherit
-    permissions:
-      contents: read 
-      actions: read
+

--- a/.github/workflows/retrigger-publish-to-other.yaml
+++ b/.github/workflows/retrigger-publish-to-other.yaml
@@ -33,6 +33,9 @@ jobs:
   retrigger:
     name: Create new "Release Publish Event"
     runs-on: ubuntu-latest
+    environment:
+      name: release
+      deployment: false
     permissions:
       contents: write
       id-token: write

--- a/cmds/ocm/commands/ocicmds/artifacts/transfer/index_transfer_test.go
+++ b/cmds/ocm/commands/ocicmds/artifacts/transfer/index_transfer_test.go
@@ -115,8 +115,8 @@ var _ = Describe("Index Transfer", func() {
 		)
 
 		By("pulling the OCI index image from GHCR and pushing it to the local registry")
-		srcRef := "ghcr.io/open-component-model/cli:main"
-		dstRef := fmt.Sprintf("%s/ocm-cli:main", registryAddress)
+		srcRef := "ghcr.io/open-component-model/cli:0.2.0"
+		dstRef := fmt.Sprintf("%s/ocm-cli:0.2.0", registryAddress)
 
 		repoSrc, err := remote.NewRepository(srcRef)
 		r.NoError(err)
@@ -203,7 +203,7 @@ configurations:
 			"run", "--rm",
 			"--network", "host",
 			"-v", fmt.Sprintf("%s:/work", tempDir),
-			"ghcr.io/open-component-model/cli:main",
+			"ghcr.io/open-component-model/cli:0.2.0",
 			"add", "component-version",
 			"--repository", "http://" + registryAddress,
 			"--config", "/work/ocmconfig.yaml",
@@ -220,7 +220,7 @@ configurations:
 			"run", "--rm",
 			"--network", "host",
 			"-v", fmt.Sprintf("%s:/work", tempDir),
-			"ghcr.io/open-component-model/cli:main",
+			"ghcr.io/open-component-model/cli:0.2.0",
 			"get", "component-version",
 			"--config", "/work/ocmconfig.yaml",
 			"-oyaml",


### PR DESCRIPTION
Cherry-pick https://github.com/open-component-model/ocm/pull/1980 because called workflow does not exist anymore and https://github.com/open-component-model/ocm/pull/1978 because we need to pin the ocmcli v2 version (and probably cherry-picking the environment will also help us to release).