### PR TITLE
chore: use ubuntu-latest instead of large_runner runner

### DIFF
--- a/.github/workflows/check_diff_action.yaml
+++ b/.github/workflows/check_diff_action.yaml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   diff-check-manifests:
     name: Check for diff
-    runs-on: large_runner
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -114,7 +114,7 @@ jobs:
 
     - name: Build
       if: matrix.build-mode == 'manual'
-      run: make build -j
+      run: make build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     # - ADDENDUM: We moved this to a larger runner for faster analysis
-    runs-on: large_runner
+    runs-on: ubuntu-latest
     timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
     permissions:
       # required for all workflows

--- a/.github/workflows/components.yaml
+++ b/.github/workflows/components.yaml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         component: ${{fromJSON(needs.define-matrix.outputs.components)}}
-    runs-on: large_runner
+    runs-on: ubuntu-latest
     steps:
       - name: Self Hosted Runner Post Job Cleanup Action
         uses: TooMuch4U/actions-clean@9b358e33df99574ac0bdf2e92fa3db1ae1415563 # v2.2
@@ -122,7 +122,7 @@ jobs:
 
   aggregate:
     name: "Aggregate"
-    runs-on: large_runner
+    runs-on: ubuntu-latest
     needs: [build, define-matrix]
     env:
       components: ${{ join(fromJSON(needs.define-matrix.outputs.components), ' ') }}

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   test:
     name: Run tests
-    runs-on: large_runner
+    runs-on: ubuntu-latest
     steps:
       - name: Self Hosted Runner Post Job Cleanup Action
         uses: TooMuch4U/actions-clean@9b358e33df99574ac0bdf2e92fa3db1ae1415563 # v2.2
@@ -73,7 +73,7 @@ jobs:
 
   go-lint:
     name: Lint Golang
-    runs-on: large_runner
+    runs-on: ubuntu-latest
     steps:
       - name: Self Hosted Runner Post Job Cleanup Action
         uses: TooMuch4U/actions-clean@9b358e33df99574ac0bdf2e92fa3db1ae1415563 # v2.2

--- a/.github/workflows/publish-latest.yaml
+++ b/.github/workflows/publish-latest.yaml
@@ -74,7 +74,7 @@ jobs:
 
   ocm-cli-latest:
     name: Build latest ocm-cli
-    runs-on: large_runner
+    runs-on: ubuntu-latest
     environment:
       name: release
       deployment: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,7 +105,7 @@ jobs:
     - release-version
     - components
     name: Release Build
-    runs-on: large_runner
+    runs-on: ubuntu-latest
     environment:
       name: release
       deployment: false


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Use `ubuntu-latest` instead of `large_runner`