### PR TITLE
chore: use go 1.26.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.3-alpine3.22 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS build
 
 RUN apk add --no-cache make git
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/ocm
 
-go 1.26.3
+go 1.26.4
 
 require (
 	dario.cat/mergo v1.0.2

--- a/hack/brew/go.mod
+++ b/hack/brew/go.mod
@@ -1,3 +1,3 @@
 module ocm.software/ocm/hack/brew
 
-go 1.26.3
+go 1.26.4


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

Update to go 1.26.4

---

Supersedes https://github.com/open-component-model/ocm/pull/1993