### PR TITLE
chore(deps): bump go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.8-alpine3.22 AS build
 
 RUN apk add --no-cache make git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.8-alpine3.22 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.8-alpine3.24 AS build
 
 RUN apk add --no-cache make git
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module ocm.software/ocm
 
-go 1.26.4
+go 1.26.8
 
 require (
 	dario.cat/mergo v1.0.2

--- a/hack/brew/go.mod
+++ b/hack/brew/go.mod
@@ -1,3 +1,3 @@
 module ocm.software/ocm/hack/brew
 
-go 1.26.4
+go 1.26.8


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
#### What this PR does / why we need it

bump go version to include CVE fixes.
